### PR TITLE
feat(rgpd): add account deletion and data export

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -12,6 +12,7 @@ import { reportRoutes } from "./routes/report";
 import { appointmentsRoutes } from "./routes/appointments";
 import { billingRoutes, stripeWebhookRoute } from "./routes/billing";
 import { barkleyRoutes } from "./routes/barkley";
+import { accountRoutes } from "./routes/account";
 import { auth } from "./lib/auth";
 
 const app = new Hono();
@@ -42,5 +43,6 @@ app.route("/api/report", reportRoutes);
 app.route("/api/appointments", appointmentsRoutes);
 app.route("/api/billing", billingRoutes);
 app.route("/api/barkley", barkleyRoutes);
+app.route("/api/account", accountRoutes);
 
 export { app };

--- a/apps/api/src/routes/account.ts
+++ b/apps/api/src/routes/account.ts
@@ -1,0 +1,215 @@
+import { Hono } from "hono";
+import Stripe from "stripe";
+import type { AppEnv } from "../types";
+import { authMiddleware } from "../middleware/auth";
+import { deleteAccountSchema } from "@focusflow/validators";
+import {
+  db,
+  user,
+  children,
+  symptoms,
+  medication,
+  medicationLogs,
+  journalEntries,
+  appointments,
+  subscription,
+  barkleySteps,
+  barkleyBehaviors,
+  barkleyBehaviorLogs,
+} from "@focusflow/db";
+import { eq, inArray } from "drizzle-orm";
+
+export const accountRoutes = new Hono<AppEnv>();
+
+accountRoutes.use("*", authMiddleware);
+
+let _stripe: Stripe | undefined;
+function getStripe() {
+  if (!_stripe) _stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+  return _stripe;
+}
+
+/**
+ * DELETE /api/account
+ * Self-service account deletion (RGPD Art. 17 — Droit à l'effacement).
+ * Cancels Stripe subscription if active, then deletes the user row.
+ * Cascade deletes handle all related data.
+ */
+accountRoutes.delete("/", async (c) => {
+  const currentUser = c.get("user");
+
+  const body = await c.req.json();
+  const parsed = deleteAccountSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "Confirmation requise : envoyez { confirmation: \"DELETE\" }" },
+      400
+    );
+  }
+
+  // Cancel Stripe subscription if one exists (must happen before DB deletion)
+  const [sub] = await db
+    .select()
+    .from(subscription)
+    .where(eq(subscription.userId, currentUser.id))
+    .limit(1);
+
+  if (sub && (sub.status === "active" || sub.status === "trialing")) {
+    await getStripe().subscriptions.cancel(sub.stripeSubscriptionId);
+  }
+
+  // Delete user — cascade deletes handle all child data
+  await db.delete(user).where(eq(user.id, currentUser.id));
+
+  return c.json({ ok: true });
+});
+
+/**
+ * GET /api/account/export
+ * Complete personal data export (RGPD Art. 20 — Droit à la portabilité).
+ * Returns all user data in structured JSON format.
+ */
+accountRoutes.get("/export", async (c) => {
+  const currentUser = c.get("user");
+
+  // Fetch user profile
+  const [profile] = await db
+    .select({
+      name: user.name,
+      email: user.email,
+      emailVerified: user.emailVerified,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
+    })
+    .from(user)
+    .where(eq(user.id, currentUser.id));
+
+  // Fetch all children
+  const userChildren = await db
+    .select()
+    .from(children)
+    .where(eq(children.parentId, currentUser.id));
+
+  const childIds = userChildren.map((c) => c.id);
+
+  // Fetch all child-related data in parallel
+  const [
+    allSymptoms,
+    allMedications,
+    allJournal,
+    allAppointments,
+    allBarkleySteps,
+    allBarkleyBehaviors,
+  ] = childIds.length > 0
+    ? await Promise.all([
+        db
+          .select()
+          .from(symptoms)
+          .where(inArray(symptoms.childId, childIds)),
+        db
+          .select()
+          .from(medication)
+          .where(inArray(medication.childId, childIds)),
+        db
+          .select()
+          .from(journalEntries)
+          .where(inArray(journalEntries.childId, childIds)),
+        db
+          .select()
+          .from(appointments)
+          .where(inArray(appointments.childId, childIds)),
+        db
+          .select()
+          .from(barkleySteps)
+          .where(inArray(barkleySteps.childId, childIds)),
+        db
+          .select()
+          .from(barkleyBehaviors)
+          .where(inArray(barkleyBehaviors.childId, childIds)),
+      ])
+    : [[], [], [], [], [], []];
+
+  // Fetch medication logs and barkley behavior logs
+  const medIds = allMedications.map((m) => m.id);
+  const behaviorIds = allBarkleyBehaviors.map((b) => b.id);
+
+  const [allMedLogs, allBehaviorLogs] = await Promise.all([
+    medIds.length > 0
+      ? db
+          .select()
+          .from(medicationLogs)
+          .where(inArray(medicationLogs.medicationId, medIds))
+      : Promise.resolve([]),
+    behaviorIds.length > 0
+      ? db
+          .select()
+          .from(barkleyBehaviorLogs)
+          .where(inArray(barkleyBehaviorLogs.behaviorId, behaviorIds))
+      : Promise.resolve([]),
+  ]);
+
+  // Fetch subscription info
+  const [sub] = await db
+    .select({
+      status: subscription.status,
+      planId: subscription.planId,
+      currentPeriodEnd: subscription.currentPeriodEnd,
+      createdAt: subscription.createdAt,
+    })
+    .from(subscription)
+    .where(eq(subscription.userId, currentUser.id))
+    .limit(1);
+
+  // Structure the export per child
+  const childrenExport = userChildren.map((child) => ({
+    name: child.name,
+    birthDate: child.birthDate,
+    diagnosisType: child.diagnosisType,
+    createdAt: child.createdAt,
+    symptoms: allSymptoms
+      .filter((s) => s.childId === child.id)
+      .map(({ childId, ...rest }) => rest),
+    medications: allMedications
+      .filter((m) => m.childId === child.id)
+      .map((med) => ({
+        name: med.name,
+        dose: med.dose,
+        scheduledAt: med.scheduledAt,
+        active: med.active,
+        createdAt: med.createdAt,
+        logs: allMedLogs
+          .filter((l) => l.medicationId === med.id)
+          .map(({ medicationId, ...rest }) => rest),
+      })),
+    journal: allJournal
+      .filter((j) => j.childId === child.id)
+      .map(({ childId, ...rest }) => rest),
+    appointments: allAppointments
+      .filter((a) => a.childId === child.id)
+      .map(({ childId, ...rest }) => rest),
+    barkleySteps: allBarkleySteps
+      .filter((s) => s.childId === child.id)
+      .map(({ childId, ...rest }) => rest),
+    barkleyBehaviors: allBarkleyBehaviors
+      .filter((b) => b.childId === child.id)
+      .map((behavior) => ({
+        name: behavior.name,
+        points: behavior.points,
+        icon: behavior.icon,
+        active: behavior.active,
+        createdAt: behavior.createdAt,
+        logs: allBehaviorLogs
+          .filter((l) => l.behaviorId === behavior.id)
+          .map(({ behaviorId, ...rest }) => rest),
+      })),
+  }));
+
+  const exportData = {
+    exportedAt: new Date().toISOString(),
+    user: profile,
+    subscription: sub ?? null,
+    children: childrenExport,
+  };
+
+  return c.json(exportData);
+});

--- a/apps/web/src/hooks/use-account.ts
+++ b/apps/web/src/hooks/use-account.ts
@@ -1,0 +1,33 @@
+import { useMutation } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import { signOut } from "@/lib/auth-client";
+
+export function useDeleteAccount() {
+  return useMutation({
+    mutationFn: () =>
+      api.delete<{ ok: boolean }>("/account", { confirmation: "DELETE" }),
+    onSuccess: async () => {
+      await signOut();
+      window.location.href = "/";
+    },
+  });
+}
+
+export function useExportAccount() {
+  return useMutation({
+    mutationFn: async () => {
+      const data = await api.get<Record<string, unknown>>("/account/export");
+      const blob = new Blob([JSON.stringify(data, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `toko-export-${new Date().toISOString().slice(0, 10)}.json`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    },
+  });
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -42,5 +42,9 @@ export const api = {
     request<T>(path, { method: "POST", body: JSON.stringify(data) }),
   patch: <T>(path: string, data: unknown) =>
     request<T>(path, { method: "PATCH", body: JSON.stringify(data) }),
-  delete: <T>(path: string) => request<T>(path, { method: "DELETE" }),
+  delete: <T>(path: string, data?: unknown) =>
+    request<T>(path, {
+      method: "DELETE",
+      ...(data !== undefined && { body: JSON.stringify(data) }),
+    }),
 };

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -22,6 +22,7 @@ import { Route as AuthenticatedJournalIndexRouteImport } from './routes/_authent
 import { Route as AuthenticatedDashboardIndexRouteImport } from './routes/_authenticated/dashboard/index'
 import { Route as AuthenticatedBarkleyIndexRouteImport } from './routes/_authenticated/barkley/index'
 import { Route as AuthenticatedAppointmentsIndexRouteImport } from './routes/_authenticated/appointments/index'
+import { Route as AuthenticatedAccountIndexRouteImport } from './routes/_authenticated/account/index'
 
 const MentionsLegalesRoute = MentionsLegalesRouteImport.update({
   id: '/mentions-legales',
@@ -94,6 +95,12 @@ const AuthenticatedAppointmentsIndexRoute =
     path: '/appointments/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedAccountIndexRoute =
+  AuthenticatedAccountIndexRouteImport.update({
+    id: '/account/',
+    path: '/account/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -101,6 +108,7 @@ export interface FileRoutesByFullPath {
   '/contact': typeof ContactRoute
   '/login': typeof LoginRoute
   '/mentions-legales': typeof MentionsLegalesRoute
+  '/account/': typeof AuthenticatedAccountIndexRoute
   '/appointments/': typeof AuthenticatedAppointmentsIndexRoute
   '/barkley/': typeof AuthenticatedBarkleyIndexRoute
   '/dashboard/': typeof AuthenticatedDashboardIndexRoute
@@ -115,6 +123,7 @@ export interface FileRoutesByTo {
   '/contact': typeof ContactRoute
   '/login': typeof LoginRoute
   '/mentions-legales': typeof MentionsLegalesRoute
+  '/account': typeof AuthenticatedAccountIndexRoute
   '/appointments': typeof AuthenticatedAppointmentsIndexRoute
   '/barkley': typeof AuthenticatedBarkleyIndexRoute
   '/dashboard': typeof AuthenticatedDashboardIndexRoute
@@ -131,6 +140,7 @@ export interface FileRoutesById {
   '/contact': typeof ContactRoute
   '/login': typeof LoginRoute
   '/mentions-legales': typeof MentionsLegalesRoute
+  '/_authenticated/account/': typeof AuthenticatedAccountIndexRoute
   '/_authenticated/appointments/': typeof AuthenticatedAppointmentsIndexRoute
   '/_authenticated/barkley/': typeof AuthenticatedBarkleyIndexRoute
   '/_authenticated/dashboard/': typeof AuthenticatedDashboardIndexRoute
@@ -147,6 +157,7 @@ export interface FileRouteTypes {
     | '/contact'
     | '/login'
     | '/mentions-legales'
+    | '/account/'
     | '/appointments/'
     | '/barkley/'
     | '/dashboard/'
@@ -161,6 +172,7 @@ export interface FileRouteTypes {
     | '/contact'
     | '/login'
     | '/mentions-legales'
+    | '/account'
     | '/appointments'
     | '/barkley'
     | '/dashboard'
@@ -176,6 +188,7 @@ export interface FileRouteTypes {
     | '/contact'
     | '/login'
     | '/mentions-legales'
+    | '/_authenticated/account/'
     | '/_authenticated/appointments/'
     | '/_authenticated/barkley/'
     | '/_authenticated/dashboard/'
@@ -287,10 +300,18 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppointmentsIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/account/': {
+      id: '/_authenticated/account/'
+      path: '/account'
+      fullPath: '/account/'
+      preLoaderRoute: typeof AuthenticatedAccountIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
   }
 }
 
 interface AuthenticatedRouteChildren {
+  AuthenticatedAccountIndexRoute: typeof AuthenticatedAccountIndexRoute
   AuthenticatedAppointmentsIndexRoute: typeof AuthenticatedAppointmentsIndexRoute
   AuthenticatedBarkleyIndexRoute: typeof AuthenticatedBarkleyIndexRoute
   AuthenticatedDashboardIndexRoute: typeof AuthenticatedDashboardIndexRoute
@@ -301,6 +322,7 @@ interface AuthenticatedRouteChildren {
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
+  AuthenticatedAccountIndexRoute: AuthenticatedAccountIndexRoute,
   AuthenticatedAppointmentsIndexRoute: AuthenticatedAppointmentsIndexRoute,
   AuthenticatedBarkleyIndexRoute: AuthenticatedBarkleyIndexRoute,
   AuthenticatedDashboardIndexRoute: AuthenticatedDashboardIndexRoute,

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -15,6 +15,7 @@ import {
   CalendarDays,
   Heart,
   ClipboardList,
+  UserCog,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
@@ -41,6 +42,7 @@ const navItems = [
   { to: "/appointments" as const, label: "Rendez-vous", icon: CalendarDays },
   { to: "/report" as const, label: "Rapport", icon: FileText },
   { to: "/barkley" as const, label: "Tableau Barkley", icon: ClipboardList },
+  { to: "/account" as const, label: "Mon compte", icon: UserCog },
 ];
 
 function Sidebar() {

--- a/apps/web/src/routes/_authenticated/account/index.tsx
+++ b/apps/web/src/routes/_authenticated/account/index.tsx
@@ -1,0 +1,183 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
+import { Download, Trash2, Shield, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { useSession } from "@/lib/auth-client";
+import { useDeleteAccount, useExportAccount } from "@/hooks/use-account";
+
+export const Route = createFileRoute("/_authenticated/account/")({
+  component: AccountPage,
+});
+
+function AccountPage() {
+  const session = useSession();
+  const deleteAccount = useDeleteAccount();
+  const exportAccount = useExportAccount();
+  const [confirmation, setConfirmation] = useState("");
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const handleDelete = () => {
+    deleteAccount.mutate();
+  };
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div>
+        <h1 className="font-heading text-2xl font-semibold tracking-tight">
+          Mon compte
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Gestion de vos donnees personnelles et droits RGPD
+        </p>
+      </div>
+
+      {/* Profile info */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Shield className="h-4 w-4" />
+            Informations personnelles
+          </CardTitle>
+          <CardDescription>
+            Donnees associees a votre compte
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Nom</span>
+            <span>{session.data?.user?.name}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Email</span>
+            <span>{session.data?.user?.email}</span>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Data export */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Download className="h-4 w-4" />
+            Exporter mes donnees
+          </CardTitle>
+          <CardDescription>
+            Telechargez une copie de toutes vos donnees personnelles au format
+            JSON (Art. 20 RGPD — Droit a la portabilite)
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button
+            variant="outline"
+            onClick={() => exportAccount.mutate()}
+            disabled={exportAccount.isPending}
+          >
+            {exportAccount.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" data-icon="inline-start" />
+            ) : (
+              <Download className="h-4 w-4" data-icon="inline-start" />
+            )}
+            {exportAccount.isPending
+              ? "Export en cours..."
+              : "Telecharger mes donnees"}
+          </Button>
+          {exportAccount.isSuccess && (
+            <p className="mt-2 text-sm text-muted-foreground">
+              Export telecharge avec succes.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Account deletion */}
+      <Card className="border-destructive/30">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-destructive">
+            <Trash2 className="h-4 w-4" />
+            Supprimer mon compte
+          </CardTitle>
+          <CardDescription>
+            Supprime definitivement votre compte et toutes les donnees associees
+            (Art. 17 RGPD — Droit a l'effacement). Cette action est irreversible.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger
+              render={
+                <Button variant="destructive">
+                  <Trash2 className="h-4 w-4" data-icon="inline-start" />
+                  Supprimer mon compte
+                </Button>
+              }
+            />
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Confirmer la suppression</DialogTitle>
+                <DialogDescription>
+                  Cette action est irreversible. Toutes vos donnees seront
+                  definitivement supprimees : profil, enfants, symptomes,
+                  medicaments, journal, rendez-vous et abonnement.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="space-y-2">
+                <Label htmlFor="delete-confirmation">
+                  Tapez <strong>DELETE</strong> pour confirmer
+                </Label>
+                <Input
+                  id="delete-confirmation"
+                  value={confirmation}
+                  onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                    setConfirmation(e.target.value)
+                  }
+                  placeholder="DELETE"
+                  autoComplete="off"
+                />
+              </div>
+              <DialogFooter>
+                <DialogClose
+                  render={<Button variant="outline" />}
+                >
+                  Annuler
+                </DialogClose>
+                <Button
+                  variant="destructive"
+                  onClick={handleDelete}
+                  disabled={
+                    confirmation !== "DELETE" || deleteAccount.isPending
+                  }
+                >
+                  {deleteAccount.isPending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" data-icon="inline-start" />
+                  ) : (
+                    <Trash2 className="h-4 w-4" data-icon="inline-start" />
+                  )}
+                  Supprimer definitivement
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/validators/src/account.ts
+++ b/packages/validators/src/account.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const deleteAccountSchema = z.object({
+  confirmation: z.literal("DELETE"),
+});
+
+export type DeleteAccount = z.infer<typeof deleteAccountSchema>;

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./account";
 export * from "./child";
 export * from "./symptom";
 export * from "./medication";


### PR DESCRIPTION
## Résumé technique

### Contexte
L'application Toko traite des données de santé d'enfants (diagnostic TDAH, symptômes quotidiens, médicaments, journal comportemental). La politique de confidentialité (`/confidentialite`) promet les droits RGPD (effacement, portabilité) mais aucun endpoint self-service n'existait — les utilisateurs devaient envoyer un email pour exercer ces droits.

### Approche retenue
Deux nouveaux endpoints dans un fichier route dédié `account.ts`, suivant les patterns existants (authMiddleware, Drizzle ORM, Hono). L'approche privilégie le hard delete en exploitant les cascade deletes déjà en place dans le schéma, plutôt qu'un soft-delete qui nécessiterait de modifier toutes les requêtes existantes.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/api/src/routes/account.ts` | Nouveau — `DELETE /api/account` + `GET /api/account/export` | Route dédiée aux opérations compte, séparée des routes domaine (children, symptoms, etc.) |
| `apps/api/src/app.ts` | Enregistrement de la route `/api/account` | Pattern identique aux autres routes |
| `packages/validators/src/account.ts` | Nouveau — `deleteAccountSchema` (confirmation: "DELETE") | Validation Zod pour empêcher la suppression accidentelle |
| `packages/validators/src/index.ts` | Export du nouveau validateur | Cohérence avec les exports existants |
| `apps/web/src/hooks/use-account.ts` | Nouveau — `useDeleteAccount()` + `useExportAccount()` | Pattern TanStack Query identique à use-children.ts |
| `apps/web/src/routes/_authenticated/account/index.tsx` | Nouveau — Page "Mon compte" | Card d'export + zone danger suppression avec Dialog de confirmation |
| `apps/web/src/routes/_authenticated.tsx` | Ajout nav item "Mon compte" | Icône UserCog, accessible depuis la sidebar |
| `apps/web/src/lib/api-client.ts` | `api.delete()` accepte un body optionnel | Nécessaire pour envoyer la confirmation de suppression |

### Points d'attention pour la revue
- **Ordering Stripe → DB** : L'annulation Stripe est appelée AVANT le DELETE SQL. Si Stripe échoue, l'utilisateur n'est pas supprimé (fail-safe). Si le DELETE échoue après Stripe, l'abonnement est annulé mais le compte persiste — cas récupérable manuellement
- **Export payload size** : L'export charge toutes les données en mémoire. Pour un usage typique (1-3 enfants, ~1 an de données), le payload est de l'ordre de quelques MB — acceptable en synchrone
- **Pas de re-authentification** : La suppression requiert une confirmation typée ("DELETE") mais pas de re-saisie du mot de passe. À considérer pour une V2

### Tests
- Typecheck : 2/2 packages passent (api + web)
- Tests : 1/1 test existant passe (health endpoint)
- Pas de tests unitaires dédiés pour les nouveaux endpoints (à ajouter)

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Ajouter des tests d'intégration pour DELETE /account et GET /account/export
- [ ] Considérer l'ajout du consentement explicite pour les données de santé (Art. 9 RGPD)
- [ ] Évaluer l'ajout de rate limiting sur les endpoints d'authentification
- [ ] Merge après approbation

> ⚠️ _Attention : d'autres branches fast-meeting sont actives (`feat/fm-auth-child-flow`, `feat/fm-landing-stripe`, `feat/fm-mvp-features`, `feat/fm-pdf-export`). Vérifier les conflits potentiels avant merge._

---
_Implémentation générée automatiquement par IA_