### PR TITLE
feat(ui): adopt mobile-first responsive design

### DIFF
--- a/apps/web/src/components/dashboard/mood-logger.tsx
+++ b/apps/web/src/components/dashboard/mood-logger.tsx
@@ -22,7 +22,7 @@ export function MoodLogger() {
             <button
               key={mood.value}
               onClick={() => setSelected(mood.value)}
-              className={`flex flex-col items-center gap-1 rounded-xl px-4 py-3 transition-all hover:bg-accent ${
+              className={`flex flex-col items-center gap-1 rounded-xl px-2 py-2 transition-all hover:bg-accent sm:px-4 sm:py-3 ${
                 selected === mood.value
                   ? "bg-primary/10 ring-2 ring-primary"
                   : "bg-muted/50"

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -134,7 +134,7 @@ function AuthenticatedLayout() {
         <aside className="hidden w-64 border-r border-border/60 bg-background lg:flex lg:flex-col">
           <Sidebar />
         </aside>
-        <main className="flex-1 p-6">
+        <main className="flex-1 p-4 sm:p-6">
           <Outlet />
         </main>
       </div>

--- a/apps/web/src/routes/_authenticated/account/index.tsx
+++ b/apps/web/src/routes/_authenticated/account/index.tsx
@@ -42,7 +42,7 @@ function AccountPage() {
   return (
     <div className="mx-auto max-w-2xl space-y-6">
       <div>
-        <h1 className="font-heading text-2xl font-semibold tracking-tight">
+        <h1 className="font-heading text-xl font-semibold tracking-tight sm:text-2xl">
           Mon compte
         </h1>
         <p className="text-sm text-muted-foreground">

--- a/apps/web/src/routes/_authenticated/appointments/index.tsx
+++ b/apps/web/src/routes/_authenticated/appointments/index.tsx
@@ -226,9 +226,9 @@ function AppointmentsPage() {
   return (
     <div className="space-y-8">
       {/* ── Header ── */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Rendez-vous</h1>
+          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">Rendez-vous</h1>
           <p className="text-muted-foreground">
             Calendrier des consultations médicales et scolaires
           </p>

--- a/apps/web/src/routes/_authenticated/barkley/index.tsx
+++ b/apps/web/src/routes/_authenticated/barkley/index.tsx
@@ -111,7 +111,7 @@ function BarkleyPage() {
     return (
       <div className="space-y-6">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">
+          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
             Tableau Barkley
           </h1>
           <p className="text-muted-foreground">
@@ -130,7 +130,7 @@ function BarkleyPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight">Tableau Barkley</h1>
+        <h1 className="text-xl font-bold tracking-tight sm:text-2xl">Tableau Barkley</h1>
         <p className="text-muted-foreground">
           Programme d'entraînement aux habiletés parentales (PEHP)
         </p>
@@ -330,9 +330,10 @@ function RewardBoard({ childId }: { childId: string }) {
               </CardContent>
             </Card>
           ) : (
-            <Card className="overflow-hidden">
+            <Card>
+              <div className="overflow-x-auto">
               {/* Day headers */}
-              <div className="grid grid-cols-[1fr_repeat(7,_minmax(36px,_1fr))_40px] border-b bg-muted/50 px-3 py-2">
+              <div className="grid min-w-[540px] grid-cols-[1fr_repeat(7,_minmax(36px,_1fr))_40px] border-b bg-muted/50 px-3 py-2">
                 <div className="text-xs font-medium text-muted-foreground" />
                 {DAY_LABELS.map((day, i) => (
                   <div
@@ -352,7 +353,7 @@ function RewardBoard({ childId }: { childId: string }) {
               {behaviors.map((behavior, idx) => (
                 <div
                   key={behavior.id}
-                  className={`grid grid-cols-[1fr_repeat(7,_minmax(36px,_1fr))_40px] items-center px-3 py-2.5 ${
+                  className={`grid min-w-[540px] grid-cols-[1fr_repeat(7,_minmax(36px,_1fr))_40px] items-center px-3 py-2.5 ${
                     idx < behaviors.length - 1 ? "border-b" : ""
                   } hover:bg-muted/30 transition-colors`}
                 >
@@ -408,6 +409,7 @@ function RewardBoard({ childId }: { childId: string }) {
                   </div>
                 </div>
               ))}
+              </div>
             </Card>
           )}
         </div>

--- a/apps/web/src/routes/_authenticated/dashboard/index.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard/index.tsx
@@ -52,7 +52,7 @@ function DashboardPage() {
   if (!children?.length) {
     return (
       <div className="mx-auto max-w-lg py-12 text-center">
-        <h1 className="text-2xl font-bold">Bienvenue sur Tokō</h1>
+        <h1 className="text-xl font-bold sm:text-2xl">Bienvenue sur Tokō</h1>
         <p className="mt-2 text-muted-foreground">
           Commencez par ajouter votre enfant pour démarrer le suivi.
         </p>
@@ -89,7 +89,7 @@ function DashboardPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight">Tableau de bord</h1>
+        <h1 className="text-xl font-bold tracking-tight sm:text-2xl">Tableau de bord</h1>
         <p className="text-muted-foreground">
           Vue d'ensemble du suivi quotidien
         </p>

--- a/apps/web/src/routes/_authenticated/journal/index.tsx
+++ b/apps/web/src/routes/_authenticated/journal/index.tsx
@@ -44,9 +44,9 @@ function JournalPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Journal</h1>
+          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">Journal</h1>
           <p className="text-muted-foreground">
             Notes et observations quotidiennes
           </p>

--- a/apps/web/src/routes/_authenticated/medications/index.tsx
+++ b/apps/web/src/routes/_authenticated/medications/index.tsx
@@ -29,9 +29,9 @@ function MedicationsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Médicaments</h1>
+          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">Médicaments</h1>
           <p className="text-muted-foreground">
             Gestion des traitements et rappels
           </p>

--- a/apps/web/src/routes/_authenticated/report/index.tsx
+++ b/apps/web/src/routes/_authenticated/report/index.tsx
@@ -57,9 +57,9 @@ function ReportPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between print:hidden">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between print:hidden">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">
+          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
             Rapport médical
           </h1>
           <p className="text-muted-foreground">
@@ -72,7 +72,7 @@ function ReportPage() {
         </Button>
       </div>
 
-      <div className="flex gap-4 print:hidden">
+      <div className="flex flex-col gap-2 sm:flex-row sm:gap-4 print:hidden">
         <div className="space-y-1">
           <Label htmlFor="from">Du</Label>
           <Input
@@ -152,10 +152,10 @@ function ReportView({ report }: { report: Report }) {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-4 gap-4 text-center sm:grid-cols-7">
+            <div className="grid grid-cols-2 gap-4 text-center sm:grid-cols-4 lg:grid-cols-7">
               {Object.entries(report.symptoms.averages).map(([key, value]) => (
                 <div key={key}>
-                  <div className="text-2xl font-bold">{value}</div>
+                  <div className="text-xl font-bold sm:text-2xl">{value}</div>
                   <div className="text-xs text-muted-foreground capitalize">
                     {{
                       agitation: "Agitation",

--- a/apps/web/src/routes/_authenticated/symptoms/index.tsx
+++ b/apps/web/src/routes/_authenticated/symptoms/index.tsx
@@ -29,9 +29,9 @@ function SymptomsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Symptômes</h1>
+          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">Symptômes</h1>
           <p className="text-muted-foreground">
             Suivi quotidien des symptômes TDAH
           </p>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,6 +24,14 @@ export default defineConfig({
       },
       dependencies: ["setup"],
     },
+    {
+      name: "mobile-chrome",
+      use: {
+        ...devices["Pixel 5"],
+        storageState: "e2e/.auth/user.json",
+      },
+      dependencies: ["setup"],
+    },
   ],
   webServer: [
     {


### PR DESCRIPTION
## Résumé technique

### Contexte
L'application Toko est actuellement desktop-first avec des ajustements responsive via `sm:` et `lg:`. Pour une app de suivi TDAH utilisée principalement par des parents sur mobile (à la sortie d'école, chez le médecin), l'expérience mobile est critique. Le padding global `p-6` (24px) mange 48px d'espace horizontal sur un écran 375px, les headers de page provoquent des collisions titre/bouton, et le tableau Barkley (grille 9 colonnes) est inutilisable sur mobile.

### Approche retenue
Migration chirurgicale mobile-first sans réécriture CSS systématique : corriger les vrais problèmes mobiles (padding, overflow, headings, layout) plutôt que d'inverser mécaniquement toutes les classes Tailwind. Ajout d'un viewport mobile aux tests E2E Playwright comme filet de sécurité.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/web/src/routes/_authenticated.tsx` | `p-6` → `p-4 sm:p-6` sur `<main>` | Récupère 16px d'espace horizontal sur mobile (affecte toutes les pages) |
| `playwright.config.ts` | Ajout projet `mobile-chrome` (Pixel 5) | Filet de sécurité E2E pour détecter les régressions mobiles |
| `*/symptoms/index.tsx` | Header flex-col mobile + heading responsive | Empêche collision titre/bouton "Ajouter" sur petit écran |
| `*/medications/index.tsx` | Header flex-col mobile + heading responsive | Idem |
| `*/journal/index.tsx` | Header flex-col mobile + heading responsive | Idem |
| `*/appointments/index.tsx` | Header flex-col mobile + heading responsive | Idem |
| `*/dashboard/index.tsx` | Headings `text-xl sm:text-2xl` | Taille de titre adaptée mobile |
| `*/account/index.tsx` | Heading responsive | Cohérence avec les autres pages |
| `*/barkley/index.tsx` | `overflow-x-auto` + `min-w-[540px]` sur la grille | Grille 9 colonnes scrollable horizontalement au lieu de crasher le layout |
| `*/report/index.tsx` | Grid `grid-cols-2 sm:4 lg:7`, date inputs empilés, heading responsive | Symptômes lisibles sur mobile, formulaire de dates utilisable |
| `components/dashboard/mood-logger.tsx` | `px-2 py-2 sm:px-4 sm:py-3` sur les boutons | Plus d'espace pour les 4 boutons emoji sur petit écran |

### Points d'attention pour la revue
- Le Barkley board utilise `overflow-x-auto` avec `min-w-[540px]` — sur mobile l'utilisateur devra scroller horizontalement. C'est un compromis acceptable vs une refonte complète en card-per-behavior
- Les headings passent de `text-2xl` fixe à `text-xl sm:text-2xl` — vérifier que la hiérarchie visuelle reste claire
- Le nouveau projet Playwright `mobile-chrome` (Pixel 5) sera exécuté sur les tests E2E existants — certains tests pourraient nécessiter des ajustements pour le viewport mobile

### Tests
- Typecheck : 2/2 passés (api + web)
- E2E : non exécutés (nécessite serveurs de dev — à valider en CI)
- Tests unitaires : non impactés (changements CSS uniquement)

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation des tests E2E sur le nouveau viewport mobile
- [ ] Merge après approbation

> **Note :** D'autres branches fast-meeting sont actives (`feat/fm-auth-child-flow`, `feat/fm-landing-stripe`, etc.). Vérifier les conflits potentiels avant merge.

---
_Implémentation générée automatiquement par IA_