### PR TITLE
feat(rewards): inline edit, emoji picker, suggestions & drag-and-drop

### DIFF
--- a/apps/api/src/routes/barkley.ts
+++ b/apps/api/src/routes/barkley.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { AppEnv } from "../types";
-import { eq, and, between, inArray, count, sql } from "drizzle-orm";
+import { eq, and, between, inArray, count, sql, asc, max } from "drizzle-orm";
 import {
   db,
   barkleySteps,
@@ -15,6 +15,8 @@ import {
   updateBarkleyBehaviorSchema,
   createBarkleyBehaviorLogSchema,
   createBarkleyRewardSchema,
+  updateBarkleyRewardSchema,
+  reorderBarkleyRewardsSchema,
 } from "@focusflow/validators";
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
@@ -253,7 +255,8 @@ barkleyRoutes.get("/rewards/:childId", async (c) => {
   const result = await db
     .select()
     .from(barkleyRewards)
-    .where(eq(barkleyRewards.childId, childId));
+    .where(eq(barkleyRewards.childId, childId))
+    .orderBy(asc(barkleyRewards.sortOrder));
 
   return c.json(result);
 });
@@ -272,12 +275,93 @@ barkleyRoutes.post("/rewards", async (c) => {
 
   await verifyChildOwnership(parsed.data.childId, user.id);
 
+  // Auto-assign sortOrder to MAX + 1
+  const [maxResult] = await db
+    .select({ maxOrder: max(barkleyRewards.sortOrder) })
+    .from(barkleyRewards)
+    .where(eq(barkleyRewards.childId, parsed.data.childId));
+
+  const nextOrder = (maxResult?.maxOrder ?? -1) + 1;
+
   const [reward] = await db
     .insert(barkleyRewards)
-    .values(parsed.data)
+    .values({ ...parsed.data, sortOrder: nextOrder })
     .returning();
 
   return c.json(reward, 201);
+});
+
+barkleyRoutes.patch("/rewards/:id", async (c) => {
+  const user = c.get("user");
+  const id = c.req.param("id");
+  const body = await c.req.json();
+  const parsed = updateBarkleyRewardSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return c.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      422
+    );
+  }
+
+  const [reward] = await db
+    .select()
+    .from(barkleyRewards)
+    .where(eq(barkleyRewards.id, id));
+
+  if (!reward) {
+    throw new AppError("NOT_FOUND", "Récompense non trouvée", 404);
+  }
+
+  await verifyChildOwnership(reward.childId, user.id);
+
+  if (reward.claimedAt) {
+    throw new AppError("CONFLICT", "Impossible de modifier une récompense déjà réclamée", 409);
+  }
+
+  const [updated] = await db
+    .update(barkleyRewards)
+    .set({ ...parsed.data, updatedAt: new Date() })
+    .where(eq(barkleyRewards.id, id))
+    .returning();
+
+  return c.json(updated);
+});
+
+barkleyRoutes.post("/rewards/:childId/reorder", async (c) => {
+  const user = c.get("user");
+  const childId = c.req.param("childId");
+  const body = await c.req.json();
+  const parsed = reorderBarkleyRewardsSchema.safeParse({ ...body, childId });
+
+  if (!parsed.success) {
+    return c.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      422
+    );
+  }
+
+  await verifyChildOwnership(childId, user.id);
+
+  for (let i = 0; i < parsed.data.orderedIds.length; i++) {
+    await db
+      .update(barkleyRewards)
+      .set({ sortOrder: i, updatedAt: new Date() })
+      .where(
+        and(
+          eq(barkleyRewards.id, parsed.data.orderedIds[i]!),
+          eq(barkleyRewards.childId, childId)
+        )
+      );
+  }
+
+  const result = await db
+    .select()
+    .from(barkleyRewards)
+    .where(eq(barkleyRewards.childId, childId))
+    .orderBy(asc(barkleyRewards.sortOrder));
+
+  return c.json(result);
 });
 
 barkleyRoutes.delete("/rewards/:id", async (c) => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,9 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@focusflow/validators": "workspace:*",
     "@fontsource-variable/plus-jakarta-sans": "^5.2.8",
     "@fontsource-variable/source-serif-4": "^5.2.9",

--- a/apps/web/src/hooks/use-barkley.ts
+++ b/apps/web/src/hooks/use-barkley.ts
@@ -10,6 +10,7 @@ import type {
   CreateBarkleyBehaviorLog,
   BarkleyReward,
   CreateBarkleyReward,
+  UpdateBarkleyReward,
 } from "@focusflow/validators";
 
 export const barkleyKeys = {
@@ -163,11 +164,47 @@ export function useCreateBarkleyReward() {
   });
 }
 
+export function useUpdateBarkleyReward() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      childId,
+      ...data
+    }: UpdateBarkleyReward & { id: string; childId: string }) =>
+      api.patch<BarkleyReward>(`/barkley/rewards/${id}`, data),
+    onSuccess: (_, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: barkleyKeys.rewards(variables.childId),
+      }),
+  });
+}
+
 export function useDeleteBarkleyReward() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ id, childId }: { id: string; childId: string }) =>
       api.delete(`/barkley/rewards/${id}`),
+    onSuccess: (_, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: barkleyKeys.rewards(variables.childId),
+      }),
+  });
+}
+
+export function useReorderBarkleyRewards() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      childId,
+      orderedIds,
+    }: {
+      childId: string;
+      orderedIds: string[];
+    }) =>
+      api.post<BarkleyReward[]>(`/barkley/rewards/${childId}/reorder`, {
+        orderedIds,
+      }),
     onSuccess: (_, variables) =>
       queryClient.invalidateQueries({
         queryKey: barkleyKeys.rewards(variables.childId),

--- a/apps/web/src/routes/_authenticated/rewards/index.tsx
+++ b/apps/web/src/routes/_authenticated/rewards/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import {
   Gift,
@@ -8,7 +8,30 @@ import {
   Trash2,
   Trophy,
   PartyPopper,
+  GripVertical,
+  Pencil,
+  Check,
+  X,
+  Sparkles,
+  Shuffle,
 } from "lucide-react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { PageLoader } from "@/components/ui/page-loader";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -17,8 +40,15 @@ import { Label } from "@/components/ui/label";
 import { Progress, ProgressValue } from "@/components/ui/progress";
 import {
   InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
   InputGroupInput,
 } from "@/components/ui/input-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import {
   Dialog,
   DialogContent,
@@ -29,17 +59,57 @@ import {
 import {
   useBarkleyRewards,
   useCreateBarkleyReward,
+  useUpdateBarkleyReward,
   useDeleteBarkleyReward,
+  useReorderBarkleyRewards,
   useBarkleyStarCount,
   useClaimBarkleyReward,
 } from "@/hooks/use-barkley";
 import { useChild } from "@/hooks/use-children";
 import { useUiStore } from "@/stores/ui-store";
 import { BehaviorTracking } from "@/components/barkley/behavior-tracking";
+import type { BarkleyReward } from "@focusflow/validators";
 
 export const Route = createFileRoute("/_authenticated/rewards/")({
   component: RewardsPage,
 });
+
+// ─── Predefined Emojis ──────────────────────────────────
+
+const REWARD_EMOJIS = [
+  "🎁", "🎮", "🎨", "🍦", "🍕", "🍿", "🎬", "🎪",
+  "🎠", "🏊", "⚽", "🚴", "🛝", "🎯", "🧩", "🎲",
+  "📖", "🖍️", "🎵", "🎤", "🛍️", "👑", "🌟", "🏆",
+  "🧸", "🎈", "🎉", "🍫", "🍰", "🍪", "🧁", "🥤",
+  "📺", "🎧", "💤", "🛁", "🐾", "🌳", "🚀", "✨",
+];
+
+// ─── Predefined Suggestions ─────────────────────────────
+
+const REWARD_SUGGESTIONS = [
+  { icon: "🎨", name: "Un temps de dessin avec maman/papa" },
+  { icon: "🎮", name: "30 min de jeux vidéo" },
+  { icon: "🍦", name: "Un cornet de glace" },
+  { icon: "🍕", name: "Choisir le repas du soir" },
+  { icon: "🎬", name: "Soirée film en famille" },
+  { icon: "🛝", name: "Sortie au parc" },
+  { icon: "🧩", name: "Un nouveau puzzle ou jeu" },
+  { icon: "📖", name: "Choisir l'histoire du soir" },
+  { icon: "🍿", name: "Soirée popcorn" },
+  { icon: "🎪", name: "Sortie spéciale (zoo, cirque...)" },
+  { icon: "🛍️", name: "Un petit cadeau surprise" },
+  { icon: "👑", name: "Roi/Reine de la journée" },
+  { icon: "🍫", name: "Un bonbon ou chocolat" },
+  { icon: "📺", name: "Un épisode en plus" },
+  { icon: "🎈", name: "Inviter un ami à la maison" },
+  { icon: "🏊", name: "Sortie piscine" },
+  { icon: "🎤", name: "Soirée karaoké" },
+  { icon: "🍰", name: "Faire un gâteau ensemble" },
+  { icon: "💤", name: "Se coucher 30 min plus tard" },
+  { icon: "🚴", name: "Balade à vélo" },
+];
+
+// ─── Page ────────────────────────────────────────────────
 
 function RewardsPage() {
   const activeChildId = useUiStore((s) => s.activeChildId);
@@ -65,8 +135,11 @@ function RewardsPage() {
   return <RewardBoard childId={activeChildId} />;
 }
 
+// ─── Board ───────────────────────────────────────────────
+
 function RewardBoard({ childId }: { childId: string }) {
   const [rewardDialogOpen, setRewardDialogOpen] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
   const { data: child } = useChild(childId);
   const { data: rewards = [], isLoading: rewardsLoading } =
     useBarkleyRewards(childId);
@@ -74,15 +147,45 @@ function RewardBoard({ childId }: { childId: string }) {
     useBarkleyStarCount(childId);
   const claimReward = useClaimBarkleyReward();
   const deleteReward = useDeleteBarkleyReward();
+  const reorder = useReorderBarkleyRewards();
 
   const totalStars = starData?.totalStars ?? 0;
-  const childName = child?.name ?? "...";
 
+  // Sort: unclaimed by sortOrder first, claimed last
   const sortedRewards = [...rewards].sort((a, b) => {
     if (a.claimedAt && !b.claimedAt) return 1;
     if (!a.claimedAt && b.claimedAt) return -1;
-    return (a.starsRequired ?? 0) - (b.starsRequired ?? 0);
+    return (a.sortOrder ?? 0) - (b.sortOrder ?? 0);
   });
+
+  const unclaimedRewards = sortedRewards.filter((r) => !r.claimedAt);
+  const claimedRewards = sortedRewards.filter((r) => !!r.claimedAt);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const oldIndex = unclaimedRewards.findIndex((r) => r.id === active.id);
+      const newIndex = unclaimedRewards.findIndex((r) => r.id === over.id);
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const reordered = arrayMove(unclaimedRewards, oldIndex, newIndex);
+      const orderedIds = [
+        ...reordered.map((r) => r.id),
+        ...claimedRewards.map((r) => r.id),
+      ];
+      reorder.mutate({ childId, orderedIds });
+    },
+    [unclaimedRewards, claimedRewards, childId, reorder]
+  );
 
   if (rewardsLoading || starsLoading) {
     return <PageLoader />;
@@ -99,8 +202,12 @@ function RewardBoard({ childId }: { childId: string }) {
         <div className="flex items-center gap-2 rounded-full bg-amber-50 dark:bg-amber-950/30 px-4 py-2 border border-amber-200/60 dark:border-amber-800/40">
           <Trophy className="h-4 w-4 text-amber-600 dark:text-amber-400" />
           <Star className="h-4 w-4 fill-amber-400 text-amber-400" />
-          <span className="text-sm font-bold text-amber-700 dark:text-amber-300">{totalStars}</span>
-          <span className="text-xs text-amber-600/80 dark:text-amber-400/80">étoiles au total</span>
+          <span className="text-sm font-bold text-amber-700 dark:text-amber-300">
+            {totalStars}
+          </span>
+          <span className="text-xs text-amber-600/80 dark:text-amber-400/80">
+            étoiles au total
+          </span>
         </div>
         <div className="h-px flex-1 bg-gradient-to-r from-transparent via-amber-300 to-transparent dark:via-amber-700" />
       </div>
@@ -111,10 +218,7 @@ function RewardBoard({ childId }: { childId: string }) {
           <Gift className="h-3.5 w-3.5" />
           Récompenses à débloquer
         </h2>
-        <Dialog
-          open={rewardDialogOpen}
-          onOpenChange={setRewardDialogOpen}
-        >
+        <Dialog open={rewardDialogOpen} onOpenChange={setRewardDialogOpen}>
           <DialogTrigger
             render={
               <Button size="sm" variant="outline">
@@ -148,125 +252,389 @@ function RewardBoard({ childId }: { childId: string }) {
           </CardContent>
         </Card>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {sortedRewards.map((reward) => {
-            const starsNeeded = reward.starsRequired ?? 0;
-            const isClaimed = !!reward.claimedAt;
-            const isUnlockable = !isClaimed && totalStars >= starsNeeded;
-            const progress =
-              starsNeeded > 0
-                ? Math.min((totalStars / starsNeeded) * 100, 100)
-                : 100;
-            const remaining = Math.max(starsNeeded - totalStars, 0);
+        <div className="grid gap-3">
+          {/* Unclaimed: drag-and-drop sortable */}
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={unclaimedRewards.map((r) => r.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {unclaimedRewards.map((reward) => (
+                <SortableRewardCard
+                  key={reward.id}
+                  reward={reward}
+                  childId={childId}
+                  totalStars={totalStars}
+                  isEditing={editingId === reward.id}
+                  onStartEdit={() => setEditingId(reward.id)}
+                  onStopEdit={() => setEditingId(null)}
+                  onClaim={() =>
+                    claimReward.mutate({ id: reward.id, childId })
+                  }
+                  onDelete={() =>
+                    deleteReward.mutate({ id: reward.id, childId })
+                  }
+                  claimPending={claimReward.isPending}
+                  deletePending={deleteReward.isPending}
+                />
+              ))}
+            </SortableContext>
+          </DndContext>
 
-            return (
-              <Card
-                key={reward.id}
-                className={`relative overflow-hidden transition-all duration-300 ${
-                  isClaimed
-                    ? "border-green-300 bg-gradient-to-b from-green-50/80 to-emerald-50/50 dark:from-green-950/20 dark:to-emerald-950/10 dark:border-green-800/30"
-                    : isUnlockable
-                      ? "border-amber-300 bg-gradient-to-b from-amber-50/80 to-orange-50/50 dark:from-amber-950/20 dark:to-orange-950/10 dark:border-amber-800/30 ring-2 ring-amber-400/50"
-                      : "opacity-75"
-                }`}
-              >
-                <CardContent className="py-4 px-4">
-                  <div className="flex items-start gap-3">
-                    {/* Icon */}
-                    <div
-                      className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-xl text-2xl ${
-                        isClaimed
-                          ? "bg-green-100 dark:bg-green-900/30"
-                          : isUnlockable
-                            ? "bg-amber-100 dark:bg-amber-900/30"
-                            : "bg-muted grayscale"
-                      }`}
-                    >
-                      {reward.icon || "🎁"}
-                    </div>
-
-                    {/* Content */}
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <h3 className="text-sm font-semibold truncate">
-                          {reward.name}
-                        </h3>
-                        {isClaimed && (
-                          <PartyPopper className="h-4 w-4 text-green-600 shrink-0" />
-                        )}
-                        {!isClaimed && !isUnlockable && (
-                          <Lock className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0" />
-                        )}
-                      </div>
-
-                      {/* Star requirement */}
-                      <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
-                        <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
-                        <span>
-                          {isClaimed
-                            ? `Débloquée !`
-                            : isUnlockable
-                              ? `Prête à débloquer !`
-                              : `${remaining} étoile${remaining > 1 ? "s" : ""} restante${remaining > 1 ? "s" : ""}`}
-                        </span>
-                      </div>
-
-                      {/* Progress bar */}
-                      {!isClaimed && starsNeeded > 0 && (
-                        <div className="mt-2">
-                          <Progress value={progress}>
-                            <ProgressValue>
-                              {() =>
-                                `${Math.min(totalStars, starsNeeded)} / ${starsNeeded}`
-                              }
-                            </ProgressValue>
-                          </Progress>
-                        </div>
-                      )}
-
-                      {/* Claim button */}
-                      {isUnlockable && (
-                        <Button
-                          size="sm"
-                          className="mt-3 w-full bg-amber-500 hover:bg-amber-600 text-white"
-                          onClick={() =>
-                            claimReward.mutate({
-                              id: reward.id,
-                              childId,
-                            })
-                          }
-                          disabled={claimReward.isPending}
-                        >
-                          <PartyPopper className="mr-1.5 h-3.5 w-3.5" />
-                          {claimReward.isPending
-                            ? "Déblocage..."
-                            : "Débloquer !"}
-                        </Button>
-                      )}
-                    </div>
-
-                    {/* Delete button */}
-                    <button
-                      onClick={() =>
-                        deleteReward.mutate({ id: reward.id, childId })
-                      }
-                      className="text-muted-foreground/30 hover:text-destructive transition-colors p-1 rounded shrink-0"
-                      disabled={deleteReward.isPending}
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                    </button>
-                  </div>
-                </CardContent>
-              </Card>
-            );
-          })}
+          {/* Claimed: not draggable */}
+          {claimedRewards.map((reward) => (
+            <RewardCardDisplay
+              key={reward.id}
+              reward={reward}
+              totalStars={totalStars}
+              isClaimed
+              onDelete={() =>
+                deleteReward.mutate({ id: reward.id, childId })
+              }
+              deletePending={deleteReward.isPending}
+            />
+          ))}
         </div>
       )}
     </div>
   );
 }
 
-// ─── Reward Form ──────────────────────────────────────────
+// ─── Sortable Reward Card ────────────────────────────────
+
+function SortableRewardCard({
+  reward,
+  childId,
+  totalStars,
+  isEditing,
+  onStartEdit,
+  onStopEdit,
+  onClaim,
+  onDelete,
+  claimPending,
+  deletePending,
+}: {
+  reward: BarkleyReward;
+  childId: string;
+  totalStars: number;
+  isEditing: boolean;
+  onStartEdit: () => void;
+  onStopEdit: () => void;
+  onClaim: () => void;
+  onDelete: () => void;
+  claimPending: boolean;
+  deletePending: boolean;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: reward.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  if (isEditing) {
+    return (
+      <div ref={setNodeRef} style={style}>
+        <RewardCardEdit
+          reward={reward}
+          childId={childId}
+          onDone={onStopEdit}
+        />
+      </div>
+    );
+  }
+
+  const starsNeeded = reward.starsRequired ?? 0;
+  const isUnlockable = totalStars >= starsNeeded;
+  const progress =
+    starsNeeded > 0 ? Math.min((totalStars / starsNeeded) * 100, 100) : 100;
+  const remaining = Math.max(starsNeeded - totalStars, 0);
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <Card
+        className={`relative overflow-hidden transition-all duration-300 ${
+          isDragging ? "opacity-50 shadow-lg" : ""
+        } ${
+          isUnlockable
+            ? "border-amber-300 bg-gradient-to-b from-amber-50/80 to-orange-50/50 dark:from-amber-950/20 dark:to-orange-950/10 dark:border-amber-800/30 ring-2 ring-amber-400/50"
+            : "opacity-75"
+        }`}
+      >
+        <CardContent className="py-4 px-4">
+          <div className="flex items-start gap-3">
+            {/* Drag handle */}
+            <button
+              {...attributes}
+              {...listeners}
+              className="mt-1 cursor-grab touch-none rounded p-1 text-muted-foreground/40 hover:text-muted-foreground transition-colors active:cursor-grabbing"
+            >
+              <GripVertical className="h-4 w-4" />
+            </button>
+
+            {/* Icon */}
+            <div
+              className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-xl text-2xl ${
+                isUnlockable
+                  ? "bg-amber-100 dark:bg-amber-900/30"
+                  : "bg-muted grayscale"
+              }`}
+            >
+              {reward.icon || "🎁"}
+            </div>
+
+            {/* Content */}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <h3 className="text-sm font-semibold truncate">
+                  {reward.name}
+                </h3>
+                {!isUnlockable && (
+                  <Lock className="h-3.5 w-3.5 text-muted-foreground/50 shrink-0" />
+                )}
+              </div>
+
+              {/* Star requirement */}
+              <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+                <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
+                <span>
+                  {isUnlockable
+                    ? "Prête à débloquer !"
+                    : `${remaining} étoile${remaining > 1 ? "s" : ""} restante${remaining > 1 ? "s" : ""}`}
+                </span>
+              </div>
+
+              {/* Progress bar */}
+              {starsNeeded > 0 && (
+                <div className="mt-2">
+                  <Progress value={progress}>
+                    <ProgressValue>
+                      {() =>
+                        `${Math.min(totalStars, starsNeeded)} / ${starsNeeded}`
+                      }
+                    </ProgressValue>
+                  </Progress>
+                </div>
+              )}
+
+              {/* Claim button */}
+              {isUnlockable && (
+                <Button
+                  size="sm"
+                  className="mt-3 w-full bg-amber-500 hover:bg-amber-600 text-white"
+                  onClick={onClaim}
+                  disabled={claimPending}
+                >
+                  <PartyPopper className="mr-1.5 h-3.5 w-3.5" />
+                  {claimPending ? "Déblocage..." : "Débloquer !"}
+                </Button>
+              )}
+            </div>
+
+            {/* Actions */}
+            <div className="flex flex-col gap-1 shrink-0">
+              <button
+                onClick={onStartEdit}
+                className="text-muted-foreground/30 hover:text-foreground transition-colors p-1 rounded"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+              </button>
+              <button
+                onClick={onDelete}
+                className="text-muted-foreground/30 hover:text-destructive transition-colors p-1 rounded"
+                disabled={deletePending}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// ─── Reward Card Edit Mode ───────────────────────────────
+
+function RewardCardEdit({
+  reward,
+  childId,
+  onDone,
+}: {
+  reward: BarkleyReward;
+  childId: string;
+  onDone: () => void;
+}) {
+  const updateReward = useUpdateBarkleyReward();
+  const [name, setName] = useState(reward.name);
+  const [icon, setIcon] = useState(reward.icon || "");
+  const [starsRequired, setStarsRequired] = useState(
+    reward.starsRequired ?? 5
+  );
+  const [showEmojis, setShowEmojis] = useState(false);
+
+  const handleSave = () => {
+    if (!name.trim()) return;
+    updateReward.mutate(
+      {
+        id: reward.id,
+        childId,
+        name: name.trim(),
+        icon: icon || undefined,
+        starsRequired,
+      },
+      { onSuccess: onDone }
+    );
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSave();
+    }
+    if (e.key === "Escape") onDone();
+  };
+
+  return (
+    <Card className="border-primary/50 ring-2 ring-primary/20">
+      <CardContent className="py-4 px-4 space-y-3">
+        <div className="flex items-center gap-2">
+          <InputGroup>
+            <InputGroupInput
+              value={icon}
+              onChange={(e) => setIcon(e.target.value)}
+              placeholder="🎁"
+              maxLength={10}
+              className="w-14 flex-none text-center text-lg"
+              onKeyDown={handleKeyDown}
+              readOnly
+              onClick={() => setShowEmojis(!showEmojis)}
+            />
+            <InputGroupInput
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={handleKeyDown}
+              autoFocus
+            />
+          </InputGroup>
+          <Input
+            type="number"
+            min={0}
+            value={starsRequired}
+            onChange={(e) => setStarsRequired(Number(e.target.value))}
+            onKeyDown={handleKeyDown}
+            className="w-20"
+          />
+          <div className="flex items-center gap-1">
+            <Star className="h-3.5 w-3.5 fill-amber-400 text-amber-400" />
+          </div>
+        </div>
+
+        {/* Emoji picker grid */}
+        {showEmojis && (
+          <div className="grid grid-cols-8 gap-1 rounded-lg border p-2">
+            {REWARD_EMOJIS.map((emoji) => (
+              <button
+                key={emoji}
+                type="button"
+                onClick={() => {
+                  setIcon(emoji);
+                  setShowEmojis(false);
+                }}
+                className={`flex h-9 w-9 items-center justify-center rounded-md text-lg hover:bg-accent transition-colors ${
+                  icon === emoji ? "bg-accent ring-2 ring-primary" : ""
+                }`}
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <Button size="sm" variant="ghost" onClick={onDone}>
+            <X className="mr-1 h-3.5 w-3.5" />
+            Annuler
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleSave}
+            disabled={!name.trim() || updateReward.isPending}
+          >
+            <Check className="mr-1 h-3.5 w-3.5" />
+            {updateReward.isPending ? "..." : "Enregistrer"}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Claimed Reward Card (static, no drag) ──────────────
+
+function RewardCardDisplay({
+  reward,
+  totalStars,
+  isClaimed,
+  onDelete,
+  deletePending,
+}: {
+  reward: BarkleyReward;
+  totalStars: number;
+  isClaimed: boolean;
+  onDelete: () => void;
+  deletePending: boolean;
+}) {
+  return (
+    <Card className="border-green-300 bg-gradient-to-b from-green-50/80 to-emerald-50/50 dark:from-green-950/20 dark:to-emerald-950/10 dark:border-green-800/30">
+      <CardContent className="py-4 px-4">
+        <div className="flex items-start gap-3">
+          {/* Spacer to align with draggable cards */}
+          <div className="w-6" />
+
+          {/* Icon */}
+          <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl text-2xl bg-green-100 dark:bg-green-900/30">
+            {reward.icon || "🎁"}
+          </div>
+
+          {/* Content */}
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-semibold truncate">{reward.name}</h3>
+              <PartyPopper className="h-4 w-4 text-green-600 shrink-0" />
+            </div>
+            <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+              <Star className="h-3 w-3 fill-amber-400 text-amber-400" />
+              <span>Débloquée !</span>
+            </div>
+          </div>
+
+          {/* Delete */}
+          <button
+            onClick={onDelete}
+            className="text-muted-foreground/30 hover:text-destructive transition-colors p-1 rounded shrink-0"
+            disabled={deletePending}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ─── Reward Form (create dialog) ────────────────────────
 
 function RewardForm({
   childId,
@@ -279,6 +647,8 @@ function RewardForm({
   const [name, setName] = useState("");
   const [icon, setIcon] = useState("");
   const [starsRequired, setStarsRequired] = useState(5);
+  const [showEmojis, setShowEmojis] = useState(false);
+  const [showSuggestions, setShowSuggestions] = useState(false);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -293,6 +663,24 @@ function RewardForm({
     );
   };
 
+  const handlePickSuggestion = (suggestion: {
+    icon: string;
+    name: string;
+  }) => {
+    setIcon(suggestion.icon);
+    setName(suggestion.name);
+    setShowSuggestions(false);
+  };
+
+  const pickRandom = () => {
+    const s =
+      REWARD_SUGGESTIONS[
+        Math.floor(Math.random() * REWARD_SUGGESTIONS.length)
+      ]!;
+    setIcon(s.icon);
+    setName(s.name);
+  };
+
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div className="space-y-2">
@@ -303,7 +691,9 @@ function RewardForm({
             onChange={(e) => setIcon(e.target.value)}
             placeholder="🎁"
             maxLength={10}
-            className="w-14 flex-none text-center text-lg"
+            className="w-14 flex-none text-center text-lg cursor-pointer"
+            readOnly
+            onClick={() => setShowEmojis(!showEmojis)}
           />
           <InputGroupInput
             id="reward-name"
@@ -312,8 +702,42 @@ function RewardForm({
             placeholder="Un temps de dessin avec maman"
             required
           />
+          <InputGroupAddon align="inline-end">
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <InputGroupButton onClick={pickRandom}>
+                    <Shuffle className="h-3.5 w-3.5" />
+                  </InputGroupButton>
+                }
+              />
+              <TooltipContent>Suggestion au hasard</TooltipContent>
+            </Tooltip>
+          </InputGroupAddon>
         </InputGroup>
       </div>
+
+      {/* Emoji picker grid */}
+      {showEmojis && (
+        <div className="grid grid-cols-8 gap-1 rounded-lg border p-2">
+          {REWARD_EMOJIS.map((emoji) => (
+            <button
+              key={emoji}
+              type="button"
+              onClick={() => {
+                setIcon(emoji);
+                setShowEmojis(false);
+              }}
+              className={`flex h-9 w-9 items-center justify-center rounded-md text-lg hover:bg-accent transition-colors ${
+                icon === emoji ? "bg-accent ring-2 ring-primary" : ""
+              }`}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+      )}
+
       <div className="space-y-2">
         <Label htmlFor="reward-stars">Étoiles nécessaires</Label>
         <Input
@@ -328,6 +752,33 @@ function RewardForm({
           Nombre d'étoiles cumulées pour débloquer cette récompense.
         </p>
       </div>
+
+      <Button
+        type="button"
+        variant="outline"
+        className="w-full"
+        onClick={() => setShowSuggestions(!showSuggestions)}
+      >
+        <Sparkles className="mr-2 h-4 w-4" />
+        {showSuggestions ? "Masquer les idées" : "Des idées ?"}
+      </Button>
+
+      {showSuggestions && (
+        <div className="grid grid-cols-1 gap-1.5 max-h-52 overflow-y-auto rounded-lg border p-2">
+          {REWARD_SUGGESTIONS.map((s) => (
+            <button
+              key={s.name}
+              type="button"
+              onClick={() => handlePickSuggestion(s)}
+              className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm hover:bg-accent transition-colors"
+            >
+              <span className="text-base">{s.icon}</span>
+              <span>{s.name}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
       <Button
         type="submit"
         className="w-full"

--- a/packages/validators/src/barkley.ts
+++ b/packages/validators/src/barkley.ts
@@ -55,6 +55,15 @@ export const createBarkleyRewardSchema = z.object({
   sortOrder: z.number().int().min(0).optional().default(0),
 });
 
+export const updateBarkleyRewardSchema = createBarkleyRewardSchema
+  .partial()
+  .omit({ childId: true });
+
+export const reorderBarkleyRewardsSchema = z.object({
+  childId: z.string().uuid(),
+  orderedIds: z.array(z.string().uuid()).min(1),
+});
+
 export const barkleyRewardSchema = createBarkleyRewardSchema.extend({
   id: z.string().uuid(),
   claimedAt: z.coerce.string().nullable(),
@@ -63,6 +72,8 @@ export const barkleyRewardSchema = createBarkleyRewardSchema.extend({
 });
 
 export type CreateBarkleyReward = z.input<typeof createBarkleyRewardSchema>;
+export type UpdateBarkleyReward = z.infer<typeof updateBarkleyRewardSchema>;
+export type ReorderBarkleyRewards = z.infer<typeof reorderBarkleyRewardsSchema>;
 export type BarkleyReward = z.infer<typeof barkleyRewardSchema>;
 
 // --- Barkley Behavior Logs (daily check-offs) ---

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,15 @@ importers:
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.4)
       '@focusflow/validators':
         specifier: workspace:*
         version: link:../../packages/validators
@@ -501,6 +510,28 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@dotenvx/dotenvx@1.57.1':
     resolution: {integrity: sha512-iKXuo8Nes9Ft4zF3AZOT4FHkl6OV8bHqn61a67qHokkBzSEurnKZAlOkT0FYrRNVGvE6nCfZMtYswyjfXCR1MQ==}
@@ -3917,6 +3948,31 @@ snapshots:
   '@csstools/css-tokenizer@4.0.0': {}
 
   '@date-fns/tz@1.4.1': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.4)
+      react: 19.2.4
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
 
   '@dotenvx/dotenvx@1.57.1':
     dependencies:


### PR DESCRIPTION
## Résumé technique

### Contexte
La page récompenses ne permettait que la création et la suppression d'items. Le champ emoji était en saisie libre, sans suggestions prédéfinies. La colonne `sortOrder` existait en base mais était inutilisée, et aucun mécanisme de réordonnancement n'était disponible.

### Approche retenue
Réutilisation systématique des patterns existants dans le codebase :
- **PATCH endpoint** : calqué sur `PATCH /behaviors/:id` (même structure fetch → ownership → update → return)
- **Reorder endpoint** : calqué sur `POST /crisis-list/:childId/reorder` (même pattern `orderedIds`)
- **Suggestions** : même pattern que `BEHAVIOR_SUGGESTIONS` et `SUGGESTIONS` (crisis-list)
- **Drag-and-drop** : nouvelle dépendance `@dnd-kit` (~15KB) pour le réordonnancement tactile/souris

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `packages/validators/src/barkley.ts` | Ajout `updateBarkleyRewardSchema` + `reorderBarkleyRewardsSchema` | Cohérence avec `updateBarkleyBehaviorSchema` et `reorderCrisisItemsSchema` |
| `apps/api/src/routes/barkley.ts` | PATCH /rewards/:id, POST /rewards/:childId/reorder, fix GET ordering, auto-assign sortOrder | Endpoints manquants, activation de la colonne `sortOrder` existante |
| `apps/web/src/hooks/use-barkley.ts` | `useUpdateBarkleyReward` + `useReorderBarkleyRewards` | Hooks miroir de `useUpdateBarkleyBehavior` et `useReorderCrisisItems` |
| `apps/web/src/routes/_authenticated/rewards/index.tsx` | Inline edit, emoji picker grid, suggestions, DnD | Refonte complète de la page avec les 4 fonctionnalités |
| `apps/web/package.json` | Ajout `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` | Nécessaire pour le drag-and-drop |

### Points d'attention pour la revue
- Le PATCH rejette les modifications sur les récompenses déjà réclamées (409) — intentionnel pour l'intégrité des données
- Les récompenses réclamées sont affichées en bas, non-draggables — séparation intentionnelle
- Le reorder n'est pas wrappé en transaction (acceptable pour des listes de 5-10 items, pattern identique à crisis-list)
- L'emoji picker est un grid inline de 40 émojis (pas de librairie externe type emoji-mart)
- Layout passé de grid 3 colonnes à liste verticale pour supporter le drag-and-drop

### Tests
- 18 tests exécutés, 18 passés, 0 échoués
- Typecheck OK sur tous les packages

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation des tests
- [ ] Test manuel du drag-and-drop sur mobile
- [ ] Merge après approbation

---
_Implémentation générée automatiquement par IA_