### PR TITLE
feat(ui): add Slider and Skeleton shadcn components

### DIFF
--- a/apps/web/src/components/symptoms/symptom-form.tsx
+++ b/apps/web/src/components/symptoms/symptom-form.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Slider } from "@/components/ui/slider";
 import { Textarea } from "@/components/ui/textarea";
 import { useCreateSymptom } from "@/hooks/use-symptoms";
 import { useUiStore } from "@/stores/ui-store";
@@ -54,16 +55,16 @@ export function SymptomForm({ onSuccess }: { onSuccess: () => void }) {
               {values[key]}/10
             </span>
           </div>
-          <input
+          <Slider
             id={key}
-            type="range"
             min={0}
             max={10}
-            value={values[key]}
-            onChange={(e) =>
-              setValues((v) => ({ ...v, [key]: Number(e.target.value) }))
-            }
-            className="w-full accent-primary"
+            step={1}
+            value={[values[key]]}
+            onValueChange={(val) => {
+              const v = Array.isArray(val) ? val[0] : val;
+              setValues((prev) => ({ ...prev, [key]: v }));
+            }}
           />
         </div>
       ))}

--- a/apps/web/src/components/ui/page-loader.tsx
+++ b/apps/web/src/components/ui/page-loader.tsx
@@ -1,0 +1,14 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function PageLoader() {
+  return (
+    <div className="space-y-4 py-6" role="status" aria-label="Chargement en cours">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <Skeleton className="h-28 rounded-xl" />
+        <Skeleton className="h-28 rounded-xl" />
+        <Skeleton className="h-28 rounded-xl" />
+      </div>
+      <Skeleton className="h-48 rounded-xl" />
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/skeleton.tsx
+++ b/apps/web/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/apps/web/src/components/ui/slider.tsx
+++ b/apps/web/src/components/ui/slider.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+import { Slider as SliderPrimitive } from "@base-ui/react/slider"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}: SliderPrimitive.Root.Props) {
+  const _values = React.useMemo(
+    () =>
+      Array.isArray(value)
+        ? value
+        : Array.isArray(defaultValue)
+          ? defaultValue
+          : [min, max],
+    [value, defaultValue, min, max]
+  )
+
+  return (
+    <SliderPrimitive.Root
+      className={cn("data-horizontal:w-full data-vertical:h-full", className)}
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      thumbAlignment="edge"
+      {...props}
+    >
+      <SliderPrimitive.Control className="relative flex w-full touch-none items-center select-none data-disabled:opacity-50 data-vertical:h-full data-vertical:min-h-40 data-vertical:w-auto data-vertical:flex-col">
+        <SliderPrimitive.Track
+          data-slot="slider-track"
+          className="relative grow overflow-hidden rounded-full bg-muted select-none data-horizontal:h-1 data-horizontal:w-full data-vertical:h-full data-vertical:w-1"
+        >
+          <SliderPrimitive.Indicator
+            data-slot="slider-range"
+            className="bg-primary select-none data-horizontal:h-full data-vertical:w-full"
+          />
+        </SliderPrimitive.Track>
+        {Array.from({ length: _values.length }, (_, index) => (
+          <SliderPrimitive.Thumb
+            data-slot="slider-thumb"
+            key={index}
+            className="relative block size-3 shrink-0 rounded-full border border-ring bg-white ring-ring/50 transition-[color,box-shadow] select-none after:absolute after:-inset-2 hover:ring-3 focus-visible:ring-3 focus-visible:outline-hidden active:ring-3 disabled:pointer-events-none disabled:opacity-50"
+          />
+        ))}
+      </SliderPrimitive.Control>
+    </SliderPrimitive.Root>
+  )
+}
+
+export { Slider }

--- a/apps/web/src/routes/_authenticated/appointments/index.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/index.tsx
@@ -14,6 +14,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
+import { PageLoader } from "@/components/ui/page-loader";
 import {
   Dialog,
   DialogContent,
@@ -95,9 +96,7 @@ function AppointmentsPage() {
           </CardContent>
         </Card>
       ) : isLoading ? (
-        <div className="flex justify-center py-12">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-        </div>
+        <PageLoader />
       ) : !appointments?.length ? (
         <Card>
           <CardContent className="flex flex-col items-center gap-3 py-12 text-center">

--- a/apps/web/src/routes/_authenticated/barkley/index.tsx
+++ b/apps/web/src/routes/_authenticated/barkley/index.tsx
@@ -8,6 +8,7 @@ import {
   Plus,
   Trash2,
 } from "lucide-react";
+import { PageLoader } from "@/components/ui/page-loader";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -166,9 +167,7 @@ function ProgrammeTab({ childId }: { childId: string }) {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center py-12">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-      </div>
+      <PageLoader />
     );
   }
 
@@ -315,9 +314,7 @@ function TokenBoardTab({ childId }: { childId: string }) {
 
   if (isLoading) {
     return (
-      <div className="flex justify-center py-12">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-      </div>
+      <PageLoader />
     );
   }
 

--- a/apps/web/src/routes/_authenticated/dashboard/index.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard/index.tsx
@@ -24,6 +24,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { PageLoader } from "@/components/ui/page-loader";
 import { MoodLogger } from "@/components/dashboard/mood-logger";
 import { WeeklyChart } from "@/components/dashboard/weekly-chart";
 import { useChildren, useCreateChild } from "@/hooks/use-children";
@@ -44,9 +45,7 @@ function DashboardPage() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-      </div>
+      <PageLoader />
     );
   }
 

--- a/apps/web/src/routes/_authenticated/journal/index.tsx
+++ b/apps/web/src/routes/_authenticated/journal/index.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { PageLoader } from "@/components/ui/page-loader";
 import { useJournal, useCreateJournalEntry } from "@/hooks/use-journal";
 import { useUiStore } from "@/stores/ui-store";
 import type { JournalTag, JournalEntry } from "@focusflow/validators";
@@ -75,9 +76,7 @@ function JournalPage() {
           </CardContent>
         </Card>
       ) : isLoading ? (
-        <div className="flex justify-center py-12">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-        </div>
+        <PageLoader />
       ) : !entries?.length ? (
         <Card>
           <CardContent className="flex flex-col items-center gap-3 py-12 text-center">

--- a/apps/web/src/routes/_authenticated/medications/index.tsx
+++ b/apps/web/src/routes/_authenticated/medications/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { PageLoader } from "@/components/ui/page-loader";
 import { useMedications, useCreateMedication } from "@/hooks/use-medications";
 import { useUiStore } from "@/stores/ui-store";
 import type { Medication } from "@focusflow/validators";
@@ -60,9 +61,7 @@ function MedicationsPage() {
           </CardContent>
         </Card>
       ) : isLoading ? (
-        <div className="flex justify-center py-12">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-        </div>
+        <PageLoader />
       ) : !medications?.length ? (
         <Card>
           <CardContent className="py-8 text-center text-muted-foreground">

--- a/apps/web/src/routes/_authenticated/report/index.tsx
+++ b/apps/web/src/routes/_authenticated/report/index.tsx
@@ -15,6 +15,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { PageLoader } from "@/components/ui/page-loader";
 import { useReport, type Report } from "@/hooks/use-report";
 import { useUiStore } from "@/stores/ui-store";
 import { useChild } from "@/hooks/use-children";
@@ -93,9 +94,7 @@ function ReportPage() {
       </div>
 
       {isLoading ? (
-        <div className="flex justify-center py-12">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-        </div>
+        <PageLoader />
       ) : isError ? (
         <Card>
           <CardContent className="py-8 text-center text-destructive">

--- a/apps/web/src/routes/_authenticated/symptoms/index.tsx
+++ b/apps/web/src/routes/_authenticated/symptoms/index.tsx
@@ -12,6 +12,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import { PageLoader } from "@/components/ui/page-loader";
 import { SymptomForm } from "@/components/symptoms/symptom-form";
 import { useSymptoms } from "@/hooks/use-symptoms";
 import { useUiStore } from "@/stores/ui-store";
@@ -60,9 +61,7 @@ function SymptomsPage() {
           </CardContent>
         </Card>
       ) : isLoading ? (
-        <div className="flex justify-center py-12">
-          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-        </div>
+        <PageLoader />
       ) : !symptoms?.length ? (
         <Card>
           <CardContent className="py-8 text-center text-muted-foreground">


### PR DESCRIPTION
## Résumé technique

### Contexte
Le projet utilise shadcn/ui v4 avec Base UI, mais le formulaire de symptômes (`SymptomForm`) utilisait un `<input type="range">` brut non stylé et inaccessible, et les 8 états de chargement à travers toutes les routes étaient des spinners copy-collés sans sémantique d'accessibilité.

### Approche retenue
Suite à une réunion rapide (4 personas : Frontend, Architecte, PO, QA), le consensus est d'ajouter uniquement les composants répondant à des problèmes existants dans le code — pas d'installation spéculative. Deux composants ajoutés :
- **Slider** (Base UI) — remplace le `<input type="range">` dans SymptomForm
- **Skeleton** — sert de base au `PageLoader` qui remplace les 8 spinners identiques

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `components/ui/slider.tsx` | Nouveau composant shadcn Slider | Primitive Base UI avec a11y, thème OKLch, keyboard nav |
| `components/ui/skeleton.tsx` | Nouveau composant shadcn Skeleton | Primitive `animate-pulse` pour loading states |
| `components/ui/page-loader.tsx` | Nouveau composant PageLoader | Centralise le pattern loading avec `role="status"` et `aria-label` |
| `components/symptoms/symptom-form.tsx` | Slider remplace `<input type="range">` | 5 sliders thémés, accessibles, cohérents cross-browser |
| `routes/_authenticated/dashboard/index.tsx` | PageLoader remplace spinner | DRY + accessibilité |
| `routes/_authenticated/symptoms/index.tsx` | PageLoader remplace spinner | DRY + accessibilité |
| `routes/_authenticated/medications/index.tsx` | PageLoader remplace spinner | DRY + accessibilité |
| `routes/_authenticated/appointments/index.tsx` | PageLoader remplace spinner | DRY + accessibilité |
| `routes/_authenticated/journal/index.tsx` | PageLoader remplace spinner | DRY + accessibilité |
| `routes/_authenticated/barkley/index.tsx` | PageLoader remplace 2 spinners | DRY + accessibilité |
| `routes/_authenticated/report/index.tsx` | PageLoader remplace spinner | DRY + accessibilité |

### Points d'attention pour la revue
- Le Slider Base UI utilise `onValueChange` avec un type `number | readonly number[]` — le handler gère les deux cas
- Le `PageLoader` utilise `role="status"` et `aria-label="Chargement en cours"` pour l'accessibilité
- Les 3 composants installés mais inutilisés (Calendar, Popover, Avatar) n'ont pas été supprimés dans cette PR — à traiter séparément

### Tests
- Build web : ✅ succès (tsc + vite build)
- Build API : ❌ échec (erreur connexion DB — non lié à cette PR)
- Tests unitaires : non exécutés (pas de suite de tests frontend configurée)

### Étapes restantes
- [ ] Ajouter Checkbox pour les toggles Barkley (débattu — le grid custom est peut-être préférable)
- [ ] Supprimer Calendar, Popover, Avatar si aucune feature planifiée
- [ ] Ajouter d'autres composants shadcn au fur et à mesure des besoins réels

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation visuelle sur mobile (les Sliders sont touch-friendly)
- [ ] Merge après approbation

> ⚠️ _Attention : d'autres branches fast-meeting sont actives (`feat/fm-auth-child-flow`, `feat/fm-landing-stripe`, etc.). Vérifier les conflits potentiels avant merge._

---
_Implémentation générée automatiquement par IA_