### PR TITLE
feat(crisis-list): add calming list for ADHD crisis moments

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -13,6 +13,7 @@ import { appointmentsRoutes } from "./routes/appointments";
 import { billingRoutes, stripeWebhookRoute } from "./routes/billing";
 import { barkleyRoutes } from "./routes/barkley";
 import { accountRoutes } from "./routes/account";
+import { crisisListRoutes } from "./routes/crisis-list";
 import { auth } from "./lib/auth";
 
 const app = new Hono();
@@ -44,5 +45,6 @@ app.route("/api/appointments", appointmentsRoutes);
 app.route("/api/billing", billingRoutes);
 app.route("/api/barkley", barkleyRoutes);
 app.route("/api/account", accountRoutes);
+app.route("/api/crisis-list", crisisListRoutes);
 
 export { app };

--- a/apps/api/src/routes/crisis-list.ts
+++ b/apps/api/src/routes/crisis-list.ts
@@ -1,0 +1,190 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../types";
+import { eq, and, asc, sql } from "drizzle-orm";
+import { db, crisisItems, children } from "@focusflow/db";
+import {
+  createCrisisItemSchema,
+  updateCrisisItemSchema,
+  reorderCrisisItemsSchema,
+} from "@focusflow/validators";
+import { authMiddleware } from "../middleware/auth";
+import { AppError } from "../middleware/error-handler";
+
+export const crisisListRoutes = new Hono<AppEnv>();
+
+crisisListRoutes.use("*", authMiddleware);
+
+crisisListRoutes.get("/:childId", async (c) => {
+  const user = c.get("user");
+  const childId = c.req.param("childId");
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(and(eq(children.id, childId), eq(children.parentId, user.id)));
+
+  if (!child) {
+    throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
+  }
+
+  const result = await db
+    .select()
+    .from(crisisItems)
+    .where(eq(crisisItems.childId, childId))
+    .orderBy(asc(crisisItems.position));
+
+  return c.json(result);
+});
+
+crisisListRoutes.post("/", async (c) => {
+  const user = c.get("user");
+  const body = await c.req.json();
+  const parsed = createCrisisItemSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return c.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      422
+    );
+  }
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(
+      and(eq(children.id, parsed.data.childId), eq(children.parentId, user.id))
+    );
+
+  if (!child) {
+    throw new AppError("FORBIDDEN", "Accès refusé", 403);
+  }
+
+  // Auto-set position to end of list
+  const [maxPos] = await db
+    .select({ max: sql<number>`coalesce(max(${crisisItems.position}), -1)` })
+    .from(crisisItems)
+    .where(eq(crisisItems.childId, parsed.data.childId));
+
+  const position = parsed.data.position ?? (maxPos?.max ?? -1) + 1;
+
+  const [item] = await db
+    .insert(crisisItems)
+    .values({ ...parsed.data, position })
+    .returning();
+
+  return c.json(item, 201);
+});
+
+crisisListRoutes.patch("/:id", async (c) => {
+  const user = c.get("user");
+  const id = c.req.param("id");
+  const body = await c.req.json();
+  const parsed = updateCrisisItemSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return c.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      422
+    );
+  }
+
+  const [existing] = await db
+    .select()
+    .from(crisisItems)
+    .where(eq(crisisItems.id, id));
+
+  if (!existing) {
+    throw new AppError("NOT_FOUND", "Élément non trouvé", 404);
+  }
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(
+      and(eq(children.id, existing.childId), eq(children.parentId, user.id))
+    );
+
+  if (!child) {
+    throw new AppError("FORBIDDEN", "Accès refusé", 403);
+  }
+
+  const [updated] = await db
+    .update(crisisItems)
+    .set({ ...parsed.data, updatedAt: new Date() })
+    .where(eq(crisisItems.id, id))
+    .returning();
+
+  return c.json(updated);
+});
+
+crisisListRoutes.delete("/:id", async (c) => {
+  const user = c.get("user");
+  const id = c.req.param("id");
+
+  const [existing] = await db
+    .select()
+    .from(crisisItems)
+    .where(eq(crisisItems.id, id));
+
+  if (!existing) {
+    throw new AppError("NOT_FOUND", "Élément non trouvé", 404);
+  }
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(
+      and(eq(children.id, existing.childId), eq(children.parentId, user.id))
+    );
+
+  if (!child) {
+    throw new AppError("FORBIDDEN", "Accès refusé", 403);
+  }
+
+  await db.delete(crisisItems).where(eq(crisisItems.id, id));
+  return c.json({ ok: true });
+});
+
+crisisListRoutes.post("/:childId/reorder", async (c) => {
+  const user = c.get("user");
+  const childId = c.req.param("childId");
+  const body = await c.req.json();
+  const parsed = reorderCrisisItemsSchema.safeParse({ ...body, childId });
+
+  if (!parsed.success) {
+    return c.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      422
+    );
+  }
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(and(eq(children.id, childId), eq(children.parentId, user.id)));
+
+  if (!child) {
+    throw new AppError("FORBIDDEN", "Accès refusé", 403);
+  }
+
+  // Update positions in a loop (small list, acceptable)
+  for (let i = 0; i < parsed.data.orderedIds.length; i++) {
+    await db
+      .update(crisisItems)
+      .set({ position: i, updatedAt: new Date() })
+      .where(
+        and(
+          eq(crisisItems.id, parsed.data.orderedIds[i]!),
+          eq(crisisItems.childId, childId)
+        )
+      );
+  }
+
+  const result = await db
+    .select()
+    .from(crisisItems)
+    .where(eq(crisisItems.childId, childId))
+    .orderBy(asc(crisisItems.position));
+
+  return c.json(result);
+});

--- a/apps/web/src/hooks/use-crisis-list.ts
+++ b/apps/web/src/hooks/use-crisis-list.ts
@@ -1,0 +1,76 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import type {
+  CrisisItem,
+  CreateCrisisItem,
+  UpdateCrisisItem,
+} from "@focusflow/validators";
+
+export const crisisListKeys = {
+  all: (childId: string) => ["crisis-list", childId] as const,
+};
+
+export function useCrisisItems(childId: string) {
+  return useQuery({
+    queryKey: crisisListKeys.all(childId),
+    queryFn: () => api.get<CrisisItem[]>(`/crisis-list/${childId}`),
+    enabled: !!childId,
+  });
+}
+
+export function useCreateCrisisItem() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateCrisisItem) =>
+      api.post<CrisisItem>("/crisis-list", data),
+    onSuccess: (_, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: crisisListKeys.all(variables.childId),
+      }),
+  });
+}
+
+export function useUpdateCrisisItem() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      childId,
+      ...data
+    }: UpdateCrisisItem & { id: string; childId: string }) =>
+      api.patch<CrisisItem>(`/crisis-list/${id}`, data),
+    onSuccess: (_, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: crisisListKeys.all(variables.childId),
+      }),
+  });
+}
+
+export function useDeleteCrisisItem() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, childId }: { id: string; childId: string }) =>
+      api.delete<{ ok: true }>(`/crisis-list/${id}`),
+    onSuccess: (_, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: crisisListKeys.all(variables.childId),
+      }),
+  });
+}
+
+export function useReorderCrisisItems() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      childId,
+      orderedIds,
+    }: {
+      childId: string;
+      orderedIds: string[];
+    }) => api.post<CrisisItem[]>(`/crisis-list/${childId}/reorder`, { orderedIds }),
+    onSuccess: (_, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: crisisListKeys.all(variables.childId),
+      }),
+  });
+}

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -23,6 +23,7 @@ import { Route as AuthenticatedJournalIndexRouteImport } from './routes/_authent
 import { Route as AuthenticatedDashboardIndexRouteImport } from './routes/_authenticated/dashboard/index'
 import { Route as AuthenticatedBarkleyIndexRouteImport } from './routes/_authenticated/barkley/index'
 import { Route as AuthenticatedAppointmentsIndexRouteImport } from './routes/_authenticated/appointments/index'
+import { Route as AuthenticatedCrisisListIndexRouteImport } from './routes/_authenticated/crisis-list/index'
 import { Route as AuthenticatedAccountIndexRouteImport } from './routes/_authenticated/account/index'
 
 const MentionsLegalesRoute = MentionsLegalesRouteImport.update({
@@ -102,6 +103,12 @@ const AuthenticatedAppointmentsIndexRoute =
     path: '/appointments/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedCrisisListIndexRoute =
+  AuthenticatedCrisisListIndexRouteImport.update({
+    id: '/crisis-list/',
+    path: '/crisis-list/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedAccountIndexRoute =
   AuthenticatedAccountIndexRouteImport.update({
     id: '/account/',
@@ -118,6 +125,7 @@ export interface FileRoutesByFullPath {
   '/account/': typeof AuthenticatedAccountIndexRoute
   '/appointments/': typeof AuthenticatedAppointmentsIndexRoute
   '/barkley/': typeof AuthenticatedBarkleyIndexRoute
+  '/crisis-list/': typeof AuthenticatedCrisisListIndexRoute
   '/dashboard/': typeof AuthenticatedDashboardIndexRoute
   '/journal/': typeof AuthenticatedJournalIndexRoute
   '/medications/': typeof AuthenticatedMedicationsIndexRoute
@@ -134,6 +142,7 @@ export interface FileRoutesByTo {
   '/account': typeof AuthenticatedAccountIndexRoute
   '/appointments': typeof AuthenticatedAppointmentsIndexRoute
   '/barkley': typeof AuthenticatedBarkleyIndexRoute
+  '/crisis-list': typeof AuthenticatedCrisisListIndexRoute
   '/dashboard': typeof AuthenticatedDashboardIndexRoute
   '/journal': typeof AuthenticatedJournalIndexRoute
   '/medications': typeof AuthenticatedMedicationsIndexRoute
@@ -152,6 +161,7 @@ export interface FileRoutesById {
   '/_authenticated/account/': typeof AuthenticatedAccountIndexRoute
   '/_authenticated/appointments/': typeof AuthenticatedAppointmentsIndexRoute
   '/_authenticated/barkley/': typeof AuthenticatedBarkleyIndexRoute
+  '/_authenticated/crisis-list/': typeof AuthenticatedCrisisListIndexRoute
   '/_authenticated/dashboard/': typeof AuthenticatedDashboardIndexRoute
   '/_authenticated/journal/': typeof AuthenticatedJournalIndexRoute
   '/_authenticated/medications/': typeof AuthenticatedMedicationsIndexRoute
@@ -170,6 +180,7 @@ export interface FileRouteTypes {
     | '/account/'
     | '/appointments/'
     | '/barkley/'
+    | '/crisis-list/'
     | '/dashboard/'
     | '/journal/'
     | '/medications/'
@@ -186,6 +197,7 @@ export interface FileRouteTypes {
     | '/account'
     | '/appointments'
     | '/barkley'
+    | '/crisis-list'
     | '/dashboard'
     | '/journal'
     | '/medications'
@@ -203,6 +215,7 @@ export interface FileRouteTypes {
     | '/_authenticated/account/'
     | '/_authenticated/appointments/'
     | '/_authenticated/barkley/'
+    | '/_authenticated/crisis-list/'
     | '/_authenticated/dashboard/'
     | '/_authenticated/journal/'
     | '/_authenticated/medications/'
@@ -320,6 +333,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAppointmentsIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/crisis-list/': {
+      id: '/_authenticated/crisis-list/'
+      path: '/crisis-list'
+      fullPath: '/crisis-list/'
+      preLoaderRoute: typeof AuthenticatedCrisisListIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/account/': {
       id: '/_authenticated/account/'
       path: '/account'
@@ -334,6 +354,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAccountIndexRoute: typeof AuthenticatedAccountIndexRoute
   AuthenticatedAppointmentsIndexRoute: typeof AuthenticatedAppointmentsIndexRoute
   AuthenticatedBarkleyIndexRoute: typeof AuthenticatedBarkleyIndexRoute
+  AuthenticatedCrisisListIndexRoute: typeof AuthenticatedCrisisListIndexRoute
   AuthenticatedDashboardIndexRoute: typeof AuthenticatedDashboardIndexRoute
   AuthenticatedJournalIndexRoute: typeof AuthenticatedJournalIndexRoute
   AuthenticatedMedicationsIndexRoute: typeof AuthenticatedMedicationsIndexRoute
@@ -346,6 +367,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAccountIndexRoute: AuthenticatedAccountIndexRoute,
   AuthenticatedAppointmentsIndexRoute: AuthenticatedAppointmentsIndexRoute,
   AuthenticatedBarkleyIndexRoute: AuthenticatedBarkleyIndexRoute,
+  AuthenticatedCrisisListIndexRoute: AuthenticatedCrisisListIndexRoute,
   AuthenticatedDashboardIndexRoute: AuthenticatedDashboardIndexRoute,
   AuthenticatedJournalIndexRoute: AuthenticatedJournalIndexRoute,
   AuthenticatedMedicationsIndexRoute: AuthenticatedMedicationsIndexRoute,

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -17,6 +17,7 @@ import {
   ClipboardList,
   Trophy,
   UserCog,
+  HandHeart,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
@@ -38,6 +39,7 @@ export const Route = createFileRoute("/_authenticated")({
 const navItems = [
   { to: "/dashboard" as const, label: "Tableau de bord", icon: BarChart3 },
   { to: "/rewards" as const, label: "Récompenses", icon: Trophy },
+  { to: "/crisis-list" as const, label: "Liste de crise", icon: HandHeart },
   { to: "/symptoms" as const, label: "Symptômes", icon: Activity },
   { to: "/medications" as const, label: "Médicaments", icon: Pill },
   { to: "/journal" as const, label: "Journal", icon: BookOpen },

--- a/apps/web/src/routes/_authenticated/crisis-list/index.tsx
+++ b/apps/web/src/routes/_authenticated/crisis-list/index.tsx
@@ -1,0 +1,328 @@
+import { useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import {
+  Plus,
+  HandHeart,
+  Trash2,
+  ArrowUp,
+  ArrowDown,
+  X,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { PageLoader } from "@/components/ui/page-loader";
+import {
+  useCrisisItems,
+  useCreateCrisisItem,
+  useDeleteCrisisItem,
+  useReorderCrisisItems,
+} from "@/hooks/use-crisis-list";
+import { useUiStore } from "@/stores/ui-store";
+import type { CrisisItem } from "@focusflow/validators";
+
+export const Route = createFileRoute("/_authenticated/crisis-list/")({
+  component: CrisisListPage,
+});
+
+function CrisisListPage() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [crisisMode, setCrisisMode] = useState(false);
+  const activeChildId = useUiStore((s) => s.activeChildId);
+  const { data: items, isLoading } = useCrisisItems(activeChildId ?? "");
+
+  if (crisisMode && items?.length) {
+    return (
+      <CrisisView items={items} onClose={() => setCrisisMode(false)} />
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
+            Liste de la crise
+          </h1>
+          <p className="text-muted-foreground">
+            Les choses qui me font du bien quand ça ne va pas
+          </p>
+        </div>
+        <div className="flex gap-2">
+          {items && items.length > 0 && (
+            <Button
+              variant="outline"
+              onClick={() => setCrisisMode(true)}
+              className="border-blue-300 text-blue-700 hover:bg-blue-50 dark:border-blue-700 dark:text-blue-300 dark:hover:bg-blue-950"
+            >
+              <HandHeart className="mr-2 h-4 w-4" />
+              Mode crise
+            </Button>
+          )}
+          <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+            <DialogTrigger
+              render={
+                <Button>
+                  <Plus className="mr-2 h-4 w-4" />
+                  Ajouter
+                </Button>
+              }
+            />
+            <DialogContent className="sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle>
+                  Qu'est-ce qui te fait du bien ?
+                </DialogTitle>
+              </DialogHeader>
+              <CrisisItemForm onSuccess={() => setDialogOpen(false)} />
+            </DialogContent>
+          </Dialog>
+        </div>
+      </div>
+
+      {!activeChildId ? (
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            Sélectionnez un enfant pour voir sa liste de la crise.
+          </CardContent>
+        </Card>
+      ) : isLoading ? (
+        <PageLoader />
+      ) : !items?.length ? (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
+            <HandHeart className="h-10 w-10 text-muted-foreground/50" />
+            <p className="font-medium text-muted-foreground">
+              La liste est vide
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Construisez cette liste avec votre enfant : qu'est-ce qui lui fait
+              du bien quand ça ne va pas ?
+            </p>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="grid gap-3">
+          {items.map((item, index) => (
+            <CrisisItemCard
+              key={item.id}
+              item={item}
+              index={index}
+              total={items.length}
+              allItems={items}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Item Card ──────────────────────────────────────────
+
+function CrisisItemCard({
+  item,
+  index,
+  total,
+  allItems,
+}: {
+  item: CrisisItem;
+  index: number;
+  total: number;
+  allItems: CrisisItem[];
+}) {
+  const activeChildId = useUiStore((s) => s.activeChildId);
+  const deleteItem = useDeleteCrisisItem();
+  const reorder = useReorderCrisisItems();
+
+  const move = (direction: "up" | "down") => {
+    if (!activeChildId) return;
+    const ids = allItems.map((i) => i.id);
+    const swapIdx = direction === "up" ? index - 1 : index + 1;
+    [ids[index], ids[swapIdx]] = [ids[swapIdx]!, ids[index]!];
+    reorder.mutate({ childId: activeChildId, orderedIds: ids });
+  };
+
+  return (
+    <Card className="transition-all hover:shadow-sm">
+      <CardContent className="flex items-center gap-3 py-3 px-4">
+        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-xl dark:bg-blue-950">
+          {item.emoji || "💙"}
+        </span>
+        <span className="flex-1 text-sm font-medium">{item.label}</span>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => move("up")}
+            disabled={index === 0 || reorder.isPending}
+            className="rounded p-1.5 text-muted-foreground/50 hover:text-foreground disabled:opacity-30 transition-colors"
+          >
+            <ArrowUp className="h-3.5 w-3.5" />
+          </button>
+          <button
+            onClick={() => move("down")}
+            disabled={index === total - 1 || reorder.isPending}
+            className="rounded p-1.5 text-muted-foreground/50 hover:text-foreground disabled:opacity-30 transition-colors"
+          >
+            <ArrowDown className="h-3.5 w-3.5" />
+          </button>
+          <button
+            onClick={() =>
+              activeChildId &&
+              deleteItem.mutate({ id: item.id, childId: activeChildId })
+            }
+            disabled={deleteItem.isPending}
+            className="rounded p-1.5 text-muted-foreground/30 hover:text-destructive transition-colors"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Form ──────────────────────────────────────────────
+
+function CrisisItemForm({ onSuccess }: { onSuccess: () => void }) {
+  const activeChildId = useUiStore((s) => s.activeChildId);
+  const createItem = useCreateCrisisItem();
+  const [label, setLabel] = useState("");
+  const [emoji, setEmoji] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!activeChildId) return;
+
+    createItem.mutate(
+      {
+        childId: activeChildId,
+        label,
+        emoji: emoji || undefined,
+      },
+      { onSuccess }
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="crisis-label">
+          Qu'est-ce qui te fait du bien ?
+        </Label>
+        <Input
+          id="crisis-label"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          placeholder="Ex : Regarder mon dessin animé préféré"
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="crisis-emoji">Emoji (optionnel)</Label>
+        <Input
+          id="crisis-emoji"
+          value={emoji}
+          onChange={(e) => setEmoji(e.target.value)}
+          placeholder="Ex : 🧸"
+          maxLength={10}
+        />
+      </div>
+      <Button
+        type="submit"
+        className="w-full"
+        disabled={!activeChildId || !label || createItem.isPending}
+      >
+        {createItem.isPending ? "Enregistrement..." : "Ajouter à ma liste"}
+      </Button>
+    </form>
+  );
+}
+
+// ─── Crisis View (full-screen reading mode) ──────────────
+
+function CrisisView({
+  items,
+  onClose,
+}: {
+  items: CrisisItem[];
+  onClose: () => void;
+}) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const item = items[currentIndex]!;
+
+  const goNext = () =>
+    setCurrentIndex((i) => Math.min(i + 1, items.length - 1));
+  const goPrev = () => setCurrentIndex((i) => Math.max(i - 1, 0));
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-gradient-to-b from-blue-50 via-indigo-50 to-purple-50 dark:from-blue-950 dark:via-indigo-950 dark:to-purple-950">
+      {/* Close button */}
+      <button
+        onClick={onClose}
+        className="absolute right-4 top-4 rounded-full p-3 text-muted-foreground hover:bg-white/50 dark:hover:bg-white/10 transition-colors"
+      >
+        <X className="h-6 w-6" />
+      </button>
+
+      {/* Progress dots */}
+      <div className="absolute top-6 left-1/2 flex -translate-x-1/2 gap-2">
+        {items.map((_, i) => (
+          <button
+            key={i}
+            onClick={() => setCurrentIndex(i)}
+            className={`h-2.5 w-2.5 rounded-full transition-all ${
+              i === currentIndex
+                ? "bg-blue-500 scale-125"
+                : "bg-blue-300/40 dark:bg-blue-600/40"
+            }`}
+          />
+        ))}
+      </div>
+
+      {/* Main content */}
+      <div className="flex flex-col items-center gap-6 px-8 text-center">
+        <span className="text-6xl sm:text-7xl animate-bounce-slow">
+          {item.emoji || "💙"}
+        </span>
+        <p className="max-w-md text-2xl font-semibold leading-relaxed text-foreground sm:text-3xl">
+          {item.label}
+        </p>
+        <p className="text-sm text-muted-foreground">
+          {currentIndex + 1} / {items.length}
+        </p>
+      </div>
+
+      {/* Navigation */}
+      <div className="absolute bottom-8 flex gap-4">
+        <Button
+          variant="ghost"
+          size="lg"
+          onClick={goPrev}
+          disabled={currentIndex === 0}
+          className="h-14 w-14 rounded-full"
+        >
+          <ChevronLeft className="h-6 w-6" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="lg"
+          onClick={goNext}
+          disabled={currentIndex === items.length - 1}
+          className="h-14 w-14 rounded-full"
+        >
+          <ChevronRight className="h-6 w-6" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/db/drizzle/0008_white_terrax.sql
+++ b/packages/db/drizzle/0008_white_terrax.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "crisis_items" (
+	"id" text PRIMARY KEY NOT NULL,
+	"child_id" text NOT NULL,
+	"label" text NOT NULL,
+	"emoji" text,
+	"position" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "crisis_items" ADD CONSTRAINT "crisis_items_child_id_children_id_fk" FOREIGN KEY ("child_id") REFERENCES "public"."children"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/drizzle/meta/0008_snapshot.json
+++ b/packages/db/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,1319 @@
+{
+  "id": "4837146d-92bb-4e13-b2c1-77502fd7ae43",
+  "prevId": "dc851cd0-91cf-4a51-9ab5-0586ca3a5a4b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.children": {
+      "name": "children",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_type": {
+          "name": "diagnosis_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undefined'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "children_parent_id_user_id_fk": {
+          "name": "children_parent_id_user_id_fk",
+          "tableFrom": "children",
+          "tableTo": "user",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.symptoms": {
+      "name": "symptoms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agitation": {
+          "name": "agitation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "focus": {
+          "name": "focus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impulse": {
+          "name": "impulse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood": {
+          "name": "mood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sleep": {
+          "name": "sleep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social": {
+          "name": "social",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "autonomy": {
+          "name": "autonomy",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "symptoms_child_id_children_id_fk": {
+          "name": "symptoms_child_id_children_id_fk",
+          "tableFrom": "symptoms",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication": {
+      "name": "medication",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose": {
+          "name": "dose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medication_child_id_children_id_fk": {
+          "name": "medication_child_id_children_id_fk",
+          "tableFrom": "medication",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_logs": {
+      "name": "medication_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "medication_id": {
+          "name": "medication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taken_at": {
+          "name": "taken_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "medication_logs_medication_id_medication_id_fk": {
+          "name": "medication_logs_medication_id_medication_id_fk",
+          "tableFrom": "medication_logs",
+          "tableTo": "medication",
+          "columnsFrom": [
+            "medication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entries": {
+      "name": "journal_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "mood_rating": {
+          "name": "mood_rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "journal_entries_child_id_children_id_fk": {
+          "name": "journal_entries_child_id_children_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.appointments": {
+      "name": "appointments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "appointments_child_id_children_id_fk": {
+          "name": "appointments_child_id_children_id_fk",
+          "tableFrom": "appointments",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscription_stripe_subscription_id_unique": {
+          "name": "subscription_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_behavior_logs": {
+      "name": "barkley_behavior_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "behavior_id": {
+          "name": "behavior_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "barkley_behavior_logs_behavior_id_barkley_behaviors_id_fk": {
+          "name": "barkley_behavior_logs_behavior_id_barkley_behaviors_id_fk",
+          "tableFrom": "barkley_behavior_logs",
+          "tableTo": "barkley_behaviors",
+          "columnsFrom": [
+            "behavior_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "barkley_behavior_logs_behavior_id_date_unique": {
+          "name": "barkley_behavior_logs_behavior_id_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "behavior_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_behaviors": {
+      "name": "barkley_behaviors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "barkley_behaviors_child_id_children_id_fk": {
+          "name": "barkley_behaviors_child_id_children_id_fk",
+          "tableFrom": "barkley_behaviors",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_rewards": {
+      "name": "barkley_rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stars_required": {
+          "name": "stars_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "barkley_rewards_child_id_children_id_fk": {
+          "name": "barkley_rewards_child_id_children_id_fk",
+          "tableFrom": "barkley_rewards",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_steps": {
+      "name": "barkley_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "barkley_steps_child_id_children_id_fk": {
+          "name": "barkley_steps_child_id_children_id_fk",
+          "tableFrom": "barkley_steps",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "barkley_steps_child_id_step_number_unique": {
+          "name": "barkley_steps_child_id_step_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "child_id",
+            "step_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crisis_items": {
+      "name": "crisis_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "crisis_items_child_id_children_id_fk": {
+          "name": "crisis_items_child_id_children_id_fk",
+          "tableFrom": "crisis_items",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1774302689705,
       "tag": "0007_dapper_wildside",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1774303238876,
+      "tag": "0008_white_terrax",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/crisis-list.ts
+++ b/packages/db/src/schema/crisis-list.ts
@@ -1,0 +1,16 @@
+import { pgTable, text, integer, timestamp } from "drizzle-orm/pg-core";
+import { children } from "./children";
+
+export const crisisItems = pgTable("crisis_items", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  childId: text("child_id")
+    .notNull()
+    .references(() => children.id, { onDelete: "cascade" }),
+  label: text("label").notNull(),
+  emoji: text("emoji"),
+  position: integer("position").notNull().default(0),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -6,3 +6,4 @@ export * from "./journal";
 export * from "./appointments";
 export * from "./subscriptions";
 export * from "./barkley";
+export * from "./crisis-list";

--- a/packages/validators/src/crisis-item.ts
+++ b/packages/validators/src/crisis-item.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const createCrisisItemSchema = z.object({
+  childId: z.string().uuid(),
+  label: z.string().min(1).max(200),
+  emoji: z.string().max(10).optional(),
+  position: z.number().int().min(0).optional(),
+});
+
+export const updateCrisisItemSchema = createCrisisItemSchema
+  .partial()
+  .omit({ childId: true });
+
+export const reorderCrisisItemsSchema = z.object({
+  childId: z.string().uuid(),
+  orderedIds: z.array(z.string().uuid()).min(1),
+});
+
+export const crisisItemSchema = createCrisisItemSchema.extend({
+  id: z.string().uuid(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
+});
+
+export type CreateCrisisItem = z.infer<typeof createCrisisItemSchema>;
+export type UpdateCrisisItem = z.infer<typeof updateCrisisItemSchema>;
+export type ReorderCrisisItems = z.infer<typeof reorderCrisisItemsSchema>;
+export type CrisisItem = z.infer<typeof crisisItemSchema>;

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -5,3 +5,4 @@ export * from "./medication";
 export * from "./journal";
 export * from "./appointment";
 export * from "./barkley";
+export * from "./crisis-item";


### PR DESCRIPTION
## Résumé technique

### Contexte
Nouvelle fonctionnalité "Liste de la crise" — une liste personnalisée d'éléments réconfortants que l'enfant TDAH crée lui-même (ou avec son parent) pour s'aider à se calmer pendant les moments de crise. L'idée vient d'un vrai enfant qui a découvert que simplement penser à sa liste l'aidait à se calmer.

### Approche retenue
Feature full-stack suivant les patterns existants du monorepo (schema → validator → route → hook → page). Deux modes d'affichage : **mode édition** (construction de la liste) et **mode crise** (plein écran, un élément à la fois, UI apaisante). Une seule table plate `crisis_items` avec tri par position — pas de sur-ingénierie pour une liste courte (5-15 items).

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `packages/db/src/schema/crisis-list.ts` | Nouvelle table `crisis_items` | Table plate avec label, emoji, position — suit le pattern des autres domaines |
| `packages/validators/src/crisis-item.ts` | Schemas Zod create/update/reorder/response | Validation partagée FE/BE, reorder accepte un tableau ordonné d'IDs |
| `apps/api/src/routes/crisis-list.ts` | CRUD + endpoint reorder | 5 endpoints avec vérification ownership parentId, position auto-incrémentée |
| `apps/web/src/hooks/use-crisis-list.ts` | Hooks React Query | Query key factory + mutations avec invalidation cache |
| `apps/web/src/routes/_authenticated/crisis-list/index.tsx` | Page avec mode édition + mode crise | Mode crise = overlay plein écran, navigation par items, UI calme (gradient bleu/violet) |
| `apps/web/src/routes/_authenticated.tsx` | Entrée nav sidebar | Icône HandHeart, positionné après Récompenses |
| `apps/web/src/routeTree.gen.ts` | Route tree mise à jour | Ajout de la route `/crisis-list` |
| `packages/db/drizzle/0008_white_terrax.sql` | Migration SQL | CREATE TABLE crisis_items |

### Points d'attention pour la revue
- Le mode crise utilise un overlay `fixed inset-0 z-50` — vérifier qu'il n'y a pas de conflit z-index avec d'autres modales
- Le réordonnement met à jour les positions dans une boucle (acceptable pour <15 items, pas de transaction SQL explicite)
- Le langage de l'UI est volontairement enfantin ("Qu'est-ce qui te fait du bien ?") — c'est intentionnel
- Pas de drag-and-drop pour V1 — boutons up/down pour simplicité mobile

### Tests
- 18 exécutés, 18 passés, 0 échoué (validators: 12, db: 5, api: 1)
- Typecheck OK sur tous les packages

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation des tests
- [ ] Merge après approbation

> ⚠️ Attention : d'autres branches fast-meeting sont actives (`fm-reward-board`, etc.). Vérifier les conflits potentiels avant merge.

---
_Implémentation générée automatiquement par IA_