### PR TITLE
feat(ui): replace emoji inputs with select dropdowns

### DIFF
--- a/apps/web/src/components/barkley/behavior-tracking.tsx
+++ b/apps/web/src/components/barkley/behavior-tracking.tsx
@@ -12,6 +12,13 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Dialog,
   DialogContent,
   DialogHeader,
@@ -384,6 +391,12 @@ export function BehaviorTracking({ childId }: { childId: string }) {
   );
 }
 
+const BEHAVIOR_EMOJIS = [
+  "🧹", "🦷", "🎒", "🍽️", "👕", "📚", "🛏️", "🤝", "🙋", "🧘",
+  "👂", "🚿", "🐕", "🗣️", "⏰", "🤫", "💪", "😊", "🎨", "✅",
+  "⭐", "🌟", "👍", "🎯", "🏅",
+];
+
 // ─── Behavior Suggestions ─────────────────────────────────
 
 const BEHAVIOR_SUGGESTIONS = [
@@ -447,14 +460,18 @@ function BehaviorForm({
       <div className="space-y-2">
         <Label htmlFor="beh-name">Nom du comportement</Label>
         <div className="flex gap-2">
-          <Input
-            id="beh-icon"
-            value={icon}
-            onChange={(e) => setIcon(e.target.value)}
-            placeholder="🧹"
-            maxLength={10}
-            className="w-16 shrink-0 text-center text-lg"
-          />
+          <Select value={icon || undefined} onValueChange={(v) => v && setIcon(v)}>
+            <SelectTrigger className="w-16 shrink-0">
+              <SelectValue placeholder="🧹" />
+            </SelectTrigger>
+            <SelectContent>
+              {BEHAVIOR_EMOJIS.map((e) => (
+                <SelectItem key={e} value={e} label={e}>
+                  <span className="text-xl">{e}</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <Input
             id="beh-name"
             value={name}

--- a/apps/web/src/routes/_authenticated/crisis-list/index.tsx
+++ b/apps/web/src/routes/_authenticated/crisis-list/index.tsx
@@ -16,6 +16,13 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Dialog,
   DialogContent,
   DialogHeader,
@@ -192,6 +199,12 @@ function CrisisItemCard({
   );
 }
 
+const CRISIS_EMOJIS = [
+  "🧸", "🎵", "📺", "🫧", "🖍️", "🤗", "📖", "🧘", "🏃", "🛁",
+  "🎮", "🐾", "🧩", "🎨", "🌳", "💤", "🎧", "🫂", "⚽", "🍫",
+  "💙", "🌈", "🍪", "🎶", "🧁",
+];
+
 // ─── Suggestions ────────────────────────────────────────
 
 const SUGGESTIONS = [
@@ -253,14 +266,18 @@ function CrisisItemForm({ onSuccess }: { onSuccess: () => void }) {
           Qu'est-ce qui te fait du bien ?
         </Label>
         <div className="flex gap-2">
-          <Input
-            id="crisis-emoji"
-            value={emoji}
-            onChange={(e) => setEmoji(e.target.value)}
-            placeholder="🧸"
-            maxLength={10}
-            className="w-16 shrink-0 text-center text-lg"
-          />
+          <Select value={emoji || undefined} onValueChange={(v) => v && setEmoji(v)}>
+            <SelectTrigger className="w-16 shrink-0">
+              <SelectValue placeholder="🧸" />
+            </SelectTrigger>
+            <SelectContent>
+              {CRISIS_EMOJIS.map((e) => (
+                <SelectItem key={e} value={e} label={e}>
+                  <span className="text-xl">{e}</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
           <Input
             id="crisis-label"
             value={label}

--- a/apps/web/src/routes/_authenticated/rewards/index.tsx
+++ b/apps/web/src/routes/_authenticated/rewards/index.tsx
@@ -16,6 +16,13 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Progress, ProgressValue } from "@/components/ui/progress";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Dialog,
   DialogContent,
   DialogHeader,
@@ -262,6 +269,12 @@ function RewardBoard({ childId }: { childId: string }) {
   );
 }
 
+const REWARD_EMOJIS = [
+  "🎁", "🏆", "🎨", "🎮", "🍦", "🎬", "🎵", "📚", "🐾", "⚽",
+  "🎯", "🌈", "🍕", "🎂", "🚲", "🎸", "🛝", "🎪", "🧸", "🌟",
+  "🎠", "🍫", "🎧", "🏊", "🎳",
+];
+
 // ─── Reward Form ──────────────────────────────────────────
 
 function RewardForm({
@@ -302,14 +315,19 @@ function RewardForm({
         />
       </div>
       <div className="space-y-2">
-        <Label htmlFor="reward-icon">Icône (emoji)</Label>
-        <Input
-          id="reward-icon"
-          value={icon}
-          onChange={(e) => setIcon(e.target.value)}
-          placeholder="Ex: 🎨"
-          maxLength={10}
-        />
+        <Label>Icône (emoji)</Label>
+        <Select value={icon || undefined} onValueChange={(v) => v && setIcon(v)}>
+          <SelectTrigger className="w-full">
+            <SelectValue placeholder="Choisir un emoji 🎁" />
+          </SelectTrigger>
+          <SelectContent>
+            {REWARD_EMOJIS.map((e) => (
+              <SelectItem key={e} value={e} label={e}>
+                <span className="text-xl">{e}</span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
       <div className="space-y-2">
         <Label htmlFor="reward-stars">Étoiles nécessaires</Label>


### PR DESCRIPTION
## Résumé technique

### Contexte
Les formulaires de récompenses, liste de crise et comportements utilisaient des champs texte libres pour la saisie d'emojis. Cela posait des problèmes d'UX : saisie incohérente, emojis non reconnaissables par les enfants, et difficulté à trouver le bon emoji sur certains appareils.

### Approche retenue
Remplacement des `<Input>` texte libre par des `<Select>` dropdown utilisant le composant Select existant (base-ui). Chaque formulaire dispose d'une liste curatée de 25 emojis adaptés à son contexte :
- **Récompenses** : emojis de cadeaux, activités, friandises (🎁 🏆 🎨 🎮 🍦...)
- **Liste de crise** : emojis apaisants et réconfortants (🧸 🎵 🤗 🧘 💤...)
- **Comportements** : emojis de tâches quotidiennes (🧹 🦷 🎒 📚 🛏️...)

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/web/src/routes/_authenticated/rewards/index.tsx` | Ajout `REWARD_EMOJIS` + remplacement Input par Select | Nouveau formulaire sans emojis curatés |
| `apps/web/src/routes/_authenticated/crisis-list/index.tsx` | Ajout `CRISIS_EMOJIS` + remplacement Input par Select | Cohérence avec les suggestions existantes |
| `apps/web/src/components/barkley/behavior-tracking.tsx` | Ajout `BEHAVIOR_EMOJIS` + remplacement Input par Select | Cohérence avec les suggestions existantes |

### Points d'attention pour la revue
- Le Select utilise le Portal de base-ui qui gère correctement le z-index dans les Dialogs
- Les listes de suggestions "Des idées ?" sont conservées pour les formulaires crise/comportement (elles remplissent aussi le champ label)
- `value={icon || undefined}` assure l'affichage du placeholder quand aucun emoji n'est sélectionné

### Tests
- Typecheck : 2 tâches réussies, 0 erreurs
- Tests unitaires : 3 suites réussies (tous passés)
- Pas de changement backend/validators/schema

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation visuelle sur mobile
- [ ] Merge après approbation

---
_Attention : d'autres branches fast-meeting sont actives. Vérifier les conflits potentiels avant merge._

_Implémentation générée automatiquement par IA_