### PR TITLE
feat(ui): add AlertDialog for destructive action confirmation

### DIFF
--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "@base-ui/react/dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return (
+    <DialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  children,
+  ...props
+}: DialogPrimitive.Popup.Props) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Popup>
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "font-heading text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <DialogPrimitive.Close
+      render={
+        <Button
+          variant="destructive"
+          data-slot="alert-dialog-action"
+          className={className}
+          {...props}
+        />
+      }
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <DialogPrimitive.Close
+      render={
+        <Button
+          variant="outline"
+          data-slot="alert-dialog-cancel"
+          className={className}
+          {...props}
+        />
+      }
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/apps/web/src/routes/_authenticated/barkley/index.tsx
+++ b/apps/web/src/routes/_authenticated/barkley/index.tsx
@@ -25,6 +25,17 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import {
   Table,
   TableBody,
   TableCell,
@@ -447,18 +458,45 @@ function TokenBoardTab({ childId }: { childId: string }) {
                         </span>
                       </TableCell>
                       <TableCell>
-                        <button
-                          onClick={() =>
-                            deleteBehavior.mutate({
-                              id: behavior.id,
-                              childId,
-                            })
-                          }
-                          className="text-muted-foreground hover:text-destructive transition-colors"
-                          disabled={deleteBehavior.isPending}
-                        >
-                          <Trash2 className="h-3.5 w-3.5" />
-                        </button>
+                        <AlertDialog>
+                          <AlertDialogTrigger
+                            render={
+                              <Button
+                                variant="ghost"
+                                size="icon-xs"
+                                className="text-muted-foreground hover:text-destructive"
+                                disabled={deleteBehavior.isPending}
+                              />
+                            }
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>
+                                Supprimer ce comportement ?
+                              </AlertDialogTitle>
+                              <AlertDialogDescription>
+                                Le comportement « {behavior.name} » et tous ses
+                                jetons associés seront supprimés. Cette action
+                                est irréversible.
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Annuler</AlertDialogCancel>
+                              <AlertDialogAction
+                                onClick={() =>
+                                  deleteBehavior.mutate({
+                                    id: behavior.id,
+                                    childId,
+                                  })
+                                }
+                              >
+                                Supprimer
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
                       </TableCell>
                     </TableRow>
                   );


### PR DESCRIPTION
## Résumé technique

### Contexte
Audit de conformité shadcn/ui déclenché par un fast meeting. L'analyse a révélé que le codebase est ~95% conforme aux conventions shadcn. Le seul problème critique identifié : le bouton de suppression de comportement dans le tableau Barkley exécute `deleteBehavior.mutate()` directement au clic, sans aucune confirmation — risque réel de perte de données pour les parents.

### Approche retenue
Créer un composant `AlertDialog` construit sur la même primitive `@base-ui/react/dialog` que le `Dialog` existant (pas de nouvelle dépendance Radix), puis encapsuler l'action de suppression dans un dialogue de confirmation. Le bouton de suppression brut (`<button>`) est remplacé par un `<Button variant="ghost" size="icon-xs">` shadcn.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/web/src/components/ui/alert-dialog.tsx` | Nouveau composant AlertDialog | Suit le même pattern Base UI que Dialog existant — pas de nouvelle dépendance |
| `apps/web/src/routes/_authenticated/barkley/index.tsx` | Wrapper la suppression de comportement avec AlertDialog + remplacement `<button>` → `<Button>` | Prévention de suppression accidentelle + conformité shadcn pour le trigger |

### Points d'attention pour la revue
- Le composant AlertDialog utilise `@base-ui/react/dialog` (pas Radix) — cohérent avec le reste du projet
- Le message de confirmation est en français et mentionne le nom du comportement pour le contexte
- Le bouton Annuler ferme le dialog, le bouton Supprimer exécute la mutation puis ferme
- Les boutons toggle (étapes programme, grille de jetons) ont été laissés intentionnellement comme `<button>` bruts — ce sont des choix UX spécifiques, pas des violations de conformité

### Tests
- TypeScript : compilation sans erreur (`tsc --noEmit` ✅)
- Pas de suite de tests détectée dans `apps/web`

### Analyse du fast meeting
**Participants :** Pixel-Perfect Hugo (Frontend) | Whiteboard Damien (Architecte) | Edge-Case Nico (QA) | Sprint Zero Sarah (PO)

**Consensus :** AlertDialog pour les actions destructives est la priorité n°1 unanime. Les boutons emoji/toggle sont des choix de design intentionnels, pas des non-conformités. L'installation de Form/react-hook-form est prématurée à ce stade (v0.6.1).

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation visuelle du dialogue de confirmation
- [ ] Merge après approbation
- [ ] (Futur) Évaluer ToggleGroup pour les boutons emoji de mood-logger
- [ ] (Futur) Ajouter ESLint avec règles interdisant `<button>` brut en TSX

> ⚠️ _Attention : d'autres branches fast-meeting sont actives (`feat/fm-auth-child-flow`, `feat/fm-shadcn-components`, etc.). Vérifier les conflits potentiels avant merge._

---
_Implémentation générée automatiquement par IA_