### PR TITLE
feat(ui): InputGroup pattern for emoji+label forms

### DIFF
--- a/apps/web/src/components/barkley/behavior-tracking.tsx
+++ b/apps/web/src/components/barkley/behavior-tracking.tsx
@@ -5,19 +5,23 @@ import {
   Plus,
   Trash2,
   Sparkles,
+  Shuffle,
 } from "lucide-react";
 import { PageLoader } from "@/components/ui/page-loader";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   Dialog,
   DialogContent,
@@ -391,12 +395,6 @@ export function BehaviorTracking({ childId }: { childId: string }) {
   );
 }
 
-const BEHAVIOR_EMOJIS = [
-  "🧹", "🦷", "🎒", "🍽️", "👕", "📚", "🛏️", "🤝", "🙋", "🧘",
-  "👂", "🚿", "🐕", "🗣️", "⏰", "🤫", "💪", "😊", "🎨", "✅",
-  "⭐", "🌟", "👍", "🎯", "🏅",
-];
-
 // ─── Behavior Suggestions ─────────────────────────────────
 
 const BEHAVIOR_SUGGESTIONS = [
@@ -455,32 +453,47 @@ function BehaviorForm({
     setShowSuggestions(false);
   };
 
+  const pickRandom = () => {
+    const s =
+      BEHAVIOR_SUGGESTIONS[
+        Math.floor(Math.random() * BEHAVIOR_SUGGESTIONS.length)
+      ]!;
+    setIcon(s.icon);
+    setName(s.name);
+  };
+
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-2">
         <Label htmlFor="beh-name">Nom du comportement</Label>
-        <div className="flex gap-2">
-          <Select value={icon || undefined} onValueChange={(v) => v && setIcon(v)}>
-            <SelectTrigger className="w-16 shrink-0">
-              <SelectValue placeholder="🧹" />
-            </SelectTrigger>
-            <SelectContent>
-              {BEHAVIOR_EMOJIS.map((e) => (
-                <SelectItem key={e} value={e} label={e}>
-                  <span className="text-xl">{e}</span>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Input
+        <InputGroup>
+          <InputGroupInput
+            value={icon}
+            onChange={(e) => setIcon(e.target.value)}
+            placeholder="🧹"
+            maxLength={10}
+            className="w-14 flex-none text-center text-lg"
+          />
+          <InputGroupInput
             id="beh-name"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="Je range ma chambre"
             required
-            className="flex-1"
           />
-        </div>
+          <InputGroupAddon align="inline-end">
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <InputGroupButton onClick={pickRandom}>
+                    <Shuffle className="h-3.5 w-3.5" />
+                  </InputGroupButton>
+                }
+              />
+              <TooltipContent>Suggestion au hasard</TooltipContent>
+            </Tooltip>
+          </InputGroupAddon>
+        </InputGroup>
       </div>
 
       <Button

--- a/apps/web/src/components/ui/input-group.tsx
+++ b/apps/web/src/components/ui/input-group.tsx
@@ -1,0 +1,146 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group border-input dark:bg-input/30 shadow-xs relative flex w-full items-center rounded-lg border outline-none transition-[color,box-shadow]",
+        "h-8",
+
+        // Variants based on alignment.
+        "has-[>[data-align=inline-start]]:[&>input]:pl-2",
+        "has-[>[data-align=inline-end]]:[&>input]:pr-2",
+
+        // Focus state.
+        "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50",
+
+        // Error state.
+        "has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40",
+
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const inputGroupAddonVariants = cva(
+  "text-muted-foreground flex h-auto cursor-text select-none items-center justify-center gap-2 py-1.5 text-sm font-medium group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start":
+          "order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
+        "inline-end":
+          "order-last pr-3 has-[>button]:mr-[-0.4rem] has-[>kbd]:mr-[-0.35rem]",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  }
+)
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) {
+          return
+        }
+        e.currentTarget.parentElement?.querySelector("input")?.focus()
+      }}
+      {...props}
+    />
+  )
+}
+
+const inputGroupButtonVariants = cva(
+  "flex items-center gap-2 text-sm shadow-none",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5",
+        "icon-xs":
+          "size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0",
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  }
+)
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "size"> &
+  VariantProps<typeof inputGroupButtonVariants>) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  )
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "text-muted-foreground flex items-center gap-2 text-sm [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+}

--- a/apps/web/src/routes/_authenticated/crisis-list/index.tsx
+++ b/apps/web/src/routes/_authenticated/crisis-list/index.tsx
@@ -10,18 +10,22 @@ import {
   ChevronLeft,
   ChevronRight,
   Sparkles,
+  Shuffle,
 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   Dialog,
   DialogContent,
@@ -199,12 +203,6 @@ function CrisisItemCard({
   );
 }
 
-const CRISIS_EMOJIS = [
-  "🧸", "🎵", "📺", "🫧", "🖍️", "🤗", "📖", "🧘", "🏃", "🛁",
-  "🎮", "🐾", "🧩", "🎨", "🌳", "💤", "🎧", "🫂", "⚽", "🍫",
-  "💙", "🌈", "🍪", "🎶", "🧁",
-];
-
 // ─── Suggestions ────────────────────────────────────────
 
 const SUGGESTIONS = [
@@ -259,34 +257,47 @@ function CrisisItemForm({ onSuccess }: { onSuccess: () => void }) {
     setShowSuggestions(false);
   };
 
+  const pickRandom = () => {
+    const s =
+      SUGGESTIONS[Math.floor(Math.random() * SUGGESTIONS.length)]!;
+    setEmoji(s.emoji);
+    setLabel(s.label);
+  };
+
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-2">
         <Label htmlFor="crisis-label">
           Qu'est-ce qui te fait du bien ?
         </Label>
-        <div className="flex gap-2">
-          <Select value={emoji || undefined} onValueChange={(v) => v && setEmoji(v)}>
-            <SelectTrigger className="w-16 shrink-0">
-              <SelectValue placeholder="🧸" />
-            </SelectTrigger>
-            <SelectContent>
-              {CRISIS_EMOJIS.map((e) => (
-                <SelectItem key={e} value={e} label={e}>
-                  <span className="text-xl">{e}</span>
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Input
+        <InputGroup>
+          <InputGroupInput
+            value={emoji}
+            onChange={(e) => setEmoji(e.target.value)}
+            placeholder="🧸"
+            maxLength={10}
+            className="w-14 flex-none text-center text-lg"
+          />
+          <InputGroupInput
             id="crisis-label"
             value={label}
             onChange={(e) => setLabel(e.target.value)}
             placeholder="Regarder mon dessin animé préféré"
             required
-            className="flex-1"
           />
-        </div>
+          <InputGroupAddon align="inline-end">
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <InputGroupButton onClick={pickRandom}>
+                    <Shuffle className="h-3.5 w-3.5" />
+                  </InputGroupButton>
+                }
+              />
+              <TooltipContent>Suggestion au hasard</TooltipContent>
+            </Tooltip>
+          </InputGroupAddon>
+        </InputGroup>
       </div>
 
       <Button

--- a/apps/web/src/routes/_authenticated/rewards/index.tsx
+++ b/apps/web/src/routes/_authenticated/rewards/index.tsx
@@ -16,12 +16,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Progress, ProgressValue } from "@/components/ui/progress";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  InputGroup,
+  InputGroupInput,
+} from "@/components/ui/input-group";
 import {
   Dialog,
   DialogContent,
@@ -269,12 +266,6 @@ function RewardBoard({ childId }: { childId: string }) {
   );
 }
 
-const REWARD_EMOJIS = [
-  "🎁", "🏆", "🎨", "🎮", "🍦", "🎬", "🎵", "📚", "🐾", "⚽",
-  "🎯", "🌈", "🍕", "🎂", "🚲", "🎸", "🛝", "🎪", "🧸", "🌟",
-  "🎠", "🍫", "🎧", "🏊", "🎳",
-];
-
 // ─── Reward Form ──────────────────────────────────────────
 
 function RewardForm({
@@ -306,28 +297,22 @@ function RewardForm({
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-2">
         <Label htmlFor="reward-name">Nom de la récompense</Label>
-        <Input
-          id="reward-name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Ex: Un temps de dessin avec maman"
-          required
-        />
-      </div>
-      <div className="space-y-2">
-        <Label>Icône (emoji)</Label>
-        <Select value={icon || undefined} onValueChange={(v) => v && setIcon(v)}>
-          <SelectTrigger className="w-full">
-            <SelectValue placeholder="Choisir un emoji 🎁" />
-          </SelectTrigger>
-          <SelectContent>
-            {REWARD_EMOJIS.map((e) => (
-              <SelectItem key={e} value={e} label={e}>
-                <span className="text-xl">{e}</span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+        <InputGroup>
+          <InputGroupInput
+            value={icon}
+            onChange={(e) => setIcon(e.target.value)}
+            placeholder="🎁"
+            maxLength={10}
+            className="w-14 flex-none text-center text-lg"
+          />
+          <InputGroupInput
+            id="reward-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Un temps de dessin avec maman"
+            required
+          />
+        </InputGroup>
       </div>
       <div className="space-y-2">
         <Label htmlFor="reward-stars">Étoiles nécessaires</Label>


### PR DESCRIPTION
## Résumé technique

### Contexte
Les formulaires de comportement, crise et récompense utilisaient un `Select` emoji séparé + un `Input` label côte à côte (`flex gap-2`), ce qui crée un aspect visuel disjoint. Le bouton "Des idées ?" de suggestion était aussi séparé sur une ligne dédiée.

### Approche retenue
Adoption du pattern `InputGroup` de shadcn/ui (adapté aux primitives base-ui du projet) pour fusionner emoji + label + bouton random en une seule ligne visuelle cohérente. Le `Select` emoji est remplacé par un `InputGroupInput` texte libre, ce qui simplifie l'UX et permet la saisie directe d'emoji.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/web/src/components/ui/input-group.tsx` | Nouveau composant InputGroup (adapté de shadcn) | Pattern de composition réutilisable avec gestion focus-within et variants d'alignement |
| `apps/web/src/components/barkley/behavior-tracking.tsx` | Remplacement Select+Input par InputGroup + ajout bouton random avec Tooltip | Fusion emoji+label+random en une seule ligne, suppression du Select et des BEHAVIOR_EMOJIS |
| `apps/web/src/routes/_authenticated/crisis-list/index.tsx` | Même refactoring pour CrisisItemForm | Cohérence du pattern, suppression CRISIS_EMOJIS |
| `apps/web/src/routes/_authenticated/rewards/index.tsx` | Fusion des champs emoji et nom séparés en un InputGroup | Alignement avec le pattern des autres formulaires, suppression REWARD_EMOJIS |

### Points d'attention pour la revue
- Le focus-within du InputGroup gère l'état visuel — vérifier le comportement de tab entre les sous-inputs
- Le bouton random (Shuffle) utilise `Tooltip` de base-ui — vérifier le rendu sur mobile
- Les tableaux `*_EMOJIS` sont supprimés (plus de Select) — les parents saisissent directement un emoji ou utilisent le bouton random/suggestion

### Tests
- Typecheck : ✅ 2/2 packages passent
- Tests unitaires : ✅ 18/18 passent (3 suites)

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Test visuel sur mobile (touch targets du bouton random)
- [ ] Merge après approbation

---
_Implémentation générée automatiquement par IA_