### PR TITLE
feat(ui): show child age and gender emoji in header selector

### DIFF
--- a/apps/web/src/components/shared/child-selector.tsx
+++ b/apps/web/src/components/shared/child-selector.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { Plus, Baby, Shuffle } from "lucide-react";
+import { Plus, Shuffle } from "lucide-react";
+import { getChildEmoji, formatChildAge } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -64,20 +65,35 @@ export function ChildSelector() {
 
   return (
     <div className="flex items-center gap-2">
-      <Baby className="h-4 w-4 text-muted-foreground" />
       <Select
         value={activeChildId ?? undefined}
         onValueChange={(v) => v && setActiveChild(v)}
       >
-        <SelectTrigger className="w-36">
+        <SelectTrigger className="w-auto min-w-36 max-w-52">
           <SelectValue placeholder="Enfant">
-            {selectedChild?.name}
+            <span className="flex items-center gap-1.5">
+              <span className="text-base leading-none">{getChildEmoji(selectedChild?.gender)}</span>
+              <span className="truncate">{selectedChild?.name}</span>
+              {selectedChild?.birthDate && (
+                <span className="text-xs text-muted-foreground whitespace-nowrap">
+                  {formatChildAge(selectedChild.birthDate)}
+                </span>
+              )}
+            </span>
           </SelectValue>
         </SelectTrigger>
         <SelectContent>
           {children.map((child) => (
             <SelectItem key={child.id} value={child.id} label={child.name}>
-              {child.name}
+              <span className="flex items-center gap-1.5">
+                <span className="text-base leading-none">{getChildEmoji(child.gender)}</span>
+                <span>{child.name}</span>
+                {child.birthDate && (
+                  <span className="text-xs text-muted-foreground">
+                    {formatChildAge(child.birthDate)}
+                  </span>
+                )}
+              </span>
             </SelectItem>
           ))}
         </SelectContent>

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -4,3 +4,29 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function getChildEmoji(gender?: "male" | "female" | "other" | null): string {
+  if (gender === "male") return "👦"
+  if (gender === "female") return "👧"
+  return "👶"
+}
+
+export function formatChildAge(birthDate: string): string {
+  const birth = new Date(birthDate)
+  if (isNaN(birth.getTime())) return ""
+
+  const now = new Date()
+  let years = now.getFullYear() - birth.getFullYear()
+  let months = now.getMonth() - birth.getMonth()
+
+  if (now.getDate() < birth.getDate()) months--
+  if (months < 0) {
+    years--
+    months += 12
+  }
+
+  if (years < 1) return months <= 1 ? "1 mois" : `${months} mois`
+  if (years === 1 && months === 0) return "1 an"
+  if (years < 2) return `${12 + months} mois`
+  return `${years} ans`
+}


### PR DESCRIPTION
## Résumé technique

### Contexte
Le sélecteur d'enfant dans le header affichait uniquement une icône `Baby` statique et le prénom. Les parents n'avaient aucune indication visuelle rapide de l'âge ni du genre de l'enfant sélectionné.

### Approche retenue
- **Emoji genré** : remplacement de l'icône lucide-react `Baby` par des emoji natifs mappés sur le genre (👦 garçon, 👧 fille, 👶 défaut/non renseigné). Les emoji natifs évitent d'ajouter une dépendance et sont naturellement lus par les lecteurs d'écran.
- **Affichage de l'âge** : calcul dynamique à partir de `birthDate` avec gestion des cas < 2 ans (en mois) et ≥ 2 ans (en années), en français.
- Décision issue d'un fast-meeting avec 3 personas (Frontend, UX/UI, PO).

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/web/src/lib/utils.ts` | Ajout de `getChildEmoji(gender)` et `formatChildAge(birthDate)` | Fonctions pures, testables, réutilisables — pas de dépendance React |
| `apps/web/src/components/shared/child-selector.tsx` | Remplacement `<Baby>` par emoji genré + affichage âge dans trigger et dropdown | Rendu cohérent entre l'enfant sélectionné et la liste déroulante |

### Points d'attention pour la revue
- L'import `Baby` de lucide-react a été retiré (plus utilisé dans ce fichier)
- La largeur du `SelectTrigger` passe de `w-36` fixe à `w-auto min-w-36 max-w-52` pour accommoder l'âge
- Le calcul d'âge est recalculé à chaque render (pas de cache) — correct car les queries refetch on window focus
- Le rendu des emoji peut varier légèrement entre OS (Android/iOS/Windows) — acceptable pour ce contexte

### Tests
- Vérification TypeScript : pas d'erreur liée aux changements (l'erreur `vite/client` est pré-existante)
- Pas de suite de tests unitaires configurée dans le projet

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation visuelle sur mobile (vérifier que `max-w-52` ne déborde pas)
- [ ] Merge après approbation

---
_Attention : d'autres branches fast-meeting sont actives (`feat/fm-auth-child-flow`, `feat/fm-landing-stripe`, etc.). Vérifier les conflits potentiels avant merge._

_Implémentation générée automatiquement par IA_