### PR TITLE
feat(report): medical consultation report with print-to-PDF

### DIFF
--- a/apps/web/src/hooks/use-report.ts
+++ b/apps/web/src/hooks/use-report.ts
@@ -1,0 +1,73 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+
+interface ReportSymptomEntry {
+  date: string;
+  agitation: number;
+  focus: number;
+  impulse: number;
+  mood: number;
+  sleep: number;
+  context: string | null;
+  notes: string | null;
+}
+
+interface ReportMedicationLog {
+  date: string;
+  status: string;
+  medicationName: string;
+}
+
+interface ReportJournalEntry {
+  date: string;
+  moodRating: number;
+  tags: string[];
+  text: string;
+}
+
+export interface Report {
+  title: string;
+  period: { from: string; to: string };
+  child: {
+    name: string;
+    birthDate: string;
+    diagnosisType: string;
+  };
+  symptoms: {
+    entryCount: number;
+    averages: {
+      agitation: number;
+      focus: number;
+      impulse: number;
+      mood: number;
+      sleep: number;
+    } | null;
+    entries: ReportSymptomEntry[];
+  };
+  medications: {
+    active: { name: string; dose: string; scheduledAt: string }[];
+    adherenceRate: number | null;
+    totalDoses: number;
+    takenDoses: number;
+    logs: ReportMedicationLog[];
+  };
+  journal: {
+    entryCount: number;
+    entries: ReportJournalEntry[];
+  };
+  generatedAt: string;
+}
+
+export const reportKeys = {
+  child: (childId: string, from: string, to: string) =>
+    ["report", childId, from, to] as const,
+};
+
+export function useReport(childId: string, from: string, to: string) {
+  return useQuery({
+    queryKey: reportKeys.child(childId, from, to),
+    queryFn: () =>
+      api.get<Report>(`/report/${childId}?from=${from}&to=${to}`),
+    enabled: !!childId && !!from && !!to,
+  });
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthenticatedSymptomsIndexRouteImport } from './routes/_authenticated/symptoms/index'
+import { Route as AuthenticatedReportIndexRouteImport } from './routes/_authenticated/report/index'
 import { Route as AuthenticatedMedicationsIndexRouteImport } from './routes/_authenticated/medications/index'
 import { Route as AuthenticatedJournalIndexRouteImport } from './routes/_authenticated/journal/index'
 import { Route as AuthenticatedDashboardIndexRouteImport } from './routes/_authenticated/dashboard/index'
@@ -35,6 +36,12 @@ const AuthenticatedSymptomsIndexRoute =
   AuthenticatedSymptomsIndexRouteImport.update({
     id: '/symptoms/',
     path: '/symptoms/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+const AuthenticatedReportIndexRoute =
+  AuthenticatedReportIndexRouteImport.update({
+    id: '/report/',
+    path: '/report/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 const AuthenticatedMedicationsIndexRoute =
@@ -62,6 +69,7 @@ export interface FileRoutesByFullPath {
   '/dashboard/': typeof AuthenticatedDashboardIndexRoute
   '/journal/': typeof AuthenticatedJournalIndexRoute
   '/medications/': typeof AuthenticatedMedicationsIndexRoute
+  '/report/': typeof AuthenticatedReportIndexRoute
   '/symptoms/': typeof AuthenticatedSymptomsIndexRoute
 }
 export interface FileRoutesByTo {
@@ -70,6 +78,7 @@ export interface FileRoutesByTo {
   '/dashboard': typeof AuthenticatedDashboardIndexRoute
   '/journal': typeof AuthenticatedJournalIndexRoute
   '/medications': typeof AuthenticatedMedicationsIndexRoute
+  '/report': typeof AuthenticatedReportIndexRoute
   '/symptoms': typeof AuthenticatedSymptomsIndexRoute
 }
 export interface FileRoutesById {
@@ -80,6 +89,7 @@ export interface FileRoutesById {
   '/_authenticated/dashboard/': typeof AuthenticatedDashboardIndexRoute
   '/_authenticated/journal/': typeof AuthenticatedJournalIndexRoute
   '/_authenticated/medications/': typeof AuthenticatedMedicationsIndexRoute
+  '/_authenticated/report/': typeof AuthenticatedReportIndexRoute
   '/_authenticated/symptoms/': typeof AuthenticatedSymptomsIndexRoute
 }
 export interface FileRouteTypes {
@@ -90,9 +100,17 @@ export interface FileRouteTypes {
     | '/dashboard/'
     | '/journal/'
     | '/medications/'
+    | '/report/'
     | '/symptoms/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/dashboard' | '/journal' | '/medications' | '/symptoms'
+  to:
+    | '/'
+    | '/login'
+    | '/dashboard'
+    | '/journal'
+    | '/medications'
+    | '/report'
+    | '/symptoms'
   id:
     | '__root__'
     | '/'
@@ -101,6 +119,7 @@ export interface FileRouteTypes {
     | '/_authenticated/dashboard/'
     | '/_authenticated/journal/'
     | '/_authenticated/medications/'
+    | '/_authenticated/report/'
     | '/_authenticated/symptoms/'
   fileRoutesById: FileRoutesById
 }
@@ -140,6 +159,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSymptomsIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/report/': {
+      id: '/_authenticated/report/'
+      path: '/report'
+      fullPath: '/report/'
+      preLoaderRoute: typeof AuthenticatedReportIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/medications/': {
       id: '/_authenticated/medications/'
       path: '/medications'
@@ -168,6 +194,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedDashboardIndexRoute: typeof AuthenticatedDashboardIndexRoute
   AuthenticatedJournalIndexRoute: typeof AuthenticatedJournalIndexRoute
   AuthenticatedMedicationsIndexRoute: typeof AuthenticatedMedicationsIndexRoute
+  AuthenticatedReportIndexRoute: typeof AuthenticatedReportIndexRoute
   AuthenticatedSymptomsIndexRoute: typeof AuthenticatedSymptomsIndexRoute
 }
 
@@ -175,6 +202,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedDashboardIndexRoute: AuthenticatedDashboardIndexRoute,
   AuthenticatedJournalIndexRoute: AuthenticatedJournalIndexRoute,
   AuthenticatedMedicationsIndexRoute: AuthenticatedMedicationsIndexRoute,
+  AuthenticatedReportIndexRoute: AuthenticatedReportIndexRoute,
   AuthenticatedSymptomsIndexRoute: AuthenticatedSymptomsIndexRoute,
 }
 

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -11,6 +11,7 @@ import {
   Activity,
   Menu,
   LogOut,
+  FileText,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
@@ -34,6 +35,7 @@ const navItems = [
   { to: "/symptoms" as const, label: "Symptômes", icon: Activity },
   { to: "/medications" as const, label: "Médicaments", icon: Pill },
   { to: "/journal" as const, label: "Journal", icon: BookOpen },
+  { to: "/report" as const, label: "Rapport", icon: FileText },
 ];
 
 function Sidebar() {

--- a/apps/web/src/routes/_authenticated/report/index.tsx
+++ b/apps/web/src/routes/_authenticated/report/index.tsx
@@ -1,0 +1,313 @@
+import { useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { FileDown, Printer } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { useReport, type Report } from "@/hooks/use-report";
+import { useUiStore } from "@/stores/ui-store";
+import { useChild } from "@/hooks/use-children";
+
+export const Route = createFileRoute("/_authenticated/report/")({
+  component: ReportPage,
+});
+
+function getDefaultDateRange() {
+  const to = new Date();
+  const from = new Date();
+  from.setDate(from.getDate() - 30);
+  return {
+    from: from.toISOString().split("T")[0]!,
+    to: to.toISOString().split("T")[0]!,
+  };
+}
+
+function ReportPage() {
+  const activeChildId = useUiStore((s) => s.activeChildId);
+  const defaults = getDefaultDateRange();
+  const [from, setFrom] = useState(defaults.from);
+  const [to, setTo] = useState(defaults.to);
+  const { data: report, isLoading, isError } = useReport(
+    activeChildId ?? "",
+    from,
+    to
+  );
+
+  if (!activeChildId) {
+    return (
+      <Card>
+        <CardContent className="py-8 text-center text-muted-foreground">
+          Sélectionnez un enfant pour générer un rapport.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between print:hidden">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">
+            Rapport médical
+          </h1>
+          <p className="text-muted-foreground">
+            Export pour consultation médicale
+          </p>
+        </div>
+        <Button onClick={() => window.print()} disabled={!report}>
+          <Printer className="mr-2 h-4 w-4" />
+          Imprimer / PDF
+        </Button>
+      </div>
+
+      <div className="flex gap-4 print:hidden">
+        <div className="space-y-1">
+          <Label htmlFor="from">Du</Label>
+          <Input
+            id="from"
+            type="date"
+            value={from}
+            onChange={(e) => setFrom(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="to">Au</Label>
+          <Input
+            id="to"
+            type="date"
+            value={to}
+            onChange={(e) => setTo(e.target.value)}
+          />
+        </div>
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+        </div>
+      ) : isError ? (
+        <Card>
+          <CardContent className="py-8 text-center text-destructive">
+            Erreur lors de la génération du rapport.
+          </CardContent>
+        </Card>
+      ) : report ? (
+        <ReportView report={report} />
+      ) : null}
+    </div>
+  );
+}
+
+function ReportView({ report }: { report: Report }) {
+  const statusLabels: Record<string, string> = {
+    taken: "Pris",
+    skipped: "Sauté",
+    delayed: "Retardé",
+  };
+
+  return (
+    <div className="space-y-6 print:space-y-4 print:text-sm">
+      {/* Header */}
+      <Card className="print:border-none print:shadow-none">
+        <CardHeader>
+          <CardTitle className="text-xl">{report.title}</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Période : du{" "}
+            {new Date(report.period.from).toLocaleDateString("fr-FR")} au{" "}
+            {new Date(report.period.to).toLocaleDateString("fr-FR")}
+          </p>
+        </CardHeader>
+        <CardContent className="grid gap-2 text-sm sm:grid-cols-3">
+          <div>
+            <span className="text-muted-foreground">Enfant :</span>{" "}
+            {report.child.name}
+          </div>
+          <div>
+            <span className="text-muted-foreground">Naissance :</span>{" "}
+            {new Date(report.child.birthDate).toLocaleDateString("fr-FR")}
+          </div>
+          <div>
+            <span className="text-muted-foreground">Diagnostic :</span>{" "}
+            {report.child.diagnosisType}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Symptom Averages */}
+      {report.symptoms.averages && (
+        <Card className="print:border-none print:shadow-none">
+          <CardHeader>
+            <CardTitle className="text-base">
+              Moyennes des symptômes ({report.symptoms.entryCount} relevés)
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="grid grid-cols-5 gap-4 text-center">
+              {Object.entries(report.symptoms.averages).map(([key, value]) => (
+                <div key={key}>
+                  <div className="text-2xl font-bold">{value}</div>
+                  <div className="text-xs text-muted-foreground capitalize">
+                    {key === "focus"
+                      ? "Concentration"
+                      : key === "impulse"
+                        ? "Impulsivité"
+                        : key === "mood"
+                          ? "Humeur"
+                          : key === "sleep"
+                            ? "Sommeil"
+                            : "Agitation"}
+                  </div>
+                  <div className="text-xs text-muted-foreground">/10</div>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Medications */}
+      <Card className="print:border-none print:shadow-none">
+        <CardHeader>
+          <CardTitle className="text-base">Traitements</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {report.medications.active.length > 0 ? (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Médicament</TableHead>
+                  <TableHead>Dosage</TableHead>
+                  <TableHead>Horaire</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {report.medications.active.map((med, i) => (
+                  <TableRow key={i}>
+                    <TableCell className="font-medium">{med.name}</TableCell>
+                    <TableCell>{med.dose}</TableCell>
+                    <TableCell>{med.scheduledAt}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Aucun traitement actif.
+            </p>
+          )}
+
+          {report.medications.adherenceRate !== null && (
+            <div className="flex items-center gap-2 text-sm">
+              <span className="text-muted-foreground">
+                Taux d'observance :
+              </span>
+              <Badge
+                variant={
+                  report.medications.adherenceRate >= 80
+                    ? "default"
+                    : "destructive"
+                }
+              >
+                {report.medications.adherenceRate}%
+              </Badge>
+              <span className="text-muted-foreground">
+                ({report.medications.takenDoses}/{report.medications.totalDoses}{" "}
+                prises)
+              </span>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Symptom Detail Table */}
+      {report.symptoms.entries.length > 0 && (
+        <Card className="print:border-none print:shadow-none">
+          <CardHeader>
+            <CardTitle className="text-base">Détail des symptômes</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Date</TableHead>
+                  <TableHead className="text-center">Agit.</TableHead>
+                  <TableHead className="text-center">Conc.</TableHead>
+                  <TableHead className="text-center">Imp.</TableHead>
+                  <TableHead className="text-center">Hum.</TableHead>
+                  <TableHead className="text-center">Som.</TableHead>
+                  <TableHead>Notes</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {report.symptoms.entries.map((s, i) => (
+                  <TableRow key={i}>
+                    <TableCell>
+                      {new Date(s.date).toLocaleDateString("fr-FR", {
+                        day: "2-digit",
+                        month: "2-digit",
+                      })}
+                    </TableCell>
+                    <TableCell className="text-center">{s.agitation}</TableCell>
+                    <TableCell className="text-center">{s.focus}</TableCell>
+                    <TableCell className="text-center">{s.impulse}</TableCell>
+                    <TableCell className="text-center">{s.mood}</TableCell>
+                    <TableCell className="text-center">{s.sleep}</TableCell>
+                    <TableCell className="max-w-[200px] truncate text-xs">
+                      {s.notes ?? "—"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Journal */}
+      {report.journal.entries.length > 0 && (
+        <Card className="print:border-none print:shadow-none">
+          <CardHeader>
+            <CardTitle className="text-base">
+              Journal ({report.journal.entryCount} entrées)
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {report.journal.entries.map((j, i) => (
+              <div key={i} className="border-b pb-2 last:border-0">
+                <div className="flex items-center gap-2 text-sm">
+                  <span className="font-medium">
+                    {new Date(j.date).toLocaleDateString("fr-FR")}
+                  </span>
+                  {j.tags.map((tag) => (
+                    <Badge key={tag} variant="outline" className="text-xs">
+                      {tag}
+                    </Badge>
+                  ))}
+                </div>
+                <p className="mt-1 text-sm text-foreground">{j.text}</p>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Footer */}
+      <p className="text-xs text-muted-foreground print:mt-8">
+        Rapport généré le{" "}
+        {new Date(report.generatedAt).toLocaleDateString("fr-FR")} à{" "}
+        {new Date(report.generatedAt).toLocaleTimeString("fr-FR")} — Tokō 登光
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Résumé technique

### Contexte
Dernier gap MVP : l'export rapport pour les consultations médicales. Le backend JSON API (`/api/report/:childId`) existe déjà — il manquait la page frontend pour visualiser et imprimer le rapport.

### Approche retenue
**Print-to-PDF natif** plutôt que Puppeteer ou @react-pdf — zéro dépendance ajoutée, le navigateur génère le PDF via `window.print()`. CSS `print:` classes de Tailwind masquent les contrôles et suppriment les bordures/ombres pour un rendu propre.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/web/src/routes/_authenticated/report/index.tsx` | Page rapport complète | Date picker, symptom averages, medication table + adherence rate, symptom detail table, journal entries |
| `apps/web/src/hooks/use-report.ts` | Hook TanStack Query + types Report | Interface typée complète pour le JSON API |
| `apps/web/src/routes/_authenticated.tsx` | Ajout lien "Rapport" dans la sidebar | Icône FileText |
| `apps/web/src/routeTree.gen.ts` | Route tree régénéré | Inclut `/report` |

### Points d'attention pour la revue
- Le print CSS utilise `print:hidden` et `print:border-none` — vérifier le rendu dans Chrome Print Preview
- Le date range par défaut est les 30 derniers jours
- L'adherence rate badge est rouge en dessous de 80%

### Tests
- 16 exécutés, 16 passés, 0 échoués

---
_Implémentation générée automatiquement par IA_