### PR TITLE
fix(rewards): unify weekly behavior board with rewards page

### DIFF
--- a/apps/web/src/components/barkley/behavior-tracking.tsx
+++ b/apps/web/src/components/barkley/behavior-tracking.tsx
@@ -1,0 +1,443 @@
+import { useState, useMemo } from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  Trash2,
+} from "lucide-react";
+import { PageLoader } from "@/components/ui/page-loader";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  useBarkleyLogs,
+  useCreateBarkleyBehavior,
+  useDeleteBarkleyBehavior,
+  useToggleBarkleyLog,
+} from "@/hooks/use-barkley";
+import { useChild } from "@/hooks/use-children";
+
+const DAY_LABELS = ["Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"];
+
+const BARKLEY_TIPS = [
+  { title: "Immédiateté", desc: "Étoile juste après le geste" },
+  { title: "Positivité", desc: "Jamais retirer une étoile" },
+  { title: "Régularité", desc: "Chaque jour avec votre enfant" },
+  { title: "Progressivité", desc: "2-3 gestes au début" },
+  { title: "Valorisation", desc: "Un bravo à chaque étoile" },
+];
+
+function getMonday(d: Date): Date {
+  const date = new Date(d);
+  const day = date.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  date.setDate(date.getDate() + diff);
+  date.setHours(0, 0, 0, 0);
+  return date;
+}
+
+function formatDate(d: Date): string {
+  return d.toISOString().split("T")[0] as string;
+}
+
+function formatWeekLabel(monday: Date): string {
+  return `Semaine du ${monday.getDate()} ${monday.toLocaleDateString("fr-FR", { month: "long", year: "numeric" })}`;
+}
+
+export function BehaviorTracking({ childId }: { childId: string }) {
+  const [currentMonday, setCurrentMonday] = useState(() =>
+    getMonday(new Date())
+  );
+  const [behaviorDialogOpen, setBehaviorDialogOpen] = useState(false);
+
+  const { data: child } = useChild(childId);
+  const week = formatDate(currentMonday);
+  const { data, isLoading } = useBarkleyLogs(childId, week);
+  const toggleLog = useToggleBarkleyLog();
+  const deleteBehavior = useDeleteBarkleyBehavior();
+
+  const behaviors = data?.behaviors?.filter((b) => b.active) ?? [];
+  const logs = data?.logs ?? [];
+
+  const logMap = useMemo(() => {
+    const map = new Map<string, Map<string, boolean>>();
+    logs.forEach((l) => {
+      if (!map.has(l.behaviorId)) map.set(l.behaviorId, new Map());
+      map.get(l.behaviorId)!.set(l.date, l.completed);
+    });
+    return map;
+  }, [logs]);
+
+  const weekDates = useMemo(() => {
+    return Array.from({ length: 7 }, (_, i) => {
+      const d = new Date(currentMonday);
+      d.setDate(d.getDate() + i);
+      return formatDate(d);
+    });
+  }, [currentMonday]);
+
+  const isChecked = (behaviorId: string, date: string) =>
+    logMap.get(behaviorId)?.get(date) ?? false;
+
+  const handleToggle = (behaviorId: string, date: string) => {
+    const current = isChecked(behaviorId, date);
+    toggleLog.mutate({
+      behaviorId,
+      date,
+      completed: !current,
+      childId,
+      week,
+    });
+  };
+
+  const handlePrevWeek = () => {
+    const d = new Date(currentMonday);
+    d.setDate(d.getDate() - 7);
+    setCurrentMonday(d);
+  };
+
+  const handleNextWeek = () => {
+    const d = new Date(currentMonday);
+    d.setDate(d.getDate() + 7);
+    setCurrentMonday(d);
+  };
+
+  const weeklyStars = useMemo(() => {
+    let total = 0;
+    behaviors.forEach((b) => {
+      weekDates.forEach((date) => {
+        if (isChecked(b.id, date)) total++;
+      });
+    });
+    return total;
+  }, [behaviors, weekDates, logMap]);
+
+  const maxStars = behaviors.length * 7;
+  const childName = child?.name ?? "...";
+
+  if (isLoading) {
+    return <PageLoader />;
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Personalized header */}
+      <div className="relative overflow-hidden rounded-xl bg-gradient-to-r from-indigo-500 via-purple-500 to-indigo-600 px-6 py-5 text-white shadow-lg">
+        <div className="absolute inset-0 opacity-10">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <span
+              key={i}
+              className="absolute text-2xl"
+              style={{
+                top: `${Math.random() * 80}%`,
+                left: `${Math.random() * 95}%`,
+                transform: `rotate(${Math.random() * 40 - 20}deg)`,
+                opacity: 0.4 + Math.random() * 0.6,
+              }}
+            >
+              ⭐
+            </span>
+          ))}
+        </div>
+        <div className="relative text-center">
+          <h2 className="text-2xl font-bold font-heading">
+            ⭐ Le Tableau de {childName} ⭐
+          </h2>
+          <div className="mt-2 flex items-center justify-center gap-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handlePrevWeek}
+              className="h-7 w-7 text-white/80 hover:text-white hover:bg-white/20"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </Button>
+            <span className="text-sm font-medium text-white/90">
+              {formatWeekLabel(currentMonday)}
+            </span>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={handleNextWeek}
+              className="h-7 w-7 text-white/80 hover:text-white hover:bg-white/20"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </Button>
+          </div>
+          {maxStars > 0 && (
+            <p className="mt-1 text-sm text-white/80">
+              {weeklyStars} / {maxStars} ⭐ cette semaine
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Behavior tracking grid */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+            Comportements
+          </h3>
+          <Dialog
+            open={behaviorDialogOpen}
+            onOpenChange={setBehaviorDialogOpen}
+          >
+            <DialogTrigger
+              render={
+                <Button size="sm" variant="outline">
+                  <Plus className="mr-1.5 h-3.5 w-3.5" />
+                  Ajouter
+                </Button>
+              }
+            />
+            <DialogContent className="sm:max-w-md">
+              <DialogHeader>
+                <DialogTitle>Nouveau comportement</DialogTitle>
+              </DialogHeader>
+              <BehaviorForm
+                childId={childId}
+                onSuccess={() => setBehaviorDialogOpen(false)}
+              />
+            </DialogContent>
+          </Dialog>
+        </div>
+
+        {behaviors.length === 0 ? (
+          <Card>
+            <CardContent className="py-8 text-center text-muted-foreground">
+              <p>
+                Ajoutez des comportements pour commencer le suivi
+                hebdomadaire.
+              </p>
+            </CardContent>
+          </Card>
+        ) : (
+          <>
+            {/* Desktop grid view */}
+            <Card className="hidden sm:block overflow-hidden">
+              <div className="grid grid-cols-[1fr_repeat(7,_minmax(36px,_1fr))_40px] border-b bg-muted/50 px-3 py-2">
+                <div className="text-xs font-medium text-muted-foreground" />
+                {DAY_LABELS.map((day, i) => (
+                  <div
+                    key={day}
+                    className="text-center text-xs font-semibold text-muted-foreground"
+                  >
+                    <div>{day}</div>
+                    <div className="text-[10px] text-muted-foreground/60">
+                      {new Date(weekDates[i]! + "T00:00:00").getDate()}
+                    </div>
+                  </div>
+                ))}
+                <div />
+              </div>
+
+              {behaviors.map((behavior, idx) => (
+                <div
+                  key={behavior.id}
+                  className={`grid grid-cols-[1fr_repeat(7,_minmax(36px,_1fr))_40px] items-center px-3 py-2.5 ${
+                    idx < behaviors.length - 1 ? "border-b" : ""
+                  } hover:bg-muted/30 transition-colors`}
+                >
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-base shrink-0">
+                      {behavior.icon || "✅"}
+                    </span>
+                    <span className="text-sm font-medium truncate">
+                      {behavior.name}
+                    </span>
+                  </div>
+
+                  {weekDates.map((date) => {
+                    const checked = isChecked(behavior.id, date);
+                    return (
+                      <div key={date} className="flex justify-center">
+                        <button
+                          onClick={() => handleToggle(behavior.id, date)}
+                          className={`flex h-8 w-8 items-center justify-center rounded-full transition-all ${
+                            checked
+                              ? "scale-110"
+                              : "hover:bg-muted/50 hover:scale-105"
+                          }`}
+                          disabled={toggleLog.isPending}
+                          title={
+                            checked
+                              ? "Retirer l'étoile"
+                              : "Ajouter une étoile"
+                          }
+                        >
+                          {checked ? (
+                            <span className="text-xl leading-none">⭐</span>
+                          ) : (
+                            <span className="text-muted-foreground/30 text-lg leading-none">
+                              ☆
+                            </span>
+                          )}
+                        </button>
+                      </div>
+                    );
+                  })}
+
+                  <div className="flex justify-center">
+                    <button
+                      onClick={() =>
+                        deleteBehavior.mutate({ id: behavior.id, childId })
+                      }
+                      className="text-muted-foreground/40 hover:text-destructive transition-colors p-1 rounded"
+                      disabled={deleteBehavior.isPending}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </Card>
+
+            {/* Mobile card view */}
+            <div className="sm:hidden space-y-3">
+              {behaviors.map((behavior) => (
+                <Card key={behavior.id} className="overflow-hidden">
+                  <CardContent className="py-3 px-4">
+                    <div className="flex items-center justify-between mb-2">
+                      <div className="flex items-center gap-2 min-w-0">
+                        <span className="text-lg shrink-0">
+                          {behavior.icon || "✅"}
+                        </span>
+                        <span className="text-sm font-semibold truncate">
+                          {behavior.name}
+                        </span>
+                      </div>
+                      <button
+                        onClick={() =>
+                          deleteBehavior.mutate({ id: behavior.id, childId })
+                        }
+                        className="text-muted-foreground/40 hover:text-destructive transition-colors p-1 rounded shrink-0"
+                        disabled={deleteBehavior.isPending}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </button>
+                    </div>
+                    <div className="flex justify-between gap-1">
+                      {weekDates.map((date, i) => {
+                        const checked = isChecked(behavior.id, date);
+                        return (
+                          <button
+                            key={date}
+                            onClick={() => handleToggle(behavior.id, date)}
+                            className={`flex flex-col items-center gap-0.5 rounded-lg px-1.5 py-1.5 transition-all flex-1 min-w-0 ${
+                              checked
+                                ? "bg-amber-50 dark:bg-amber-950/20"
+                                : "hover:bg-muted/50"
+                            }`}
+                            disabled={toggleLog.isPending}
+                          >
+                            <span className="text-[10px] font-medium text-muted-foreground">
+                              {DAY_LABELS[i]}
+                            </span>
+                            {checked ? (
+                              <span className="text-lg leading-none">⭐</span>
+                            ) : (
+                              <span className="text-muted-foreground/30 text-lg leading-none">
+                                ☆
+                              </span>
+                            )}
+                          </button>
+                        );
+                      })}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* Barkley tips */}
+      <Card className="bg-gradient-to-r from-indigo-50/60 to-purple-50/60 dark:from-indigo-950/20 dark:to-purple-950/20 border-indigo-200/40 dark:border-indigo-800/30">
+        <CardContent className="py-3 px-4">
+          <p className="text-xs font-semibold text-indigo-700 dark:text-indigo-300 mb-2">
+            Conseils Barkley
+          </p>
+          <div className="flex flex-wrap gap-x-4 gap-y-1">
+            {BARKLEY_TIPS.map((tip) => (
+              <p key={tip.title} className="text-xs text-muted-foreground">
+                <span className="font-semibold text-foreground/80">
+                  {tip.title}
+                </span>
+                {" — "}
+                {tip.desc}
+              </p>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ─── Behavior Form ────────────────────────────────────────
+
+function BehaviorForm({
+  childId,
+  onSuccess,
+}: {
+  childId: string;
+  onSuccess: () => void;
+}) {
+  const createBehavior = useCreateBarkleyBehavior();
+  const [name, setName] = useState("");
+  const [icon, setIcon] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    createBehavior.mutate(
+      {
+        childId,
+        name,
+        points: 1,
+        icon: icon || undefined,
+      },
+      { onSuccess }
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="beh-name">Nom du comportement</Label>
+        <Input
+          id="beh-name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Ex: Je range ma chambre"
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="beh-icon">Icône (emoji)</Label>
+        <Input
+          id="beh-icon"
+          value={icon}
+          onChange={(e) => setIcon(e.target.value)}
+          placeholder="Ex: 🧹"
+          maxLength={10}
+        />
+      </div>
+      <Button
+        type="submit"
+        className="w-full"
+        disabled={!name || createBehavior.isPending}
+      >
+        {createBehavior.isPending ? "Enregistrement..." : "Ajouter"}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/hooks/use-barkley.ts
+++ b/apps/web/src/hooks/use-barkley.ts
@@ -130,10 +130,14 @@ export function useToggleBarkleyLog() {
     mutationFn: (
       data: CreateBarkleyBehaviorLog & { childId: string; week: string }
     ) => api.post<BarkleyBehaviorLog>("/barkley/logs", data),
-    onSuccess: (_, variables) =>
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: barkleyKeys.logs(variables.childId, variables.week),
-      }),
+      });
+      queryClient.invalidateQueries({
+        queryKey: barkleyKeys.stars(variables.childId),
+      });
+    },
   });
 }
 

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -45,7 +45,7 @@ const navItems = [
   { to: "/journal" as const, label: "Journal", icon: BookOpen },
   { to: "/appointments" as const, label: "Rendez-vous", icon: CalendarDays },
   { to: "/report" as const, label: "Rapport", icon: FileText },
-  { to: "/barkley" as const, label: "Suivi Barkley", icon: ClipboardList },
+  { to: "/barkley" as const, label: "Programme Barkley", icon: ClipboardList },
   { to: "/account" as const, label: "Mon compte", icon: UserCog },
 ];
 

--- a/apps/web/src/routes/_authenticated/barkley/index.tsx
+++ b/apps/web/src/routes/_authenticated/barkley/index.tsx
@@ -1,36 +1,14 @@
-import { useState, useMemo } from "react";
+import { useMemo } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import {
-  Check,
-  ChevronLeft,
-  ChevronRight,
-  Plus,
-  Trash2,
-} from "lucide-react";
+import { Check } from "lucide-react";
 import { PageLoader } from "@/components/ui/page-loader";
 import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Progress, ProgressLabel, ProgressValue } from "@/components/ui/progress";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
 import {
   useBarkleySteps,
   useCompleteBarkleyStep,
   useDeleteBarkleyStep,
-  useBarkleyLogs,
-  useCreateBarkleyBehavior,
-  useDeleteBarkleyBehavior,
-  useToggleBarkleyLog,
 } from "@/hooks/use-barkley";
-import { useChild } from "@/hooks/use-children";
 import { useUiStore } from "@/stores/ui-store";
 
 export const Route = createFileRoute("/_authenticated/barkley/")({
@@ -56,48 +34,6 @@ const BARKLEY_STEPS = [
   { number: 10, title: "Bilan et maintien des acquis" },
 ];
 
-const DAY_LABELS = ["Lun", "Mar", "Mer", "Jeu", "Ven", "Sam", "Dim"];
-
-const BARKLEY_TIPS = [
-  {
-    title: "Immédiateté",
-    desc: "Étoile juste après le geste",
-  },
-  {
-    title: "Positivité",
-    desc: "Jamais retirer une étoile",
-  },
-  {
-    title: "Régularité",
-    desc: "Chaque jour avec votre enfant",
-  },
-  {
-    title: "Progressivité",
-    desc: "2-3 gestes au début",
-  },
-  {
-    title: "Valorisation",
-    desc: "Un bravo à chaque étoile",
-  },
-];
-
-function getMonday(d: Date): Date {
-  const date = new Date(d);
-  const day = date.getDay();
-  const diff = day === 0 ? -6 : 1 - day;
-  date.setDate(date.getDate() + diff);
-  date.setHours(0, 0, 0, 0);
-  return date;
-}
-
-function formatDate(d: Date): string {
-  return d.toISOString().split("T")[0] as string;
-}
-
-function formatWeekLabel(monday: Date): string {
-  return `Semaine du ${monday.getDate()} ${monday.toLocaleDateString("fr-FR", { month: "long", year: "numeric" })}`;
-}
-
 function BarkleyPage() {
   const activeChildId = useUiStore((s) => s.activeChildId);
 
@@ -106,7 +42,7 @@ function BarkleyPage() {
       <div className="space-y-6">
         <div>
           <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
-            Suivi Barkley
+            Programme Barkley
           </h1>
           <p className="text-muted-foreground">
             Programme d'entraînement aux habiletés parentales (PEHP)
@@ -114,7 +50,7 @@ function BarkleyPage() {
         </div>
         <Card>
           <CardContent className="py-8 text-center text-muted-foreground">
-            Sélectionnez un enfant pour accéder au suivi Barkley.
+            Sélectionnez un enfant pour accéder au programme Barkley.
           </CardContent>
         </Card>
       </div>
@@ -124,357 +60,15 @@ function BarkleyPage() {
   return (
     <div className="space-y-6">
       <div>
-        <h1 className="text-xl font-bold tracking-tight sm:text-2xl">Suivi Barkley</h1>
+        <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
+          Programme Barkley
+        </h1>
         <p className="text-muted-foreground">
           Programme d'entraînement aux habiletés parentales (PEHP)
         </p>
       </div>
 
-      <Tabs defaultValue="suivi">
-        <TabsList className="grid w-full grid-cols-2">
-          <TabsTrigger value="suivi">Suivi hebdomadaire</TabsTrigger>
-          <TabsTrigger value="programme">Programme</TabsTrigger>
-        </TabsList>
-        <TabsContent value="suivi">
-          <BehaviorTracking childId={activeChildId} />
-        </TabsContent>
-        <TabsContent value="programme">
-          <ProgrammeTab childId={activeChildId} />
-        </TabsContent>
-      </Tabs>
-    </div>
-  );
-}
-
-// ─── Behavior Tracking (weekly star grid) ─────────────────
-
-function BehaviorTracking({ childId }: { childId: string }) {
-  const [currentMonday, setCurrentMonday] = useState(() =>
-    getMonday(new Date())
-  );
-  const [behaviorDialogOpen, setBehaviorDialogOpen] = useState(false);
-
-  const { data: child } = useChild(childId);
-  const week = formatDate(currentMonday);
-  const { data, isLoading } = useBarkleyLogs(childId, week);
-  const toggleLog = useToggleBarkleyLog();
-  const deleteBehavior = useDeleteBarkleyBehavior();
-
-  const behaviors = data?.behaviors?.filter((b) => b.active) ?? [];
-  const logs = data?.logs ?? [];
-
-  const logMap = useMemo(() => {
-    const map = new Map<string, Map<string, boolean>>();
-    logs.forEach((l) => {
-      if (!map.has(l.behaviorId)) map.set(l.behaviorId, new Map());
-      map.get(l.behaviorId)!.set(l.date, l.completed);
-    });
-    return map;
-  }, [logs]);
-
-  const weekDates = useMemo(() => {
-    return Array.from({ length: 7 }, (_, i) => {
-      const d = new Date(currentMonday);
-      d.setDate(d.getDate() + i);
-      return formatDate(d);
-    });
-  }, [currentMonday]);
-
-  const isChecked = (behaviorId: string, date: string) =>
-    logMap.get(behaviorId)?.get(date) ?? false;
-
-  const handleToggle = (behaviorId: string, date: string) => {
-    const current = isChecked(behaviorId, date);
-    toggleLog.mutate({
-      behaviorId,
-      date,
-      completed: !current,
-      childId,
-      week,
-    });
-  };
-
-  const handlePrevWeek = () => {
-    const d = new Date(currentMonday);
-    d.setDate(d.getDate() - 7);
-    setCurrentMonday(d);
-  };
-
-  const handleNextWeek = () => {
-    const d = new Date(currentMonday);
-    d.setDate(d.getDate() + 7);
-    setCurrentMonday(d);
-  };
-
-  const weeklyStars = useMemo(() => {
-    let total = 0;
-    behaviors.forEach((b) => {
-      weekDates.forEach((date) => {
-        if (isChecked(b.id, date)) total++;
-      });
-    });
-    return total;
-  }, [behaviors, weekDates, logMap]);
-
-  const maxStars = behaviors.length * 7;
-  const childName = child?.name ?? "...";
-
-  if (isLoading) {
-    return <PageLoader />;
-  }
-
-  return (
-    <div className="mt-4 space-y-4">
-      {/* Personalized header */}
-      <div className="relative overflow-hidden rounded-xl bg-gradient-to-r from-indigo-500 via-purple-500 to-indigo-600 px-6 py-5 text-white shadow-lg">
-        <div className="absolute inset-0 opacity-10">
-          {Array.from({ length: 12 }).map((_, i) => (
-            <span
-              key={i}
-              className="absolute text-2xl"
-              style={{
-                top: `${Math.random() * 80}%`,
-                left: `${Math.random() * 95}%`,
-                transform: `rotate(${Math.random() * 40 - 20}deg)`,
-                opacity: 0.4 + Math.random() * 0.6,
-              }}
-            >
-              ⭐
-            </span>
-          ))}
-        </div>
-        <div className="relative text-center">
-          <h2 className="text-2xl font-bold font-heading">
-            ⭐ Le Tableau de {childName} ⭐
-          </h2>
-          <div className="mt-2 flex items-center justify-center gap-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={handlePrevWeek}
-              className="h-7 w-7 text-white/80 hover:text-white hover:bg-white/20"
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-            <span className="text-sm font-medium text-white/90">
-              {formatWeekLabel(currentMonday)}
-            </span>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={handleNextWeek}
-              className="h-7 w-7 text-white/80 hover:text-white hover:bg-white/20"
-            >
-              <ChevronRight className="h-4 w-4" />
-            </Button>
-          </div>
-          {maxStars > 0 && (
-            <p className="mt-1 text-sm text-white/80">
-              {weeklyStars} / {maxStars} ⭐ cette semaine
-            </p>
-          )}
-        </div>
-      </div>
-
-      {/* Behavior tracking grid */}
-      <div className="space-y-3">
-        <div className="flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
-            Comportements
-          </h3>
-          <Dialog
-            open={behaviorDialogOpen}
-            onOpenChange={setBehaviorDialogOpen}
-          >
-            <DialogTrigger
-              render={
-                <Button size="sm" variant="outline">
-                  <Plus className="mr-1.5 h-3.5 w-3.5" />
-                  Ajouter
-                </Button>
-              }
-            />
-            <DialogContent className="sm:max-w-md">
-              <DialogHeader>
-                <DialogTitle>Nouveau comportement</DialogTitle>
-              </DialogHeader>
-              <BehaviorForm
-                childId={childId}
-                onSuccess={() => setBehaviorDialogOpen(false)}
-              />
-            </DialogContent>
-          </Dialog>
-        </div>
-
-        {behaviors.length === 0 ? (
-          <Card>
-            <CardContent className="py-8 text-center text-muted-foreground">
-              <p>
-                Ajoutez des comportements pour commencer le suivi
-                hebdomadaire.
-              </p>
-            </CardContent>
-          </Card>
-        ) : (
-          <>
-            {/* Desktop grid view */}
-            <Card className="hidden sm:block overflow-hidden">
-              <div className="grid grid-cols-[1fr_repeat(7,_minmax(36px,_1fr))_40px] border-b bg-muted/50 px-3 py-2">
-                <div className="text-xs font-medium text-muted-foreground" />
-                {DAY_LABELS.map((day, i) => (
-                  <div
-                    key={day}
-                    className="text-center text-xs font-semibold text-muted-foreground"
-                  >
-                    <div>{day}</div>
-                    <div className="text-[10px] text-muted-foreground/60">
-                      {new Date(weekDates[i]! + "T00:00:00").getDate()}
-                    </div>
-                  </div>
-                ))}
-                <div />
-              </div>
-
-              {behaviors.map((behavior, idx) => (
-                <div
-                  key={behavior.id}
-                  className={`grid grid-cols-[1fr_repeat(7,_minmax(36px,_1fr))_40px] items-center px-3 py-2.5 ${
-                    idx < behaviors.length - 1 ? "border-b" : ""
-                  } hover:bg-muted/30 transition-colors`}
-                >
-                  <div className="flex items-center gap-2 min-w-0">
-                    <span className="text-base shrink-0">
-                      {behavior.icon || "✅"}
-                    </span>
-                    <span className="text-sm font-medium truncate">
-                      {behavior.name}
-                    </span>
-                  </div>
-
-                  {weekDates.map((date) => {
-                    const checked = isChecked(behavior.id, date);
-                    return (
-                      <div key={date} className="flex justify-center">
-                        <button
-                          onClick={() => handleToggle(behavior.id, date)}
-                          className={`flex h-8 w-8 items-center justify-center rounded-full transition-all ${
-                            checked
-                              ? "scale-110"
-                              : "hover:bg-muted/50 hover:scale-105"
-                          }`}
-                          disabled={toggleLog.isPending}
-                          title={
-                            checked
-                              ? "Retirer l'étoile"
-                              : "Ajouter une étoile"
-                          }
-                        >
-                          {checked ? (
-                            <span className="text-xl leading-none">⭐</span>
-                          ) : (
-                            <span className="text-muted-foreground/30 text-lg leading-none">
-                              ☆
-                            </span>
-                          )}
-                        </button>
-                      </div>
-                    );
-                  })}
-
-                  <div className="flex justify-center">
-                    <button
-                      onClick={() =>
-                        deleteBehavior.mutate({ id: behavior.id, childId })
-                      }
-                      className="text-muted-foreground/40 hover:text-destructive transition-colors p-1 rounded"
-                      disabled={deleteBehavior.isPending}
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </button>
-                  </div>
-                </div>
-              ))}
-            </Card>
-
-            {/* Mobile card view */}
-            <div className="sm:hidden space-y-3">
-              {behaviors.map((behavior) => (
-                <Card key={behavior.id} className="overflow-hidden">
-                  <CardContent className="py-3 px-4">
-                    <div className="flex items-center justify-between mb-2">
-                      <div className="flex items-center gap-2 min-w-0">
-                        <span className="text-lg shrink-0">
-                          {behavior.icon || "✅"}
-                        </span>
-                        <span className="text-sm font-semibold truncate">
-                          {behavior.name}
-                        </span>
-                      </div>
-                      <button
-                        onClick={() =>
-                          deleteBehavior.mutate({ id: behavior.id, childId })
-                        }
-                        className="text-muted-foreground/40 hover:text-destructive transition-colors p-1 rounded shrink-0"
-                        disabled={deleteBehavior.isPending}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
-                    <div className="flex justify-between gap-1">
-                      {weekDates.map((date, i) => {
-                        const checked = isChecked(behavior.id, date);
-                        return (
-                          <button
-                            key={date}
-                            onClick={() => handleToggle(behavior.id, date)}
-                            className={`flex flex-col items-center gap-0.5 rounded-lg px-1.5 py-1.5 transition-all flex-1 min-w-0 ${
-                              checked
-                                ? "bg-amber-50 dark:bg-amber-950/20"
-                                : "hover:bg-muted/50"
-                            }`}
-                            disabled={toggleLog.isPending}
-                          >
-                            <span className="text-[10px] font-medium text-muted-foreground">
-                              {DAY_LABELS[i]}
-                            </span>
-                            {checked ? (
-                              <span className="text-lg leading-none">⭐</span>
-                            ) : (
-                              <span className="text-muted-foreground/30 text-lg leading-none">
-                                ☆
-                              </span>
-                            )}
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </CardContent>
-                </Card>
-              ))}
-            </div>
-          </>
-        )}
-      </div>
-
-      {/* Barkley tips */}
-      <Card className="bg-gradient-to-r from-indigo-50/60 to-purple-50/60 dark:from-indigo-950/20 dark:to-purple-950/20 border-indigo-200/40 dark:border-indigo-800/30">
-        <CardContent className="py-3 px-4">
-          <p className="text-xs font-semibold text-indigo-700 dark:text-indigo-300 mb-2">
-            Conseils Barkley
-          </p>
-          <div className="flex flex-wrap gap-x-4 gap-y-1">
-            {BARKLEY_TIPS.map((tip) => (
-              <p key={tip.title} className="text-xs text-muted-foreground">
-                <span className="font-semibold text-foreground/80">
-                  {tip.title}
-                </span>
-                {" — "}
-                {tip.desc}
-              </p>
-            ))}
-          </div>
-        </CardContent>
-      </Card>
+      <ProgrammeTab childId={activeChildId} />
     </div>
   );
 }
@@ -515,7 +109,7 @@ function ProgrammeTab({ childId }: { childId: string }) {
   }
 
   return (
-    <div className="mt-4 space-y-4">
+    <div className="space-y-4">
       <Card>
         <CardContent className="py-4">
           <Progress value={progressValue}>
@@ -583,64 +177,5 @@ function ProgrammeTab({ childId }: { childId: string }) {
         })}
       </div>
     </div>
-  );
-}
-
-// ─── Behavior Form ────────────────────────────────────────
-
-function BehaviorForm({
-  childId,
-  onSuccess,
-}: {
-  childId: string;
-  onSuccess: () => void;
-}) {
-  const createBehavior = useCreateBarkleyBehavior();
-  const [name, setName] = useState("");
-  const [icon, setIcon] = useState("");
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    createBehavior.mutate(
-      {
-        childId,
-        name,
-        points: 1,
-        icon: icon || undefined,
-      },
-      { onSuccess }
-    );
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="space-y-2">
-        <Label htmlFor="beh-name">Nom du comportement</Label>
-        <Input
-          id="beh-name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Ex: Je range ma chambre"
-          required
-        />
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="beh-icon">Icône (emoji)</Label>
-        <Input
-          id="beh-icon"
-          value={icon}
-          onChange={(e) => setIcon(e.target.value)}
-          placeholder="Ex: 🧹"
-          maxLength={10}
-        />
-      </div>
-      <Button
-        type="submit"
-        className="w-full"
-        disabled={!name || createBehavior.isPending}
-      >
-        {createBehavior.isPending ? "Enregistrement..." : "Ajouter"}
-      </Button>
-    </form>
   );
 }

--- a/apps/web/src/routes/_authenticated/rewards/index.tsx
+++ b/apps/web/src/routes/_authenticated/rewards/index.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/hooks/use-barkley";
 import { useChild } from "@/hooks/use-children";
 import { useUiStore } from "@/stores/ui-store";
+import { BehaviorTracking } from "@/components/barkley/behavior-tracking";
 
 export const Route = createFileRoute("/_authenticated/rewards/")({
   component: RewardsPage,
@@ -74,7 +75,6 @@ function RewardBoard({ childId }: { childId: string }) {
   const childName = child?.name ?? "...";
 
   const sortedRewards = [...rewards].sort((a, b) => {
-    // Claimed last, then by starsRequired ascending
     if (a.claimedAt && !b.claimedAt) return 1;
     if (!a.claimedAt && b.claimedAt) return -1;
     return (a.starsRequired ?? 0) - (b.starsRequired ?? 0);
@@ -86,44 +86,26 @@ function RewardBoard({ childId }: { childId: string }) {
 
   return (
     <div className="space-y-6">
-      {/* Hero header with star count */}
-      <div className="relative overflow-hidden rounded-xl bg-gradient-to-r from-amber-500 via-orange-500 to-amber-600 px-6 py-6 text-white shadow-lg">
-        <div className="absolute inset-0 opacity-10">
-          {Array.from({ length: 8 }).map((_, i) => (
-            <span
-              key={i}
-              className="absolute text-2xl"
-              style={{
-                top: `${Math.random() * 80}%`,
-                left: `${Math.random() * 95}%`,
-                transform: `rotate(${Math.random() * 40 - 20}deg)`,
-                opacity: 0.4 + Math.random() * 0.6,
-              }}
-            >
-              {i % 2 === 0 ? "⭐" : "🎁"}
-            </span>
-          ))}
+      {/* Weekly behavior tracking grid */}
+      <BehaviorTracking childId={childId} />
+
+      {/* Visual connector: stars unlock rewards */}
+      <div className="flex items-center justify-center gap-3 py-2">
+        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-amber-300 to-transparent dark:via-amber-700" />
+        <div className="flex items-center gap-2 rounded-full bg-amber-50 dark:bg-amber-950/30 px-4 py-2 border border-amber-200/60 dark:border-amber-800/40">
+          <Trophy className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+          <Star className="h-4 w-4 fill-amber-400 text-amber-400" />
+          <span className="text-sm font-bold text-amber-700 dark:text-amber-300">{totalStars}</span>
+          <span className="text-xs text-amber-600/80 dark:text-amber-400/80">étoiles au total</span>
         </div>
-        <div className="relative text-center">
-          <h1 className="text-2xl font-bold font-heading">
-            <Trophy className="inline-block h-6 w-6 mr-2 -mt-1" />
-            Récompenses de {childName}
-          </h1>
-          <div className="mt-3 flex items-center justify-center gap-3">
-            <div className="flex items-center gap-2 rounded-full bg-white/20 px-4 py-2 backdrop-blur-sm">
-              <Star className="h-5 w-5 fill-yellow-300 text-yellow-300" />
-              <span className="text-xl font-bold">{totalStars}</span>
-              <span className="text-sm text-white/80">étoiles gagnées</span>
-            </div>
-          </div>
-        </div>
+        <div className="h-px flex-1 bg-gradient-to-r from-transparent via-amber-300 to-transparent dark:via-amber-700" />
       </div>
 
-      {/* Add reward button */}
+      {/* Reward section header */}
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider flex items-center gap-1.5">
           <Gift className="h-3.5 w-3.5" />
-          Tableau de récompenses
+          Récompenses à débloquer
         </h2>
         <Dialog
           open={rewardDialogOpen}


### PR DESCRIPTION
## Résumé technique

### Contexte
La page Récompenses (`/rewards`) n'affichait que les cartes de récompenses, séparément de la grille hebdomadaire de suivi des comportements qui vivait dans `/barkley`. Cette séparation brisait la boucle motivationnelle TDAH : l'enfant ne voyait pas le lien direct entre ses étoiles gagnées et les récompenses à débloquer.

### Approche retenue
Extraction du composant `BehaviorTracking` dans un fichier partagé, puis composition de la page Récompenses en deux zones verticales :
1. **Zone "gagner"** — la grille hebdomadaire de comportements (étoiles)
2. **Connecteur visuel** — compteur d'étoiles cumulées
3. **Zone "débloquer"** — les cartes de récompenses

Alternative rejetée : tabs dans une seule page (masque le lien cause-effet), duplication du code (maintenance double).

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/web/src/components/barkley/behavior-tracking.tsx` | Nouveau composant extrait | Réutilisation sans duplication entre `/rewards` et potentiellement `/barkley` |
| `apps/web/src/routes/_authenticated/rewards/index.tsx` | Intègre `BehaviorTracking` + connecteur visuel + récompenses | Page unifiée tâches → étoiles → récompenses |
| `apps/web/src/routes/_authenticated/barkley/index.tsx` | Simplifié en page Programme uniquement | Suppression du tab "Suivi hebdomadaire" déplacé vers `/rewards` |
| `apps/web/src/hooks/use-barkley.ts` | Ajout invalidation `barkley-stars` dans `useToggleBarkleyLog` | Synchronisation immédiate du compteur d'étoiles quand on toggle une étoile |
| `apps/web/src/routes/_authenticated.tsx` | Renommage nav "Programme Barkley" | Reflète le nouveau contenu de la page `/barkley` |

### Points d'attention pour la revue
- La correction de cache invalidation dans `useToggleBarkleyLog` est critique : sans elle, les barres de progression des récompenses ne se mettent pas à jour en temps réel
- Le composant extrait est identique à l'original — pas de props supplémentaires, pas d'abstraction prématurée
- Zéro changement API/schéma/migration — pure restructuration frontend

### Tests
- Typecheck : 2 packages vérifiés, 0 erreurs
- Tests unitaires : 18 tests exécutés, 18 passés, 0 échoués

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation visuelle sur mobile (scroll du comportement grid + récompenses)
- [ ] Merge après approbation

---
_Implémentation générée automatiquement par IA_