### PR TITLE
feat(mvp): journal API, dashboard stats, report endpoint

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,6 +6,9 @@ import { healthRoutes } from "./routes/health";
 import { childrenRoutes } from "./routes/children";
 import { symptomsRoutes } from "./routes/symptoms";
 import { medicationsRoutes } from "./routes/medications";
+import { journalRoutes } from "./routes/journal";
+import { statsRoutes } from "./routes/stats";
+import { reportRoutes } from "./routes/report";
 import { auth } from "./lib/auth";
 
 const app = new Hono();
@@ -26,5 +29,8 @@ app.route("/api/health", healthRoutes);
 app.route("/api/children", childrenRoutes);
 app.route("/api/symptoms", symptomsRoutes);
 app.route("/api/medications", medicationsRoutes);
+app.route("/api/journal", journalRoutes);
+app.route("/api/stats", statsRoutes);
+app.route("/api/report", reportRoutes);
 
 export { app };

--- a/apps/api/src/routes/journal.ts
+++ b/apps/api/src/routes/journal.ts
@@ -1,0 +1,135 @@
+import { Hono } from "hono";
+import { eq, and } from "drizzle-orm";
+import { db, journalEntries, children } from "@focusflow/db";
+import {
+  createJournalEntrySchema,
+  updateJournalEntrySchema,
+} from "@focusflow/validators";
+import { authMiddleware } from "../middleware/auth";
+import { AppError } from "../middleware/error-handler";
+
+export const journalRoutes = new Hono();
+
+journalRoutes.use("*", authMiddleware);
+
+journalRoutes.get("/:childId", async (c) => {
+  const user = c.get("user") as { id: string };
+  const childId = c.req.param("childId");
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(and(eq(children.id, childId), eq(children.parentId, user.id)));
+
+  if (!child) {
+    throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
+  }
+
+  const result = await db
+    .select()
+    .from(journalEntries)
+    .where(eq(journalEntries.childId, childId));
+
+  return c.json(result);
+});
+
+journalRoutes.post("/", async (c) => {
+  const user = c.get("user") as { id: string };
+  const body = await c.req.json();
+  const parsed = createJournalEntrySchema.safeParse(body);
+
+  if (!parsed.success) {
+    return c.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      422
+    );
+  }
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(
+      and(eq(children.id, parsed.data.childId), eq(children.parentId, user.id))
+    );
+
+  if (!child) {
+    throw new AppError("FORBIDDEN", "Accès refusé", 403);
+  }
+
+  const [entry] = await db
+    .insert(journalEntries)
+    .values(parsed.data)
+    .returning();
+
+  return c.json(entry, 201);
+});
+
+journalRoutes.patch("/:id", async (c) => {
+  const user = c.get("user") as { id: string };
+  const id = c.req.param("id");
+  const body = await c.req.json();
+  const parsed = updateJournalEntrySchema.safeParse(body);
+
+  if (!parsed.success) {
+    return c.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      422
+    );
+  }
+
+  const [existing] = await db
+    .select()
+    .from(journalEntries)
+    .where(eq(journalEntries.id, id));
+
+  if (!existing) {
+    throw new AppError("NOT_FOUND", "Entrée non trouvée", 404);
+  }
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(
+      and(eq(children.id, existing.childId), eq(children.parentId, user.id))
+    );
+
+  if (!child) {
+    throw new AppError("FORBIDDEN", "Accès refusé", 403);
+  }
+
+  const [updated] = await db
+    .update(journalEntries)
+    .set({ ...parsed.data, updatedAt: new Date() })
+    .where(eq(journalEntries.id, id))
+    .returning();
+
+  return c.json(updated);
+});
+
+journalRoutes.delete("/:id", async (c) => {
+  const user = c.get("user") as { id: string };
+  const id = c.req.param("id");
+
+  const [existing] = await db
+    .select()
+    .from(journalEntries)
+    .where(eq(journalEntries.id, id));
+
+  if (!existing) {
+    throw new AppError("NOT_FOUND", "Entrée non trouvée", 404);
+  }
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(
+      and(eq(children.id, existing.childId), eq(children.parentId, user.id))
+    );
+
+  if (!child) {
+    throw new AppError("FORBIDDEN", "Accès refusé", 403);
+  }
+
+  await db.delete(journalEntries).where(eq(journalEntries.id, id));
+  return c.json({ ok: true });
+});

--- a/apps/api/src/routes/report.ts
+++ b/apps/api/src/routes/report.ts
@@ -1,0 +1,169 @@
+import { Hono } from "hono";
+import { eq, and, gte, lte } from "drizzle-orm";
+import {
+  db,
+  children,
+  symptoms,
+  medication,
+  medicationLogs,
+  journalEntries,
+} from "@focusflow/db";
+import { authMiddleware } from "../middleware/auth";
+import { AppError } from "../middleware/error-handler";
+
+export const reportRoutes = new Hono();
+
+reportRoutes.use("*", authMiddleware);
+
+/**
+ * Generate a plain-text medical consultation report.
+ * GET /api/report/:childId?from=2024-01-01&to=2024-01-31
+ *
+ * Returns a structured text report suitable for printing or
+ * copy-pasting into a medical consultation document.
+ * A future iteration can wrap this in a PDF renderer.
+ */
+reportRoutes.get("/:childId", async (c) => {
+  const user = c.get("user") as { id: string };
+  const childId = c.req.param("childId");
+  const from = c.req.query("from");
+  const to = c.req.query("to");
+
+  if (!from || !to) {
+    return c.json(
+      { error: "Paramètres 'from' et 'to' requis (YYYY-MM-DD)" },
+      400
+    );
+  }
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(and(eq(children.id, childId), eq(children.parentId, user.id)));
+
+  if (!child) {
+    throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
+  }
+
+  // Fetch all data for the period
+  const [periodSymptoms, meds, logs, journal] = await Promise.all([
+    db
+      .select()
+      .from(symptoms)
+      .where(
+        and(
+          eq(symptoms.childId, childId),
+          gte(symptoms.date, from),
+          lte(symptoms.date, to)
+        )
+      ),
+    db
+      .select()
+      .from(medication)
+      .where(eq(medication.childId, childId)),
+    db
+      .select()
+      .from(medicationLogs)
+      .where(
+        and(gte(medicationLogs.date, from), lte(medicationLogs.date, to))
+      ),
+    db
+      .select()
+      .from(journalEntries)
+      .where(
+        and(
+          eq(journalEntries.childId, childId),
+          gte(journalEntries.date, from),
+          lte(journalEntries.date, to)
+        )
+      ),
+  ]);
+
+  // Filter logs to only those for this child's medications
+  const medIds = new Set(meds.map((m) => m.id));
+  const childLogs = logs.filter((l) => medIds.has(l.medicationId));
+
+  // Compute averages
+  const avgSymptoms =
+    periodSymptoms.length > 0
+      ? {
+          agitation: avg(periodSymptoms.map((s) => s.agitation)),
+          focus: avg(periodSymptoms.map((s) => s.focus)),
+          impulse: avg(periodSymptoms.map((s) => s.impulse)),
+          mood: avg(periodSymptoms.map((s) => s.mood)),
+          sleep: avg(periodSymptoms.map((s) => s.sleep)),
+        }
+      : null;
+
+  // Medication adherence
+  const totalDoses = childLogs.length;
+  const takenDoses = childLogs.filter((l) => l.status === "taken").length;
+  const adherenceRate =
+    totalDoses > 0 ? Math.round((takenDoses / totalDoses) * 100) : null;
+
+  // Build report
+  const diagnosisLabel = {
+    inattentive: "Prédominance inattentive",
+    hyperactive: "Prédominance hyperactive-impulsive",
+    mixed: "Présentation combinée",
+  }[child.diagnosisType] ?? child.diagnosisType;
+
+  const report = {
+    title: `Rapport de suivi TDAH — ${child.name}`,
+    period: { from, to },
+    child: {
+      name: child.name,
+      birthDate: child.birthDate,
+      diagnosisType: diagnosisLabel,
+    },
+    symptoms: {
+      entryCount: periodSymptoms.length,
+      averages: avgSymptoms,
+      entries: periodSymptoms.map((s) => ({
+        date: s.date,
+        agitation: s.agitation,
+        focus: s.focus,
+        impulse: s.impulse,
+        mood: s.mood,
+        sleep: s.sleep,
+        context: s.context,
+        notes: s.notes,
+      })),
+    },
+    medications: {
+      active: meds
+        .filter((m) => m.active)
+        .map((m) => ({
+          name: m.name,
+          dose: m.dose,
+          scheduledAt: m.scheduledAt,
+        })),
+      adherenceRate,
+      totalDoses,
+      takenDoses,
+      logs: childLogs.map((l) => ({
+        date: l.date,
+        status: l.status,
+        medicationName:
+          meds.find((m) => m.id === l.medicationId)?.name ?? "Inconnu",
+      })),
+    },
+    journal: {
+      entryCount: journal.length,
+      entries: journal.map((j) => ({
+        date: j.date,
+        moodRating: j.moodRating,
+        tags: j.tags,
+        text: j.text,
+      })),
+    },
+    generatedAt: new Date().toISOString(),
+  };
+
+  return c.json(report);
+});
+
+function avg(numbers: number[]): number {
+  if (numbers.length === 0) return 0;
+  return Math.round((numbers.reduce((a, b) => a + b, 0) / numbers.length) * 10) / 10;
+}

--- a/apps/api/src/routes/stats.ts
+++ b/apps/api/src/routes/stats.ts
@@ -1,0 +1,111 @@
+import { Hono } from "hono";
+import { eq, and, gte, sql } from "drizzle-orm";
+import {
+  db,
+  children,
+  symptoms,
+  medication,
+  medicationLogs,
+  journalEntries,
+} from "@focusflow/db";
+import { authMiddleware } from "../middleware/auth";
+import { AppError } from "../middleware/error-handler";
+
+export const statsRoutes = new Hono();
+
+statsRoutes.use("*", authMiddleware);
+
+statsRoutes.get("/:childId", async (c) => {
+  const user = c.get("user") as { id: string };
+  const childId = c.req.param("childId");
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(and(eq(children.id, childId), eq(children.parentId, user.id)));
+
+  if (!child) {
+    throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
+  }
+
+  const today = new Date().toISOString().split("T")[0]!;
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split("T")[0]!;
+
+  // Medications taken today
+  const activeMeds = await db
+    .select()
+    .from(medication)
+    .where(
+      and(eq(medication.childId, childId), eq(medication.active, true))
+    );
+
+  const todayLogs = await db
+    .select()
+    .from(medicationLogs)
+    .where(
+      and(
+        eq(medicationLogs.date, today),
+        eq(medicationLogs.status, "taken")
+      )
+    );
+
+  const medsTakenToday = todayLogs.filter((log) =>
+    activeMeds.some((med) => med.id === log.medicationId)
+  ).length;
+
+  // Weekly symptoms
+  const weeklySymptoms = await db
+    .select()
+    .from(symptoms)
+    .where(
+      and(
+        eq(symptoms.childId, childId),
+        gte(symptoms.date, sevenDaysAgo)
+      )
+    );
+
+  // Latest mood from journal
+  const latestJournal = await db
+    .select()
+    .from(journalEntries)
+    .where(eq(journalEntries.childId, childId))
+    .orderBy(sql`${journalEntries.date} DESC`)
+    .limit(1);
+
+  // Streak: consecutive days with at least one symptom entry
+  const allSymptoms = await db
+    .select({ date: symptoms.date })
+    .from(symptoms)
+    .where(eq(symptoms.childId, childId))
+    .orderBy(sql`${symptoms.date} DESC`);
+
+  let streak = 0;
+  const todayDate = new Date(today);
+  for (let i = 0; i < 365; i++) {
+    const checkDate = new Date(todayDate);
+    checkDate.setDate(checkDate.getDate() - i);
+    const dateStr = checkDate.toISOString().split("T")[0];
+    if (allSymptoms.some((s) => s.date === dateStr)) {
+      streak++;
+    } else {
+      break;
+    }
+  }
+
+  return c.json({
+    medicationsTakenToday: medsTakenToday,
+    totalActiveMedications: activeMeds.length,
+    streak,
+    latestMoodRating: latestJournal[0]?.moodRating ?? null,
+    weeklySymptoms: weeklySymptoms.map((s) => ({
+      date: s.date,
+      mood: s.mood,
+      focus: s.focus,
+      agitation: s.agitation,
+      impulse: s.impulse,
+      sleep: s.sleep,
+    })),
+  });
+});

--- a/apps/web/src/components/dashboard/weekly-chart.tsx
+++ b/apps/web/src/components/dashboard/weekly-chart.tsx
@@ -9,63 +9,87 @@ import {
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
-const placeholderData = [
-  { day: "Lun", mood: 3, focus: 5, agitation: 4 },
-  { day: "Mar", mood: 4, focus: 6, agitation: 3 },
-  { day: "Mer", mood: 3, focus: 4, agitation: 5 },
-  { day: "Jeu", mood: 2, focus: 3, agitation: 7 },
-  { day: "Ven", mood: 4, focus: 7, agitation: 2 },
-  { day: "Sam", mood: 5, focus: 6, agitation: 3 },
-  { day: "Dim", mood: 4, focus: 5, agitation: 4 },
-];
+interface SymptomPoint {
+  date: string;
+  mood: number;
+  focus: number;
+  agitation: number;
+  impulse: number;
+  sleep: number;
+}
 
-export function WeeklyChart() {
+const dayNames: Record<number, string> = {
+  0: "Dim",
+  1: "Lun",
+  2: "Mar",
+  3: "Mer",
+  4: "Jeu",
+  5: "Ven",
+  6: "Sam",
+};
+
+export function WeeklyChart({ data }: { data?: SymptomPoint[] }) {
+  const chartData = data?.map((s) => ({
+    day: dayNames[new Date(s.date).getDay()] ?? s.date,
+    mood: s.mood,
+    focus: s.focus,
+    agitation: s.agitation,
+  }));
+
+  const hasData = chartData && chartData.length > 0;
+
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-base">Semaine en cours</CardTitle>
       </CardHeader>
       <CardContent>
-        <ResponsiveContainer width="100%" height={200}>
-          <AreaChart data={placeholderData}>
-            <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
-            <XAxis
-              dataKey="day"
-              className="text-xs"
-              tick={{ fill: "var(--muted-foreground)" }}
-            />
-            <YAxis
-              domain={[0, 10]}
-              className="text-xs"
-              tick={{ fill: "var(--muted-foreground)" }}
-            />
-            <Tooltip />
-            <Area
-              type="monotone"
-              dataKey="mood"
-              stackId="1"
-              stroke="#f97316"
-              fill="#f9731640"
-              name="Humeur"
-            />
-            <Area
-              type="monotone"
-              dataKey="focus"
-              stackId="2"
-              stroke="#10b981"
-              fill="#10b98140"
-              name="Concentration"
-            />
-            <Area
-              type="monotone"
-              dataKey="agitation"
-              stackId="3"
-              stroke="#f43f5e"
-              fill="#f43f5e40"
-              name="Agitation"
-            />
-          </AreaChart>
-        </ResponsiveContainer>
+        {hasData ? (
+          <ResponsiveContainer width="100%" height={200}>
+            <AreaChart data={chartData}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+              <XAxis
+                dataKey="day"
+                className="text-xs"
+                tick={{ fill: "var(--muted-foreground)" }}
+              />
+              <YAxis
+                domain={[0, 10]}
+                className="text-xs"
+                tick={{ fill: "var(--muted-foreground)" }}
+              />
+              <Tooltip />
+              <Area
+                type="monotone"
+                dataKey="mood"
+                stackId="1"
+                stroke="#f97316"
+                fill="#f9731640"
+                name="Humeur"
+              />
+              <Area
+                type="monotone"
+                dataKey="focus"
+                stackId="2"
+                stroke="#10b981"
+                fill="#10b98140"
+                name="Concentration"
+              />
+              <Area
+                type="monotone"
+                dataKey="agitation"
+                stackId="3"
+                stroke="#f43f5e"
+                fill="#f43f5e40"
+                name="Agitation"
+              />
+            </AreaChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="flex h-[200px] items-center justify-center text-sm text-muted-foreground">
+            Aucune donnée cette semaine. Ajoutez des relevés de symptômes.
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/apps/web/src/hooks/use-journal.ts
+++ b/apps/web/src/hooks/use-journal.ts
@@ -1,0 +1,27 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import type { JournalEntry, CreateJournalEntry } from "@focusflow/validators";
+
+export const journalKeys = {
+  all: (childId: string) => ["journal", childId] as const,
+};
+
+export function useJournal(childId: string) {
+  return useQuery({
+    queryKey: journalKeys.all(childId),
+    queryFn: () => api.get<JournalEntry[]>(`/journal/${childId}`),
+    enabled: !!childId,
+  });
+}
+
+export function useCreateJournalEntry() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateJournalEntry) =>
+      api.post<JournalEntry>("/journal", data),
+    onSuccess: (_, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: journalKeys.all(variables.childId),
+      }),
+  });
+}

--- a/apps/web/src/hooks/use-stats.ts
+++ b/apps/web/src/hooks/use-stats.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+
+interface Stats {
+  medicationsTakenToday: number;
+  totalActiveMedications: number;
+  streak: number;
+  latestMoodRating: number | null;
+  weeklySymptoms: {
+    date: string;
+    mood: number;
+    focus: number;
+    agitation: number;
+    impulse: number;
+    sleep: number;
+  }[];
+}
+
+export const statsKeys = {
+  child: (childId: string) => ["stats", childId] as const,
+};
+
+export function useStats(childId: string) {
+  return useQuery({
+    queryKey: statsKeys.child(childId),
+    queryFn: () => api.get<Stats>(`/stats/${childId}`),
+    enabled: !!childId,
+    refetchInterval: 60_000,
+  });
+}

--- a/apps/web/src/routes/_authenticated/dashboard/index.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard/index.tsx
@@ -5,15 +5,19 @@ import { Button } from "@/components/ui/button";
 import { MoodLogger } from "@/components/dashboard/mood-logger";
 import { WeeklyChart } from "@/components/dashboard/weekly-chart";
 import { useChildren } from "@/hooks/use-children";
+import { useStats } from "@/hooks/use-stats";
 import { useUiStore } from "@/stores/ui-store";
 
 export const Route = createFileRoute("/_authenticated/dashboard/")({
   component: DashboardPage,
 });
 
+const moodLabels = ["", "Difficile", "Moyen", "Bien", "Super"];
+
 function DashboardPage() {
   const { data: children, isLoading } = useChildren();
   const activeChildId = useUiStore((s) => s.activeChildId);
+  const { data: stats } = useStats(activeChildId ?? "");
 
   if (isLoading) {
     return (
@@ -35,6 +39,16 @@ function DashboardPage() {
     );
   }
 
+  const medLabel = stats
+    ? `${stats.medicationsTakenToday}/${stats.totalActiveMedications}`
+    : "—";
+
+  const streakLabel = stats ? `${stats.streak}` : "—";
+
+  const moodLabel = stats?.latestMoodRating
+    ? moodLabels[stats.latestMoodRating] ?? "—"
+    : "—";
+
   return (
     <div className="space-y-6">
       <div>
@@ -47,14 +61,14 @@ function DashboardPage() {
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <KpiCard
           title="Médicaments"
-          value="—"
-          subtitle="aujourd'hui"
+          value={medLabel}
+          subtitle="pris aujourd'hui"
           icon={Pill}
           color="text-status-success"
         />
         <KpiCard
           title="Série"
-          value="—"
+          value={streakLabel}
           subtitle="jours consécutifs"
           icon={Flame}
           color="text-primary"
@@ -68,8 +82,8 @@ function DashboardPage() {
         />
         <KpiCard
           title="Humeur"
-          value="—"
-          subtitle="tendance"
+          value={moodLabel}
+          subtitle="dernière entrée"
           icon={SmilePlus}
           color="text-status-danger"
         />
@@ -77,7 +91,7 @@ function DashboardPage() {
 
       <div className="grid gap-6 lg:grid-cols-2">
         <MoodLogger />
-        <WeeklyChart />
+        <WeeklyChart data={stats?.weeklySymptoms} />
       </div>
     </div>
   );

--- a/apps/web/src/routes/_authenticated/journal/index.tsx
+++ b/apps/web/src/routes/_authenticated/journal/index.tsx
@@ -13,13 +13,18 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import type { JournalTag } from "@focusflow/validators";
+import { useJournal, useCreateJournalEntry } from "@/hooks/use-journal";
+import { useUiStore } from "@/stores/ui-store";
+import type { JournalTag, JournalEntry } from "@focusflow/validators";
 
 export const Route = createFileRoute("/_authenticated/journal/")({
   component: JournalPage,
 });
 
-const tagConfig: Record<JournalTag, { label: string; variant: "default" | "secondary" | "outline" | "destructive" }> = {
+const tagConfig: Record<
+  JournalTag,
+  { label: string; variant: "default" | "secondary" | "outline" | "destructive" }
+> = {
   school: { label: "École", variant: "default" },
   victory: { label: "Victoire", variant: "default" },
   crisis: { label: "Crise", variant: "destructive" },
@@ -33,6 +38,8 @@ const moodEmojis = ["😢", "😐", "🙂", "😄"];
 
 function JournalPage() {
   const [dialogOpen, setDialogOpen] = useState(false);
+  const activeChildId = useUiStore((s) => s.activeChildId);
+  const { data: entries, isLoading } = useJournal(activeChildId ?? "");
 
   return (
     <div className="space-y-6">
@@ -61,20 +68,75 @@ function JournalPage() {
         </Dialog>
       </div>
 
-      <Card>
-        <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
-          <BookOpen className="h-10 w-10 text-muted-foreground/50" />
-          <p className="text-muted-foreground">
-            Votre journal est vide. Commencez à écrire vos premières
-            observations.
-          </p>
-        </CardContent>
-      </Card>
+      {!activeChildId ? (
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            Sélectionnez un enfant pour voir son journal.
+          </CardContent>
+        </Card>
+      ) : isLoading ? (
+        <div className="flex justify-center py-12">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+        </div>
+      ) : !entries?.length ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+            <BookOpen className="h-10 w-10 text-muted-foreground/50" />
+            <p className="text-muted-foreground">
+              Votre journal est vide. Commencez à écrire vos premières
+              observations.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-4">
+          {entries.map((entry) => (
+            <JournalCard key={entry.id} entry={entry} />
+          ))}
+        </div>
+      )}
     </div>
   );
 }
 
+function JournalCard({ entry }: { entry: JournalEntry }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm font-medium">
+            {new Date(entry.date).toLocaleDateString("fr-FR", {
+              weekday: "long",
+              day: "numeric",
+              month: "long",
+            })}
+          </CardTitle>
+          <span className="text-lg">{moodEmojis[entry.moodRating - 1]}</span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-sm text-foreground">{entry.text}</p>
+        {entry.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {entry.tags.map((tag) => (
+              <Badge
+                key={tag}
+                variant={tagConfig[tag as JournalTag]?.variant ?? "secondary"}
+                className="text-xs"
+              >
+                {tagConfig[tag as JournalTag]?.label ?? tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
 function JournalForm({ onSuccess }: { onSuccess: () => void }) {
+  const activeChildId = useUiStore((s) => s.activeChildId);
+  const createEntry = useCreateJournalEntry();
   const [text, setText] = useState("");
   const [selectedTags, setSelectedTags] = useState<JournalTag[]>([]);
   const [moodRating, setMoodRating] = useState(3);
@@ -85,14 +147,24 @@ function JournalForm({ onSuccess }: { onSuccess: () => void }) {
     );
   };
 
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!activeChildId) return;
+
+    createEntry.mutate(
+      {
+        childId: activeChildId,
+        date: new Date().toISOString().split("T")[0]!,
+        text,
+        tags: selectedTags,
+        moodRating,
+      },
+      { onSuccess }
+    );
+  };
+
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        onSuccess();
-      }}
-      className="space-y-4"
-    >
+    <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-2">
         <Label>Humeur du jour</Label>
         <div className="flex justify-around">
@@ -116,18 +188,21 @@ function JournalForm({ onSuccess }: { onSuccess: () => void }) {
       <div className="space-y-2">
         <Label>Tags</Label>
         <div className="flex flex-wrap gap-2">
-          {(Object.entries(tagConfig) as [JournalTag, typeof tagConfig[JournalTag]][]).map(
-            ([tag, config]) => (
-              <Badge
-                key={tag}
-                variant={selectedTags.includes(tag) ? "default" : "outline"}
-                className="cursor-pointer"
-                onClick={() => toggleTag(tag)}
-              >
-                {config.label}
-              </Badge>
-            )
-          )}
+          {(
+            Object.entries(tagConfig) as [
+              JournalTag,
+              (typeof tagConfig)[JournalTag],
+            ][]
+          ).map(([tag, config]) => (
+            <Badge
+              key={tag}
+              variant={selectedTags.includes(tag) ? "default" : "outline"}
+              className="cursor-pointer"
+              onClick={() => toggleTag(tag)}
+            >
+              {config.label}
+            </Badge>
+          ))}
         </div>
       </div>
 
@@ -143,8 +218,12 @@ function JournalForm({ onSuccess }: { onSuccess: () => void }) {
         />
       </div>
 
-      <Button type="submit" className="w-full">
-        Enregistrer
+      <Button
+        type="submit"
+        className="w-full"
+        disabled={!activeChildId || createEntry.isPending}
+      >
+        {createEntry.isPending ? "Enregistrement..." : "Enregistrer"}
       </Button>
     </form>
   );


### PR DESCRIPTION
## Résumé technique

### Contexte
Trois gaps MVP restaient après l'implémentation de l'auth et du child selector : le journal n'avait pas de backend, le dashboard affichait des placeholders, et l'export rapport n'existait pas.

### Approche retenue
- **Stats API** dédié (`/api/stats/:childId`) plutôt que des queries côté frontend — centralise la logique métier (streak, adherence rate) côté serveur
- **Report API** retourne du JSON structuré — un futur endpoint pourra wrapper ce JSON en PDF via Puppeteer ou @react-pdf sans changer la logique de données
- **Journal CRUD** suit le même pattern que symptoms/medications (ownership check via children.parentId)

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/api/src/routes/journal.ts` | CRUD complet (GET/POST/PATCH/DELETE) | Ownership check sur chaque opération via children.parentId |
| `apps/api/src/routes/stats.ts` | Dashboard KPIs (med adherence, streak, mood, weekly symptoms) | Calcul côté serveur pour éviter N+1 queries frontend |
| `apps/api/src/routes/report.ts` | Rapport consultation (symptom averages, med adherence, journal) | JSON structuré, paramètres from/to pour filtrage période |
| `apps/api/src/app.ts` | Wiring des 3 nouvelles routes | `/api/journal`, `/api/stats`, `/api/report` |
| `apps/web/src/hooks/use-stats.ts` | Hook TanStack Query pour stats dashboard | Refetch toutes les 60s |
| `apps/web/src/hooks/use-journal.ts` | Hook TanStack Query pour journal CRUD | Cache invalidation on create |
| `apps/web/src/routes/_authenticated/dashboard/index.tsx` | KPIs wired to real stats API | Medications taken/total, streak, mood label |
| `apps/web/src/components/dashboard/weekly-chart.tsx` | Accepte données réelles, fallback empty state | Plus de données placeholder hardcodées |
| `apps/web/src/routes/_authenticated/journal/index.tsx` | Wired to journal API, liste + création | Tags, mood emoji, ownership-scoped |

### Points d'attention pour la revue
- Le streak calcule les jours consécutifs avec entrée symptômes — boucle jusqu'à 365 jours, acceptable pour le MVP mais à optimiser avec une query SQL si les données grandissent
- Le report filtre les medication_logs par date PUIS par child — pourrait être optimisé en un seul JOIN
- WeeklyChart utilise `new Date(s.date).getDay()` pour les labels de jour — attention aux timezones

### Tests
- 16 exécutés, 16 passés, 0 échoués

### Prochaines étapes
- [ ] PDF renderer (wrapper le JSON report en PDF téléchargeable)
- [ ] Google OAuth
- [ ] Appointment calendar (V1)
- [ ] Visual routines (V1)

---
_Implémentation générée automatiquement par IA_

> _Attention : d'autres branches fast-meeting sont actives (fm-toko-scaffold, fm-auth-child-flow). Vérifier les conflits potentiels avant merge._