### PR TITLE
feat(rewards): reward board as main feature with star-based unlocking

### DIFF
--- a/apps/api/src/routes/barkley.ts
+++ b/apps/api/src/routes/barkley.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { AppEnv } from "../types";
-import { eq, and, between, inArray } from "drizzle-orm";
+import { eq, and, between, inArray, count, sql } from "drizzle-orm";
 import {
   db,
   barkleySteps,
@@ -298,6 +298,97 @@ barkleyRoutes.delete("/rewards/:id", async (c) => {
   await db.delete(barkleyRewards).where(eq(barkleyRewards.id, id));
 
   return c.json({ success: true });
+});
+
+// ─── Cumulative Stars ────────────────────────────────────
+
+barkleyRoutes.get("/stars/:childId", async (c) => {
+  const user = c.get("user");
+  const childId = c.req.param("childId");
+
+  await verifyChildOwnership(childId, user.id);
+
+  const behaviors = await db
+    .select({ id: barkleyBehaviors.id })
+    .from(barkleyBehaviors)
+    .where(eq(barkleyBehaviors.childId, childId));
+
+  if (!behaviors.length) {
+    return c.json({ totalStars: 0 });
+  }
+
+  const behaviorIds = behaviors.map((b) => b.id);
+
+  const [result] = await db
+    .select({ total: count() })
+    .from(barkleyBehaviorLogs)
+    .where(
+      and(
+        inArray(barkleyBehaviorLogs.behaviorId, behaviorIds),
+        eq(barkleyBehaviorLogs.completed, true)
+      )
+    );
+
+  return c.json({ totalStars: result?.total ?? 0 });
+});
+
+// ─── Claim Reward ────────────────────────────────────────
+
+barkleyRoutes.post("/rewards/:id/claim", async (c) => {
+  const user = c.get("user");
+  const id = c.req.param("id");
+
+  const [reward] = await db
+    .select()
+    .from(barkleyRewards)
+    .where(eq(barkleyRewards.id, id));
+
+  if (!reward) {
+    throw new AppError("NOT_FOUND", "Récompense non trouvée", 404);
+  }
+
+  await verifyChildOwnership(reward.childId, user.id);
+
+  if (reward.claimedAt) {
+    return c.json({ error: "Récompense déjà réclamée" }, 409);
+  }
+
+  // Count cumulative stars for this child
+  const behaviors = await db
+    .select({ id: barkleyBehaviors.id })
+    .from(barkleyBehaviors)
+    .where(eq(barkleyBehaviors.childId, reward.childId));
+
+  const behaviorIds = behaviors.map((b) => b.id);
+  let totalStars = 0;
+
+  if (behaviorIds.length) {
+    const [result] = await db
+      .select({ total: count() })
+      .from(barkleyBehaviorLogs)
+      .where(
+        and(
+          inArray(barkleyBehaviorLogs.behaviorId, behaviorIds),
+          eq(barkleyBehaviorLogs.completed, true)
+        )
+      );
+    totalStars = result?.total ?? 0;
+  }
+
+  if (totalStars < reward.starsRequired) {
+    return c.json(
+      { error: "Pas assez d'étoiles", required: reward.starsRequired, current: totalStars },
+      422
+    );
+  }
+
+  const [updated] = await db
+    .update(barkleyRewards)
+    .set({ claimedAt: new Date(), updatedAt: new Date() })
+    .where(eq(barkleyRewards.id, id))
+    .returning();
+
+  return c.json(updated);
 });
 
 // ─── Behavior Logs ────────────────────────────────────────

--- a/apps/web/src/hooks/use-barkley.ts
+++ b/apps/web/src/hooks/use-barkley.ts
@@ -18,6 +18,7 @@ export const barkleyKeys = {
   logs: (childId: string, week: string) =>
     ["barkley-logs", childId, week] as const,
   rewards: (childId: string) => ["barkley-rewards", childId] as const,
+  stars: (childId: string) => ["barkley-stars", childId] as const,
 };
 
 // ─── Steps ────────────────────────────────────────────────
@@ -167,5 +168,34 @@ export function useDeleteBarkleyReward() {
       queryClient.invalidateQueries({
         queryKey: barkleyKeys.rewards(variables.childId),
       }),
+  });
+}
+
+// ─── Cumulative Stars ────────────────────────────────────
+
+export function useBarkleyStarCount(childId: string) {
+  return useQuery({
+    queryKey: barkleyKeys.stars(childId),
+    queryFn: () =>
+      api.get<{ totalStars: number }>(`/barkley/stars/${childId}`),
+    enabled: !!childId,
+  });
+}
+
+// ─── Claim Reward ────────────────────────────────────────
+
+export function useClaimBarkleyReward() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id }: { id: string; childId: string }) =>
+      api.post<BarkleyReward>(`/barkley/rewards/${id}/claim`, {}),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: barkleyKeys.rewards(variables.childId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: barkleyKeys.stars(variables.childId),
+      });
+    },
   });
 }

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -16,6 +16,7 @@ import { Route as ConfidentialiteRouteImport } from './routes/confidentialite'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as AuthenticatedSymptomsIndexRouteImport } from './routes/_authenticated/symptoms/index'
+import { Route as AuthenticatedRewardsIndexRouteImport } from './routes/_authenticated/rewards/index'
 import { Route as AuthenticatedReportIndexRouteImport } from './routes/_authenticated/report/index'
 import { Route as AuthenticatedMedicationsIndexRouteImport } from './routes/_authenticated/medications/index'
 import { Route as AuthenticatedJournalIndexRouteImport } from './routes/_authenticated/journal/index'
@@ -57,6 +58,12 @@ const AuthenticatedSymptomsIndexRoute =
   AuthenticatedSymptomsIndexRouteImport.update({
     id: '/symptoms/',
     path: '/symptoms/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+const AuthenticatedRewardsIndexRoute =
+  AuthenticatedRewardsIndexRouteImport.update({
+    id: '/rewards/',
+    path: '/rewards/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 const AuthenticatedReportIndexRoute =
@@ -115,6 +122,7 @@ export interface FileRoutesByFullPath {
   '/journal/': typeof AuthenticatedJournalIndexRoute
   '/medications/': typeof AuthenticatedMedicationsIndexRoute
   '/report/': typeof AuthenticatedReportIndexRoute
+  '/rewards/': typeof AuthenticatedRewardsIndexRoute
   '/symptoms/': typeof AuthenticatedSymptomsIndexRoute
 }
 export interface FileRoutesByTo {
@@ -130,6 +138,7 @@ export interface FileRoutesByTo {
   '/journal': typeof AuthenticatedJournalIndexRoute
   '/medications': typeof AuthenticatedMedicationsIndexRoute
   '/report': typeof AuthenticatedReportIndexRoute
+  '/rewards': typeof AuthenticatedRewardsIndexRoute
   '/symptoms': typeof AuthenticatedSymptomsIndexRoute
 }
 export interface FileRoutesById {
@@ -147,6 +156,7 @@ export interface FileRoutesById {
   '/_authenticated/journal/': typeof AuthenticatedJournalIndexRoute
   '/_authenticated/medications/': typeof AuthenticatedMedicationsIndexRoute
   '/_authenticated/report/': typeof AuthenticatedReportIndexRoute
+  '/_authenticated/rewards/': typeof AuthenticatedRewardsIndexRoute
   '/_authenticated/symptoms/': typeof AuthenticatedSymptomsIndexRoute
 }
 export interface FileRouteTypes {
@@ -164,6 +174,7 @@ export interface FileRouteTypes {
     | '/journal/'
     | '/medications/'
     | '/report/'
+    | '/rewards/'
     | '/symptoms/'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -179,6 +190,7 @@ export interface FileRouteTypes {
     | '/journal'
     | '/medications'
     | '/report'
+    | '/rewards'
     | '/symptoms'
   id:
     | '__root__'
@@ -195,6 +207,7 @@ export interface FileRouteTypes {
     | '/_authenticated/journal/'
     | '/_authenticated/medications/'
     | '/_authenticated/report/'
+    | '/_authenticated/rewards/'
     | '/_authenticated/symptoms/'
   fileRoutesById: FileRoutesById
 }
@@ -258,6 +271,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSymptomsIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/rewards/': {
+      id: '/_authenticated/rewards/'
+      path: '/rewards'
+      fullPath: '/rewards/'
+      preLoaderRoute: typeof AuthenticatedRewardsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/report/': {
       id: '/_authenticated/report/'
       path: '/report'
@@ -318,6 +338,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedJournalIndexRoute: typeof AuthenticatedJournalIndexRoute
   AuthenticatedMedicationsIndexRoute: typeof AuthenticatedMedicationsIndexRoute
   AuthenticatedReportIndexRoute: typeof AuthenticatedReportIndexRoute
+  AuthenticatedRewardsIndexRoute: typeof AuthenticatedRewardsIndexRoute
   AuthenticatedSymptomsIndexRoute: typeof AuthenticatedSymptomsIndexRoute
 }
 
@@ -329,6 +350,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedJournalIndexRoute: AuthenticatedJournalIndexRoute,
   AuthenticatedMedicationsIndexRoute: AuthenticatedMedicationsIndexRoute,
   AuthenticatedReportIndexRoute: AuthenticatedReportIndexRoute,
+  AuthenticatedRewardsIndexRoute: AuthenticatedRewardsIndexRoute,
   AuthenticatedSymptomsIndexRoute: AuthenticatedSymptomsIndexRoute,
 }
 

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -15,6 +15,7 @@ import {
   CalendarDays,
   Heart,
   ClipboardList,
+  Trophy,
   UserCog,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -36,12 +37,13 @@ export const Route = createFileRoute("/_authenticated")({
 
 const navItems = [
   { to: "/dashboard" as const, label: "Tableau de bord", icon: BarChart3 },
+  { to: "/rewards" as const, label: "Récompenses", icon: Trophy },
   { to: "/symptoms" as const, label: "Symptômes", icon: Activity },
   { to: "/medications" as const, label: "Médicaments", icon: Pill },
   { to: "/journal" as const, label: "Journal", icon: BookOpen },
   { to: "/appointments" as const, label: "Rendez-vous", icon: CalendarDays },
   { to: "/report" as const, label: "Rapport", icon: FileText },
-  { to: "/barkley" as const, label: "Tableau Barkley", icon: ClipboardList },
+  { to: "/barkley" as const, label: "Suivi Barkley", icon: ClipboardList },
   { to: "/account" as const, label: "Mon compte", icon: UserCog },
 ];
 

--- a/apps/web/src/routes/_authenticated/barkley/index.tsx
+++ b/apps/web/src/routes/_authenticated/barkley/index.tsx
@@ -4,15 +4,12 @@ import {
   Check,
   ChevronLeft,
   ChevronRight,
-  Gift,
   Plus,
-  Star,
   Trash2,
 } from "lucide-react";
 import { PageLoader } from "@/components/ui/page-loader";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Progress, ProgressLabel, ProgressValue } from "@/components/ui/progress";
@@ -32,9 +29,6 @@ import {
   useCreateBarkleyBehavior,
   useDeleteBarkleyBehavior,
   useToggleBarkleyLog,
-  useBarkleyRewards,
-  useCreateBarkleyReward,
-  useDeleteBarkleyReward,
 } from "@/hooks/use-barkley";
 import { useChild } from "@/hooks/use-children";
 import { useUiStore } from "@/stores/ui-store";
@@ -112,7 +106,7 @@ function BarkleyPage() {
       <div className="space-y-6">
         <div>
           <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
-            Tableau Barkley
+            Suivi Barkley
           </h1>
           <p className="text-muted-foreground">
             Programme d'entraînement aux habiletés parentales (PEHP)
@@ -120,7 +114,7 @@ function BarkleyPage() {
         </div>
         <Card>
           <CardContent className="py-8 text-center text-muted-foreground">
-            Sélectionnez un enfant pour accéder au tableau Barkley.
+            Sélectionnez un enfant pour accéder au suivi Barkley.
           </CardContent>
         </Card>
       </div>
@@ -130,19 +124,19 @@ function BarkleyPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-xl font-bold tracking-tight sm:text-2xl">Tableau Barkley</h1>
+        <h1 className="text-xl font-bold tracking-tight sm:text-2xl">Suivi Barkley</h1>
         <p className="text-muted-foreground">
           Programme d'entraînement aux habiletés parentales (PEHP)
         </p>
       </div>
 
-      <Tabs defaultValue="jetons">
+      <Tabs defaultValue="suivi">
         <TabsList className="grid w-full grid-cols-2">
-          <TabsTrigger value="jetons">Tableau de récompenses</TabsTrigger>
+          <TabsTrigger value="suivi">Suivi hebdomadaire</TabsTrigger>
           <TabsTrigger value="programme">Programme</TabsTrigger>
         </TabsList>
-        <TabsContent value="jetons">
-          <RewardBoard childId={activeChildId} />
+        <TabsContent value="suivi">
+          <BehaviorTracking childId={activeChildId} />
         </TabsContent>
         <TabsContent value="programme">
           <ProgrammeTab childId={activeChildId} />
@@ -152,23 +146,19 @@ function BarkleyPage() {
   );
 }
 
-// ─── Reward Board (main visual board) ─────────────────────
+// ─── Behavior Tracking (weekly star grid) ─────────────────
 
-function RewardBoard({ childId }: { childId: string }) {
+function BehaviorTracking({ childId }: { childId: string }) {
   const [currentMonday, setCurrentMonday] = useState(() =>
     getMonday(new Date())
   );
   const [behaviorDialogOpen, setBehaviorDialogOpen] = useState(false);
-  const [rewardDialogOpen, setRewardDialogOpen] = useState(false);
 
   const { data: child } = useChild(childId);
   const week = formatDate(currentMonday);
   const { data, isLoading } = useBarkleyLogs(childId, week);
-  const { data: rewards = [], isLoading: rewardsLoading } =
-    useBarkleyRewards(childId);
   const toggleLog = useToggleBarkleyLog();
   const deleteBehavior = useDeleteBarkleyBehavior();
-  const deleteReward = useDeleteBarkleyReward();
 
   const behaviors = data?.behaviors?.filter((b) => b.active) ?? [];
   const logs = data?.logs ?? [];
@@ -216,7 +206,6 @@ function RewardBoard({ childId }: { childId: string }) {
     setCurrentMonday(d);
   };
 
-  // Count total stars for the week
   const weeklyStars = useMemo(() => {
     let total = 0;
     behaviors.forEach((b) => {
@@ -228,10 +217,9 @@ function RewardBoard({ childId }: { childId: string }) {
   }, [behaviors, weekDates, logMap]);
 
   const maxStars = behaviors.length * 7;
-
   const childName = child?.name ?? "...";
 
-  if (isLoading || rewardsLoading) {
+  if (isLoading) {
     return <PageLoader />;
   }
 
@@ -288,52 +276,50 @@ function RewardBoard({ childId }: { childId: string }) {
         </div>
       </div>
 
-      {/* Main content: behavior grid + rewards */}
-      <div className="grid grid-cols-1 lg:grid-cols-[1fr_280px] gap-4">
-        {/* Behavior tracking grid */}
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-              Comportements
-            </h3>
-            <Dialog
-              open={behaviorDialogOpen}
-              onOpenChange={setBehaviorDialogOpen}
-            >
-              <DialogTrigger
-                render={
-                  <Button size="sm" variant="outline">
-                    <Plus className="mr-1.5 h-3.5 w-3.5" />
-                    Ajouter
-                  </Button>
-                }
+      {/* Behavior tracking grid */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+            Comportements
+          </h3>
+          <Dialog
+            open={behaviorDialogOpen}
+            onOpenChange={setBehaviorDialogOpen}
+          >
+            <DialogTrigger
+              render={
+                <Button size="sm" variant="outline">
+                  <Plus className="mr-1.5 h-3.5 w-3.5" />
+                  Ajouter
+                </Button>
+              }
+            />
+            <DialogContent className="sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle>Nouveau comportement</DialogTitle>
+              </DialogHeader>
+              <BehaviorForm
+                childId={childId}
+                onSuccess={() => setBehaviorDialogOpen(false)}
               />
-              <DialogContent className="sm:max-w-md">
-                <DialogHeader>
-                  <DialogTitle>Nouveau comportement</DialogTitle>
-                </DialogHeader>
-                <BehaviorForm
-                  childId={childId}
-                  onSuccess={() => setBehaviorDialogOpen(false)}
-                />
-              </DialogContent>
-            </Dialog>
-          </div>
+            </DialogContent>
+          </Dialog>
+        </div>
 
-          {behaviors.length === 0 ? (
-            <Card>
-              <CardContent className="py-8 text-center text-muted-foreground">
-                <p>
-                  Ajoutez des comportements pour commencer le tableau de
-                  récompenses.
-                </p>
-              </CardContent>
-            </Card>
-          ) : (
-            <Card>
-              <div className="overflow-x-auto">
-              {/* Day headers */}
-              <div className="grid min-w-[540px] grid-cols-[1fr_repeat(7,_minmax(36px,_1fr))_40px] border-b bg-muted/50 px-3 py-2">
+        {behaviors.length === 0 ? (
+          <Card>
+            <CardContent className="py-8 text-center text-muted-foreground">
+              <p>
+                Ajoutez des comportements pour commencer le suivi
+                hebdomadaire.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            {/* Desktop grid view */}
+            <Card className="hidden sm:block overflow-hidden">
+              <div className="grid grid-cols-[1fr_repeat(7,_minmax(36px,_1fr))_40px] border-b bg-muted/50 px-3 py-2">
                 <div className="text-xs font-medium text-muted-foreground" />
                 {DAY_LABELS.map((day, i) => (
                   <div
@@ -349,11 +335,10 @@ function RewardBoard({ childId }: { childId: string }) {
                 <div />
               </div>
 
-              {/* Behavior rows */}
               {behaviors.map((behavior, idx) => (
                 <div
                   key={behavior.id}
-                  className={`grid min-w-[540px] grid-cols-[1fr_repeat(7,_minmax(36px,_1fr))_40px] items-center px-3 py-2.5 ${
+                  className={`grid grid-cols-[1fr_repeat(7,_minmax(36px,_1fr))_40px] items-center px-3 py-2.5 ${
                     idx < behaviors.length - 1 ? "border-b" : ""
                   } hover:bg-muted/30 transition-colors`}
                 >
@@ -409,79 +394,66 @@ function RewardBoard({ childId }: { childId: string }) {
                   </div>
                 </div>
               ))}
-              </div>
             </Card>
-          )}
-        </div>
 
-        {/* Rewards sidebar */}
-        <div className="space-y-3">
-          <div className="flex items-center justify-between">
-            <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
-              <Gift className="h-3.5 w-3.5" />
-              Récompenses
-            </h3>
-            <Dialog
-              open={rewardDialogOpen}
-              onOpenChange={setRewardDialogOpen}
-            >
-              <DialogTrigger
-                render={
-                  <Button size="sm" variant="ghost" className="h-7 w-7 p-0">
-                    <Plus className="h-3.5 w-3.5" />
-                  </Button>
-                }
-              />
-              <DialogContent className="sm:max-w-md">
-                <DialogHeader>
-                  <DialogTitle>Nouvelle récompense</DialogTitle>
-                </DialogHeader>
-                <RewardForm
-                  childId={childId}
-                  onSuccess={() => setRewardDialogOpen(false)}
-                />
-              </DialogContent>
-            </Dialog>
-          </div>
-
-          <Card className="bg-gradient-to-b from-amber-50/80 to-orange-50/50 dark:from-amber-950/20 dark:to-orange-950/10 border-amber-200/50 dark:border-amber-800/30">
-            <CardContent className="py-3 px-4">
-              {rewards.length === 0 ? (
-                <p className="text-sm text-muted-foreground text-center py-4">
-                  Ajoutez des récompenses motivantes pour votre enfant.
-                </p>
-              ) : (
-                <ul className="space-y-2.5">
-                  {rewards.map((reward) => (
-                    <li
-                      key={reward.id}
-                      className="group flex items-start gap-2"
-                    >
-                      <span className="text-base shrink-0 mt-0.5">
-                        {reward.icon || "🎁"}
-                      </span>
-                      <span className="text-sm font-medium flex-1">
-                        {reward.name}
-                      </span>
+            {/* Mobile card view */}
+            <div className="sm:hidden space-y-3">
+              {behaviors.map((behavior) => (
+                <Card key={behavior.id} className="overflow-hidden">
+                  <CardContent className="py-3 px-4">
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="text-lg shrink-0">
+                          {behavior.icon || "✅"}
+                        </span>
+                        <span className="text-sm font-semibold truncate">
+                          {behavior.name}
+                        </span>
+                      </div>
                       <button
                         onClick={() =>
-                          deleteReward.mutate({
-                            id: reward.id,
-                            childId,
-                          })
+                          deleteBehavior.mutate({ id: behavior.id, childId })
                         }
-                        className="opacity-0 group-hover:opacity-100 text-muted-foreground/40 hover:text-destructive transition-all p-0.5"
-                        disabled={deleteReward.isPending}
+                        className="text-muted-foreground/40 hover:text-destructive transition-colors p-1 rounded shrink-0"
+                        disabled={deleteBehavior.isPending}
                       >
-                        <Trash2 className="h-3 w-3" />
+                        <Trash2 className="h-3.5 w-3.5" />
                       </button>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </CardContent>
-          </Card>
-        </div>
+                    </div>
+                    <div className="flex justify-between gap-1">
+                      {weekDates.map((date, i) => {
+                        const checked = isChecked(behavior.id, date);
+                        return (
+                          <button
+                            key={date}
+                            onClick={() => handleToggle(behavior.id, date)}
+                            className={`flex flex-col items-center gap-0.5 rounded-lg px-1.5 py-1.5 transition-all flex-1 min-w-0 ${
+                              checked
+                                ? "bg-amber-50 dark:bg-amber-950/20"
+                                : "hover:bg-muted/50"
+                            }`}
+                            disabled={toggleLog.isPending}
+                          >
+                            <span className="text-[10px] font-medium text-muted-foreground">
+                              {DAY_LABELS[i]}
+                            </span>
+                            {checked ? (
+                              <span className="text-lg leading-none">⭐</span>
+                            ) : (
+                              <span className="text-muted-foreground/30 text-lg leading-none">
+                                ☆
+                              </span>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </>
+        )}
       </div>
 
       {/* Barkley tips */}
@@ -668,64 +640,6 @@ function BehaviorForm({
         disabled={!name || createBehavior.isPending}
       >
         {createBehavior.isPending ? "Enregistrement..." : "Ajouter"}
-      </Button>
-    </form>
-  );
-}
-
-// ─── Reward Form ──────────────────────────────────────────
-
-function RewardForm({
-  childId,
-  onSuccess,
-}: {
-  childId: string;
-  onSuccess: () => void;
-}) {
-  const createReward = useCreateBarkleyReward();
-  const [name, setName] = useState("");
-  const [icon, setIcon] = useState("");
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    createReward.mutate(
-      {
-        childId,
-        name,
-        icon: icon || undefined,
-      },
-      { onSuccess }
-    );
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="space-y-2">
-        <Label htmlFor="reward-name">Nom de la récompense</Label>
-        <Input
-          id="reward-name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Ex: Un temps de dessin avec maman"
-          required
-        />
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="reward-icon">Icône (emoji)</Label>
-        <Input
-          id="reward-icon"
-          value={icon}
-          onChange={(e) => setIcon(e.target.value)}
-          placeholder="Ex: 🎨"
-          maxLength={10}
-        />
-      </div>
-      <Button
-        type="submit"
-        className="w-full"
-        disabled={!name || createReward.isPending}
-      >
-        {createReward.isPending ? "Enregistrement..." : "Ajouter"}
       </Button>
     </form>
   );

--- a/apps/web/src/routes/_authenticated/rewards/index.tsx
+++ b/apps/web/src/routes/_authenticated/rewards/index.tsx
@@ -1,0 +1,355 @@
+import { useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import {
+  Gift,
+  Lock,
+  Plus,
+  Star,
+  Trash2,
+  Trophy,
+  PartyPopper,
+} from "lucide-react";
+import { PageLoader } from "@/components/ui/page-loader";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Progress, ProgressValue } from "@/components/ui/progress";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  useBarkleyRewards,
+  useCreateBarkleyReward,
+  useDeleteBarkleyReward,
+  useBarkleyStarCount,
+  useClaimBarkleyReward,
+} from "@/hooks/use-barkley";
+import { useChild } from "@/hooks/use-children";
+import { useUiStore } from "@/stores/ui-store";
+
+export const Route = createFileRoute("/_authenticated/rewards/")({
+  component: RewardsPage,
+});
+
+function RewardsPage() {
+  const activeChildId = useUiStore((s) => s.activeChildId);
+
+  if (!activeChildId) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">Récompenses</h1>
+          <p className="text-muted-foreground">
+            Tableau de récompenses à débloquer avec des étoiles
+          </p>
+        </div>
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            Sélectionnez un enfant pour accéder aux récompenses.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return <RewardBoard childId={activeChildId} />;
+}
+
+function RewardBoard({ childId }: { childId: string }) {
+  const [rewardDialogOpen, setRewardDialogOpen] = useState(false);
+  const { data: child } = useChild(childId);
+  const { data: rewards = [], isLoading: rewardsLoading } =
+    useBarkleyRewards(childId);
+  const { data: starData, isLoading: starsLoading } =
+    useBarkleyStarCount(childId);
+  const claimReward = useClaimBarkleyReward();
+  const deleteReward = useDeleteBarkleyReward();
+
+  const totalStars = starData?.totalStars ?? 0;
+  const childName = child?.name ?? "...";
+
+  const sortedRewards = [...rewards].sort((a, b) => {
+    // Claimed last, then by starsRequired ascending
+    if (a.claimedAt && !b.claimedAt) return 1;
+    if (!a.claimedAt && b.claimedAt) return -1;
+    return (a.starsRequired ?? 0) - (b.starsRequired ?? 0);
+  });
+
+  if (rewardsLoading || starsLoading) {
+    return <PageLoader />;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Hero header with star count */}
+      <div className="relative overflow-hidden rounded-xl bg-gradient-to-r from-amber-500 via-orange-500 to-amber-600 px-6 py-6 text-white shadow-lg">
+        <div className="absolute inset-0 opacity-10">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <span
+              key={i}
+              className="absolute text-2xl"
+              style={{
+                top: `${Math.random() * 80}%`,
+                left: `${Math.random() * 95}%`,
+                transform: `rotate(${Math.random() * 40 - 20}deg)`,
+                opacity: 0.4 + Math.random() * 0.6,
+              }}
+            >
+              {i % 2 === 0 ? "⭐" : "🎁"}
+            </span>
+          ))}
+        </div>
+        <div className="relative text-center">
+          <h1 className="text-2xl font-bold font-heading">
+            <Trophy className="inline-block h-6 w-6 mr-2 -mt-1" />
+            Récompenses de {childName}
+          </h1>
+          <div className="mt-3 flex items-center justify-center gap-3">
+            <div className="flex items-center gap-2 rounded-full bg-white/20 px-4 py-2 backdrop-blur-sm">
+              <Star className="h-5 w-5 fill-yellow-300 text-yellow-300" />
+              <span className="text-xl font-bold">{totalStars}</span>
+              <span className="text-sm text-white/80">étoiles gagnées</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Add reward button */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
+          <Gift className="h-3.5 w-3.5" />
+          Tableau de récompenses
+        </h2>
+        <Dialog
+          open={rewardDialogOpen}
+          onOpenChange={setRewardDialogOpen}
+        >
+          <DialogTrigger
+            render={
+              <Button size="sm" variant="outline">
+                <Plus className="mr-1.5 h-3.5 w-3.5" />
+                Ajouter
+              </Button>
+            }
+          />
+          <DialogContent className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>Nouvelle récompense</DialogTitle>
+            </DialogHeader>
+            <RewardForm
+              childId={childId}
+              onSuccess={() => setRewardDialogOpen(false)}
+            />
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {/* Reward cards */}
+      {sortedRewards.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center text-muted-foreground">
+            <Gift className="mx-auto mb-3 h-10 w-10 text-muted-foreground/30" />
+            <p className="font-medium">Aucune récompense</p>
+            <p className="text-sm mt-1">
+              Ajoutez des récompenses motivantes que votre enfant pourra
+              débloquer en gagnant des étoiles.
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {sortedRewards.map((reward) => {
+            const starsNeeded = reward.starsRequired ?? 0;
+            const isClaimed = !!reward.claimedAt;
+            const isUnlockable = !isClaimed && totalStars >= starsNeeded;
+            const progress =
+              starsNeeded > 0
+                ? Math.min((totalStars / starsNeeded) * 100, 100)
+                : 100;
+            const remaining = Math.max(starsNeeded - totalStars, 0);
+
+            return (
+              <Card
+                key={reward.id}
+                className={`relative overflow-hidden transition-all duration-300 ${
+                  isClaimed
+                    ? "border-green-300 bg-gradient-to-b from-green-50/80 to-emerald-50/50 dark:from-green-950/20 dark:to-emerald-950/10 dark:border-green-800/30"
+                    : isUnlockable
+                      ? "border-amber-300 bg-gradient-to-b from-amber-50/80 to-orange-50/50 dark:from-amber-950/20 dark:to-orange-950/10 dark:border-amber-800/30 ring-2 ring-amber-400/50"
+                      : "opacity-75"
+                }`}
+              >
+                <CardContent className="py-4 px-4">
+                  <div className="flex items-start gap-3">
+                    {/* Icon */}
+                    <div
+                      className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-xl text-2xl ${
+                        isClaimed
+                          ? "bg-green-100 dark:bg-green-900/30"
+                          : isUnlockable
+                            ? "bg-amber-100 dark:bg-amber-900/30"
+                            : "bg-muted grayscale"
+                      }`}
+                    >
+                      {reward.icon || "🎁"}
+                    </div>
+
+                    {/* Content */}
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2">
+                        <h3 className="text-sm font-semibold truncate">
+                          {reward.name}
+                        </h3>
+                        {isClaimed && (
+                          <PartyPopper className="h-4 w-4 text-green-600 shrink-0" />
+                        )}
+                        {!isClaimed && !isUnlockable && (
+                          <Lock className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0" />
+                        )}
+                      </div>
+
+                      {/* Star requirement */}
+                      <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+                        <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
+                        <span>
+                          {isClaimed
+                            ? `Débloquée !`
+                            : isUnlockable
+                              ? `Prête à débloquer !`
+                              : `${remaining} étoile${remaining > 1 ? "s" : ""} restante${remaining > 1 ? "s" : ""}`}
+                        </span>
+                      </div>
+
+                      {/* Progress bar */}
+                      {!isClaimed && starsNeeded > 0 && (
+                        <div className="mt-2">
+                          <Progress value={progress}>
+                            <ProgressValue>
+                              {() =>
+                                `${Math.min(totalStars, starsNeeded)} / ${starsNeeded}`
+                              }
+                            </ProgressValue>
+                          </Progress>
+                        </div>
+                      )}
+
+                      {/* Claim button */}
+                      {isUnlockable && (
+                        <Button
+                          size="sm"
+                          className="mt-3 w-full bg-amber-500 hover:bg-amber-600 text-white"
+                          onClick={() =>
+                            claimReward.mutate({
+                              id: reward.id,
+                              childId,
+                            })
+                          }
+                          disabled={claimReward.isPending}
+                        >
+                          <PartyPopper className="mr-1.5 h-3.5 w-3.5" />
+                          {claimReward.isPending
+                            ? "Déblocage..."
+                            : "Débloquer !"}
+                        </Button>
+                      )}
+                    </div>
+
+                    {/* Delete button */}
+                    <button
+                      onClick={() =>
+                        deleteReward.mutate({ id: reward.id, childId })
+                      }
+                      className="text-muted-foreground/30 hover:text-destructive transition-colors p-1 rounded shrink-0"
+                      disabled={deleteReward.isPending}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Reward Form ──────────────────────────────────────────
+
+function RewardForm({
+  childId,
+  onSuccess,
+}: {
+  childId: string;
+  onSuccess: () => void;
+}) {
+  const createReward = useCreateBarkleyReward();
+  const [name, setName] = useState("");
+  const [icon, setIcon] = useState("");
+  const [starsRequired, setStarsRequired] = useState(5);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    createReward.mutate(
+      {
+        childId,
+        name,
+        starsRequired,
+        icon: icon || undefined,
+      },
+      { onSuccess }
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="reward-name">Nom de la récompense</Label>
+        <Input
+          id="reward-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Ex: Un temps de dessin avec maman"
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="reward-icon">Icône (emoji)</Label>
+        <Input
+          id="reward-icon"
+          value={icon}
+          onChange={(e) => setIcon(e.target.value)}
+          placeholder="Ex: 🎨"
+          maxLength={10}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="reward-stars">Étoiles nécessaires</Label>
+        <Input
+          id="reward-stars"
+          type="number"
+          min={0}
+          value={starsRequired}
+          onChange={(e) => setStarsRequired(Number(e.target.value))}
+          required
+        />
+        <p className="text-xs text-muted-foreground">
+          Nombre d'étoiles cumulées pour débloquer cette récompense.
+        </p>
+      </div>
+      <Button
+        type="submit"
+        className="w-full"
+        disabled={!name || createReward.isPending}
+      >
+        {createReward.isPending ? "Enregistrement..." : "Ajouter"}
+      </Button>
+    </form>
+  );
+}

--- a/packages/db/drizzle/0007_dapper_wildside.sql
+++ b/packages/db/drizzle/0007_dapper_wildside.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "barkley_rewards" ADD COLUMN "stars_required" integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE "barkley_rewards" ADD COLUMN "claimed_at" timestamp;--> statement-breakpoint
+-- Grandfather existing rewards as already claimed (starsRequired=0, already unlocked)
+UPDATE "barkley_rewards" SET "claimed_at" = NOW() WHERE "claimed_at" IS NULL;

--- a/packages/db/drizzle/meta/0007_snapshot.json
+++ b/packages/db/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1247 @@
+{
+  "id": "dc851cd0-91cf-4a51-9ab5-0586ca3a5a4b",
+  "prevId": "385d20f2-d573-4532-8772-1814bc28bac8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.children": {
+      "name": "children",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_type": {
+          "name": "diagnosis_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undefined'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "children_parent_id_user_id_fk": {
+          "name": "children_parent_id_user_id_fk",
+          "tableFrom": "children",
+          "tableTo": "user",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.symptoms": {
+      "name": "symptoms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agitation": {
+          "name": "agitation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "focus": {
+          "name": "focus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impulse": {
+          "name": "impulse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood": {
+          "name": "mood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sleep": {
+          "name": "sleep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social": {
+          "name": "social",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "autonomy": {
+          "name": "autonomy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "symptoms_child_id_children_id_fk": {
+          "name": "symptoms_child_id_children_id_fk",
+          "tableFrom": "symptoms",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication": {
+      "name": "medication",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose": {
+          "name": "dose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medication_child_id_children_id_fk": {
+          "name": "medication_child_id_children_id_fk",
+          "tableFrom": "medication",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_logs": {
+      "name": "medication_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "medication_id": {
+          "name": "medication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taken_at": {
+          "name": "taken_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medication_logs_medication_id_medication_id_fk": {
+          "name": "medication_logs_medication_id_medication_id_fk",
+          "tableFrom": "medication_logs",
+          "tableTo": "medication",
+          "columnsFrom": [
+            "medication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entries": {
+      "name": "journal_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "mood_rating": {
+          "name": "mood_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entries_child_id_children_id_fk": {
+          "name": "journal_entries_child_id_children_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointments_child_id_children_id_fk": {
+          "name": "appointments_child_id_children_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscription_stripe_subscription_id_unique": {
+          "name": "subscription_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_behavior_logs": {
+      "name": "barkley_behavior_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "behavior_id": {
+          "name": "behavior_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "barkley_behavior_logs_behavior_id_barkley_behaviors_id_fk": {
+          "name": "barkley_behavior_logs_behavior_id_barkley_behaviors_id_fk",
+          "tableFrom": "barkley_behavior_logs",
+          "tableTo": "barkley_behaviors",
+          "columnsFrom": [
+            "behavior_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "barkley_behavior_logs_behavior_id_date_unique": {
+          "name": "barkley_behavior_logs_behavior_id_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "behavior_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_behaviors": {
+      "name": "barkley_behaviors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "barkley_behaviors_child_id_children_id_fk": {
+          "name": "barkley_behaviors_child_id_children_id_fk",
+          "tableFrom": "barkley_behaviors",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_rewards": {
+      "name": "barkley_rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stars_required": {
+          "name": "stars_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "barkley_rewards_child_id_children_id_fk": {
+          "name": "barkley_rewards_child_id_children_id_fk",
+          "tableFrom": "barkley_rewards",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_steps": {
+      "name": "barkley_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "barkley_steps_child_id_children_id_fk": {
+          "name": "barkley_steps_child_id_children_id_fk",
+          "tableFrom": "barkley_steps",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "barkley_steps_child_id_step_number_unique": {
+          "name": "barkley_steps_child_id_step_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "child_id",
+            "step_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1774281795672,
       "tag": "0006_wealthy_prodigy",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1774302689705,
+      "tag": "0007_dapper_wildside",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/barkley.ts
+++ b/packages/db/src/schema/barkley.ts
@@ -52,6 +52,8 @@ export const barkleyRewards = pgTable("barkley_rewards", {
     .references(() => children.id, { onDelete: "cascade" }),
   name: text("name").notNull(),
   icon: text("icon"),
+  starsRequired: integer("stars_required").notNull().default(0),
+  claimedAt: timestamp("claimed_at"),
   sortOrder: integer("sort_order").notNull().default(0),
   createdAt: timestamp("created_at").notNull().defaultNow(),
   updatedAt: timestamp("updated_at").notNull().defaultNow(),

--- a/packages/validators/src/barkley.ts
+++ b/packages/validators/src/barkley.ts
@@ -51,13 +51,15 @@ export const createBarkleyRewardSchema = z.object({
   childId: z.string().uuid(),
   name: z.string().min(1).max(200),
   icon: z.string().max(10).optional(),
+  starsRequired: z.number().int().min(0).default(5),
   sortOrder: z.number().int().min(0).optional().default(0),
 });
 
 export const barkleyRewardSchema = createBarkleyRewardSchema.extend({
   id: z.string().uuid(),
-  createdAt: z.string().datetime(),
-  updatedAt: z.string().datetime(),
+  claimedAt: z.coerce.string().nullable(),
+  createdAt: z.coerce.string(),
+  updatedAt: z.coerce.string(),
 });
 
 export type CreateBarkleyReward = z.input<typeof createBarkleyRewardSchema>;


### PR DESCRIPTION
## Résumé technique

### Contexte
La page Barkley combinait le suivi comportemental et les récompenses dans une seule page avec des onglets. Les récompenses étaient une simple liste décorative sans mécanisme de déblocage. L'utilisateur souhaite promouvoir les récompenses en fonctionnalité principale avec un système de déblocage basé sur les étoiles cumulées.

### Approche retenue
Séparation en deux pages distinctes avec modèle "milestone" pour les récompenses. Les étoiles sont un compteur cumulatif all-time (COUNT sur les logs), pas une monnaie à dépenser. Une fois débloquée, une récompense reste débloquée définitivement — aligné avec le principe Barkley "Jamais retirer une étoile".

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `packages/db/src/schema/barkley.ts` | Ajout `starsRequired` (int, default 0) + `claimedAt` (timestamp, nullable) | Seuil de déblocage + tracking du claim |
| `packages/db/drizzle/0007_dapper_wildside.sql` | Migration avec grandfathering des rewards existants | Les rewards existants sont marqués claimed pour ne pas casser l'UX |
| `packages/validators/src/barkley.ts` | Ajout des champs au schema Zod | Validation côté client et serveur |
| `apps/api/src/routes/barkley.ts` | Ajout `GET /barkley/stars/:childId` + `POST /barkley/rewards/:id/claim` | Comptage cumulatif serveur + claim avec vérification |
| `apps/web/src/hooks/use-barkley.ts` | Ajout `useBarkleyStarCount` + `useClaimBarkleyReward` | React Query hooks pour les nouveaux endpoints |
| `apps/web/src/routes/_authenticated/rewards/index.tsx` | Nouvelle page rewards mobile-first | Cartes avec progression, états locked/unlockable/claimed |
| `apps/web/src/routes/_authenticated/barkley/index.tsx` | Refactoring : suppression rewards sidebar, ajout vue mobile cards | Focus sur le suivi comportemental + programme |
| `apps/web/src/routes/_authenticated.tsx` | Ajout "Récompenses" (Trophy icon) en 2ème position nav | Promotion en fonctionnalité principale |

### Points d'attention pour la revue
- La migration grandfathers les rewards existants (`claimed_at = NOW()`) — vérifier que c'est le comportement souhaité en prod
- Le claim est permanent (pas de un-claim) — conforme à la philosophie Barkley
- Le comptage cumulatif utilise COUNT(*) sur les logs — performant pour usage familial, à surveiller si croissance massive
- La vue mobile du behavior grid utilise des cartes empilées au lieu de la grille 9 colonnes

### Tests
- Build TypeScript : ✅ (web + API)
- Tests automatisés : non exécutés (pas de DB disponible dans le worktree)

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Exécuter la migration sur la DB
- [ ] Tester le flow complet : créer reward → gagner étoiles → débloquer
- [ ] Valider l'UX mobile sur vrais appareils

---
_Implémentation générée automatiquement par IA_