### PR TITLE
feat(auth): add login, auth guard, and child selector

### DIFF
--- a/apps/api/src/routes/medications.ts
+++ b/apps/api/src/routes/medications.ts
@@ -65,6 +65,7 @@ medicationsRoutes.post("/", async (c) => {
 });
 
 medicationsRoutes.post("/log", async (c) => {
+  const user = c.get("user") as { id: string };
   const body = await c.req.json();
   const parsed = createMedicationLogSchema.safeParse(body);
 
@@ -73,6 +74,27 @@ medicationsRoutes.post("/log", async (c) => {
       { error: "Données invalides", details: parsed.error.flatten() },
       422
     );
+  }
+
+  // Verify the medication belongs to a child owned by the user
+  const [med] = await db
+    .select()
+    .from(medication)
+    .where(eq(medication.id, parsed.data.medicationId));
+
+  if (!med) {
+    throw new AppError("NOT_FOUND", "Médicament non trouvé", 404);
+  }
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(
+      and(eq(children.id, med.childId), eq(children.parentId, user.id))
+    );
+
+  if (!child) {
+    throw new AppError("FORBIDDEN", "Accès refusé", 403);
   }
 
   const [log] = await db

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "@fontsource-variable/geist": "^5.2.8",
     "@tanstack/react-query": "^5.62.0",
     "@tanstack/react-router": "^1.92.0",
+    "better-auth": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",

--- a/apps/web/src/components/shared/child-selector.tsx
+++ b/apps/web/src/components/shared/child-selector.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from "react";
+import { Plus, Baby } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { useChildren, useCreateChild } from "@/hooks/use-children";
+import { useUiStore } from "@/stores/ui-store";
+
+export function ChildSelector() {
+  const { data: children, isLoading } = useChildren();
+  const { activeChildId, setActiveChild } = useUiStore();
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  // Auto-select first child if none is selected
+  useEffect(() => {
+    if (!activeChildId && children?.length) {
+      setActiveChild(children[0]!.id);
+    }
+  }, [activeChildId, children, setActiveChild]);
+
+  if (isLoading) return null;
+
+  if (!children?.length) {
+    return (
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogTrigger
+          render={
+            <Button size="sm" variant="outline">
+              <Plus className="mr-1.5 h-3.5 w-3.5" />
+              Ajouter un enfant
+            </Button>
+          }
+        />
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Ajouter votre enfant</DialogTitle>
+          </DialogHeader>
+          <AddChildForm onSuccess={() => setDialogOpen(false)} />
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Baby className="h-4 w-4 text-muted-foreground" />
+      <Select
+        value={activeChildId ?? undefined}
+        onValueChange={setActiveChild}
+      >
+        <SelectTrigger className="w-36">
+          <SelectValue placeholder="Enfant" />
+        </SelectTrigger>
+        <SelectContent>
+          {children.map((child) => (
+            <SelectItem key={child.id} value={child.id}>
+              {child.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+        <DialogTrigger
+          render={
+            <Button size="icon" variant="ghost" className="h-8 w-8">
+              <Plus className="h-4 w-4" />
+            </Button>
+          }
+        />
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Ajouter un enfant</DialogTitle>
+          </DialogHeader>
+          <AddChildForm onSuccess={() => setDialogOpen(false)} />
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}
+
+function AddChildForm({ onSuccess }: { onSuccess: () => void }) {
+  const createChild = useCreateChild();
+  const setActiveChild = useUiStore((s) => s.setActiveChild);
+  const [name, setName] = useState("");
+  const [birthDate, setBirthDate] = useState("");
+  const [diagnosisType, setDiagnosisType] = useState<string>("mixed");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    createChild.mutate(
+      {
+        name,
+        birthDate,
+        diagnosisType: diagnosisType as "inattentive" | "hyperactive" | "mixed",
+      },
+      {
+        onSuccess: (data) => {
+          setActiveChild(data.id);
+          onSuccess();
+        },
+      }
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="child-name">Prénom</Label>
+        <Input
+          id="child-name"
+          placeholder="Prénom de l'enfant"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="child-birth">Date de naissance</Label>
+        <Input
+          id="child-birth"
+          type="date"
+          value={birthDate}
+          onChange={(e) => setBirthDate(e.target.value)}
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="child-diagnosis">Type de diagnostic</Label>
+        <Select value={diagnosisType} onValueChange={setDiagnosisType}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="inattentive">Inattentif</SelectItem>
+            <SelectItem value="hyperactive">Hyperactif</SelectItem>
+            <SelectItem value="mixed">Mixte</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <Button
+        type="submit"
+        className="w-full"
+        disabled={createChild.isPending}
+      >
+        {createChild.isPending ? "Ajout..." : "Ajouter"}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,0 +1,7 @@
+import { createAuthClient } from "better-auth/react";
+
+export const authClient = createAuthClient({
+  baseURL: import.meta.env.VITE_API_URL || "",
+});
+
+export const { useSession, signIn, signUp, signOut } = authClient;

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,6 +9,7 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthenticatedSymptomsIndexRouteImport } from './routes/_authenticated/symptoms/index'
@@ -16,6 +17,11 @@ import { Route as AuthenticatedMedicationsIndexRouteImport } from './routes/_aut
 import { Route as AuthenticatedJournalIndexRouteImport } from './routes/_authenticated/journal/index'
 import { Route as AuthenticatedDashboardIndexRouteImport } from './routes/_authenticated/dashboard/index'
 
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AuthenticatedRoute = AuthenticatedRouteImport.update({
   id: '/_authenticated',
   getParentRoute: () => rootRouteImport,
@@ -52,6 +58,7 @@ const AuthenticatedDashboardIndexRoute =
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
   '/dashboard/': typeof AuthenticatedDashboardIndexRoute
   '/journal/': typeof AuthenticatedJournalIndexRoute
   '/medications/': typeof AuthenticatedMedicationsIndexRoute
@@ -59,6 +66,7 @@ export interface FileRoutesByFullPath {
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/login': typeof LoginRoute
   '/dashboard': typeof AuthenticatedDashboardIndexRoute
   '/journal': typeof AuthenticatedJournalIndexRoute
   '/medications': typeof AuthenticatedMedicationsIndexRoute
@@ -68,6 +76,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/_authenticated': typeof AuthenticatedRouteWithChildren
+  '/login': typeof LoginRoute
   '/_authenticated/dashboard/': typeof AuthenticatedDashboardIndexRoute
   '/_authenticated/journal/': typeof AuthenticatedJournalIndexRoute
   '/_authenticated/medications/': typeof AuthenticatedMedicationsIndexRoute
@@ -75,13 +84,20 @@ export interface FileRoutesById {
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/dashboard/' | '/journal/' | '/medications/' | '/symptoms/'
+  fullPaths:
+    | '/'
+    | '/login'
+    | '/dashboard/'
+    | '/journal/'
+    | '/medications/'
+    | '/symptoms/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/dashboard' | '/journal' | '/medications' | '/symptoms'
+  to: '/' | '/login' | '/dashboard' | '/journal' | '/medications' | '/symptoms'
   id:
     | '__root__'
     | '/'
     | '/_authenticated'
+    | '/login'
     | '/_authenticated/dashboard/'
     | '/_authenticated/journal/'
     | '/_authenticated/medications/'
@@ -91,10 +107,18 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
+  LoginRoute: typeof LoginRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/_authenticated': {
       id: '/_authenticated'
       path: ''
@@ -161,6 +185,7 @@ const AuthenticatedRouteWithChildren = AuthenticatedRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
+  LoginRoute: LoginRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -1,17 +1,31 @@
-import { createFileRoute, Outlet, Link } from "@tanstack/react-router";
+import {
+  createFileRoute,
+  Outlet,
+  Link,
+  redirect,
+} from "@tanstack/react-router";
 import {
   BarChart3,
   Pill,
   BookOpen,
   Activity,
   Menu,
+  LogOut,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Separator } from "@/components/ui/separator";
 import { useUiStore } from "@/stores/ui-store";
+import { ChildSelector } from "@/components/shared/child-selector";
+import { authClient, useSession, signOut } from "@/lib/auth-client";
 
 export const Route = createFileRoute("/_authenticated")({
+  beforeLoad: async () => {
+    const session = await authClient.getSession();
+    if (!session.data) {
+      throw redirect({ to: "/login" });
+    }
+  },
   component: AuthenticatedLayout,
 });
 
@@ -41,6 +55,12 @@ function Sidebar() {
 
 function AuthenticatedLayout() {
   const { sidebarOpen, toggleSidebar } = useUiStore();
+  const session = useSession();
+
+  const handleSignOut = async () => {
+    await signOut();
+    window.location.href = "/login";
+  };
 
   return (
     <div className="min-h-screen bg-background">
@@ -57,7 +77,8 @@ function AuthenticatedLayout() {
             <SheetContent side="left" className="w-64 p-0">
               <div className="flex h-14 items-center px-6">
                 <span className="text-lg font-bold text-primary">
-                  Tokō <span className="text-xs text-muted-foreground">登光</span>
+                  Tokō{" "}
+                  <span className="text-xs text-muted-foreground">登光</span>
                 </span>
               </div>
               <Separator />
@@ -68,6 +89,16 @@ function AuthenticatedLayout() {
           <Link to="/dashboard" className="text-lg font-bold text-primary">
             Tokō <span className="text-xs text-muted-foreground">登光</span>
           </Link>
+
+          <div className="ml-auto flex items-center gap-3">
+            <ChildSelector />
+            <span className="hidden text-sm text-muted-foreground sm:inline">
+              {session.data?.user?.name}
+            </span>
+            <Button variant="ghost" size="icon" onClick={handleSignOut}>
+              <LogOut className="h-4 w-4" />
+            </Button>
+          </div>
         </div>
       </header>
 

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -1,0 +1,182 @@
+import { useState } from "react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { signIn, signUp } from "@/lib/auth-client";
+
+export const Route = createFileRoute("/login")({
+  component: LoginPage,
+});
+
+function LoginPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
+      <div className="w-full max-w-md space-y-6">
+        <div className="text-center">
+          <h1 className="text-3xl font-bold text-primary">
+            Tokō <span className="text-lg text-muted-foreground">登光</span>
+          </h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            L'application qui aide les parents à guider leur enfant TDAH, un
+            jour à la fois.
+          </p>
+        </div>
+
+        <Tabs defaultValue="login">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="login">Connexion</TabsTrigger>
+            <TabsTrigger value="register">Inscription</TabsTrigger>
+          </TabsList>
+          <TabsContent value="login">
+            <LoginForm />
+          </TabsContent>
+          <TabsContent value="register">
+            <RegisterForm />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+}
+
+function LoginForm() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    const result = await signIn.email({ email, password });
+
+    if (result.error) {
+      setError(result.error.message ?? "Identifiants incorrects");
+      setLoading(false);
+      return;
+    }
+
+    navigate({ to: "/dashboard" });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Connexion</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="login-email">Email</Label>
+            <Input
+              id="login-email"
+              type="email"
+              placeholder="parent@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="login-password">Mot de passe</Label>
+            <Input
+              id="login-password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+            />
+          </div>
+          {error && (
+            <p className="text-sm text-destructive">{error}</p>
+          )}
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? "Connexion..." : "Se connecter"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RegisterForm() {
+  const navigate = useNavigate();
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+
+    const result = await signUp.email({ name, email, password });
+
+    if (result.error) {
+      setError(result.error.message ?? "Erreur lors de l'inscription");
+      setLoading(false);
+      return;
+    }
+
+    navigate({ to: "/dashboard" });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Créer un compte</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="register-name">Nom</Label>
+            <Input
+              id="register-name"
+              placeholder="Votre nom"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="register-email">Email</Label>
+            <Input
+              id="register-email"
+              type="email"
+              placeholder="parent@example.com"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="register-password">Mot de passe</Label>
+            <Input
+              id="register-password"
+              type="password"
+              placeholder="Minimum 8 caractères"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              minLength={8}
+              required
+            />
+          </div>
+          {error && (
+            <p className="text-sm text-destructive">{error}</p>
+          )}
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? "Inscription..." : "Créer mon compte"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/stores/ui-store.ts
+++ b/apps/web/src/stores/ui-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 interface UiState {
   sidebarOpen: boolean;
@@ -7,9 +8,17 @@ interface UiState {
   setActiveChild: (id: string) => void;
 }
 
-export const useUiStore = create<UiState>((set) => ({
-  sidebarOpen: false,
-  activeChildId: null,
-  toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen })),
-  setActiveChild: (id) => set({ activeChildId: id }),
-}));
+export const useUiStore = create<UiState>()(
+  persist(
+    (set) => ({
+      sidebarOpen: false,
+      activeChildId: null,
+      toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen })),
+      setActiveChild: (id) => set({ activeChildId: id }),
+    }),
+    {
+      name: "toko-ui",
+      partialize: (state) => ({ activeChildId: state.activeChildId }),
+    }
+  )
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.92.0
         version: 1.168.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      better-auth:
+        specifier: ^1.2.0
+        version: 1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.1(@opentelemetry/api@1.9.0)(gel@2.2.0)(kysely@0.28.14)(postgres@3.4.8))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.0(@opentelemetry/api@1.9.0)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(typescript@5.9.3))(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1


### PR DESCRIPTION
## Résumé technique

### Contexte
L'application avait des routes API protégées (401 sans session) mais aucune interface de connexion côté frontend. Tous les appels API échouaient silencieusement. Le sélecteur d'enfant n'existait pas — `activeChildId` était toujours `null`, rendant les pages symptômes et médicaments inutilisables.

Un fast meeting avec 4 personas (PO, Frontend, Backend, Architecte) a identifié auth + child selector comme les deux blockers critiques du MVP, unanimement prioritaires devant dashboard KPIs, journal API, et PDF export.

### Approche retenue
- **better-auth client** natif (`better-auth/react`) plutôt qu'un auth custom — cohérent avec le backend déjà configuré
- **`beforeLoad` guard** sur TanStack Router plutôt qu'un wrapper React — exécuté avant le rendu, pas de flash de contenu non-authentifié
- **Zustand persist middleware** pour `activeChildId` plutôt qu'URL params — survit au refresh sans polluer l'URL
- **Ownership check** ajouté sur `POST /medications/log` — vulnérabilité identifiée par SOLID Alex pendant la réunion

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/web/src/lib/auth-client.ts` | Client better-auth avec `createAuthClient` | Fournit `useSession`, `signIn`, `signUp`, `signOut` |
| `apps/web/src/routes/login.tsx` | Page login/register avec tabs | Email/password, validation, messages d'erreur en français |
| `apps/web/src/routes/_authenticated.tsx` | `beforeLoad` auth guard + sign-out + child selector dans header | Redirige vers `/login` si pas de session |
| `apps/web/src/components/shared/child-selector.tsx` | Dropdown sélection + dialog ajout enfant | Auto-select premier enfant, formulaire avec diagnostic type |
| `apps/web/src/stores/ui-store.ts` | Persist `activeChildId` via zustand/middleware | Survit au refresh navigateur |
| `apps/api/src/routes/medications.ts` | Ownership check sur `POST /log` | Vérifie que le médicament appartient à un enfant du parent authentifié |
| `apps/web/src/routeTree.gen.ts` | Route tree régénéré | Inclut `/login` |

### Points d'attention pour la revue
- Le `beforeLoad` appelle `authClient.getSession()` — vérifier que le cookie de session est bien envoyé cross-origin en dev (proxy Vite)
- Le `signOut` fait un `window.location.href = "/login"` plutôt qu'un `navigate()` pour garantir un reset complet du state React
- L'ownership check sur `/log` fait 2 queries (medication + children) — acceptable pour le MVP, à optimiser avec un JOIN si nécessaire

### Tests
- 16 exécutés, 16 passés, 0 échoués (validators: 10, db: 5, api: 1)

### Étapes restantes
- [ ] Journal API routes (backend manquant)
- [ ] Dashboard KPIs wired to real data
- [ ] PDF export
- [ ] Google OAuth (post-MVP)

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation des tests
- [ ] Merge après approbation

---
_Implémentation générée automatiquement par IA_

> _Attention : la branche `feat/fm-toko-scaffold` est également active. Vérifier les conflits potentiels avant merge._