### PR TITLE
Make EmojiPicker reusable across all emoji selection UIs

### DIFF
--- a/apps/web/src/components/barkley/behavior-tracking.tsx
+++ b/apps/web/src/components/barkley/behavior-tracking.tsx
@@ -17,6 +17,7 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from "@/components/ui/input-group";
+import { EmojiPicker } from "@/components/emoji-picker";
 import {
   Tooltip,
   TooltipContent,
@@ -479,13 +480,7 @@ function BehaviorForm({
       <div className="space-y-2">
         <Label htmlFor="beh-name">Nom du comportement</Label>
         <InputGroup>
-          <InputGroupInput
-            value={icon}
-            onChange={(e) => setIcon(e.target.value)}
-            placeholder="🧹"
-            maxLength={10}
-            className="w-14 flex-none text-center text-lg"
-          />
+          <EmojiPicker value={icon} onSelect={setIcon} placeholder="🧹" />
           <InputGroupInput
             id="beh-name"
             value={name}

--- a/apps/web/src/components/emoji-picker.tsx
+++ b/apps/web/src/components/emoji-picker.tsx
@@ -1,10 +1,11 @@
+import type { ReactElement } from "react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
 
-const DEFAULT_EMOJIS = [
+export const DEFAULT_EMOJIS = [
   "🎁", "🎮", "🎨", "🍦", "🍕", "🍿", "🎬", "🎪",
   "🎠", "🏊", "⚽", "🚴", "🛝", "🎯", "🧩", "🎲",
   "📖", "🖍️", "🎵", "🎤", "🛍️", "👑", "🌟", "🏆",
@@ -12,31 +13,52 @@ const DEFAULT_EMOJIS = [
   "📺", "🎧", "💤", "🛁", "🐾", "🌳", "🚀", "✨",
 ];
 
+export const CRISIS_EMOJIS = [
+  "🧸", "🎵", "📺", "🫧", "🖍️",
+  "🤗", "📖", "🧘", "🏃", "🛁",
+  "🎮", "🐾", "🧩", "🎨", "🌳",
+  "💤", "🎧", "🫂", "⚽", "🍫",
+  "💙", "⭐", "🌈", "🎪", "😊",
+];
+
+const GRID_COLS: Record<number, string> = {
+  5: "grid-cols-5",
+  6: "grid-cols-6",
+  7: "grid-cols-7",
+  8: "grid-cols-8",
+};
+
 export function EmojiPicker({
   value,
   onSelect,
   emojis = DEFAULT_EMOJIS,
   placeholder = "🎁",
+  columns = 8,
+  children,
 }: {
   value: string;
   onSelect: (emoji: string) => void;
   emojis?: string[];
   placeholder?: string;
+  columns?: number;
+  children?: ReactElement;
 }) {
   return (
     <Popover>
-      <PopoverTrigger
-        className="flex h-9 w-14 flex-none cursor-pointer items-center justify-center rounded-l-md border border-r-0 bg-background text-lg transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-      >
-        {value || <span className="opacity-50">{placeholder}</span>}
-      </PopoverTrigger>
+      {children ? (
+        <PopoverTrigger render={children} />
+      ) : (
+        <PopoverTrigger className="flex h-9 w-14 flex-none cursor-pointer items-center justify-center rounded-l-md border border-r-0 bg-background text-lg transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+          {value || <span className="opacity-50">{placeholder}</span>}
+        </PopoverTrigger>
+      )}
       <PopoverContent
         align="start"
         side="bottom"
         sideOffset={4}
         className="w-auto p-2"
       >
-        <div className="grid grid-cols-8 gap-1">
+        <div className={`grid gap-1 ${GRID_COLS[columns] ?? "grid-cols-8"}`}>
           {emojis.map((emoji) => (
             <button
               key={emoji}

--- a/apps/web/src/routes/_authenticated/crisis-list/index.tsx
+++ b/apps/web/src/routes/_authenticated/crisis-list/index.tsx
@@ -28,12 +28,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 import { PageLoader } from "@/components/ui/page-loader";
+import { EmojiPicker, CRISIS_EMOJIS } from "@/components/emoji-picker";
 import {
   useCrisisItems,
   useCreateCrisisItem,
@@ -47,16 +43,6 @@ import type { CrisisItem } from "@focusflow/validators";
 export const Route = createFileRoute("/_authenticated/crisis-list/")({
   component: CrisisListPage,
 });
-
-// ─── Emoji options for the picker ─────────────────────────
-
-const EMOJI_OPTIONS = [
-  "🧸", "🎵", "📺", "🫧", "🖍️",
-  "🤗", "📖", "🧘", "🏃", "🛁",
-  "🎮", "🐾", "🧩", "🎨", "🌳",
-  "💤", "🎧", "🫂", "⚽", "🍫",
-  "💙", "⭐", "🌈", "🎪", "😊",
-];
 
 // ─── Suggestions ────────────────────────────────────────
 
@@ -196,55 +182,6 @@ function CrisisListPage() {
   );
 }
 
-// ─── Emoji Picker (custom select) ─────────────────────────
-
-function EmojiPicker({
-  value,
-  onChange,
-}: {
-  value: string;
-  onChange: (emoji: string) => void;
-}) {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger
-        render={
-          <button
-            type="button"
-            className="flex h-10 w-16 shrink-0 items-center justify-center gap-1 rounded-md border bg-background text-xl transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            <span>{value || "😊"}</span>
-            <ChevronDown className="h-3 w-3 text-muted-foreground" />
-          </button>
-        }
-      />
-      <PopoverContent align="start" className="w-auto p-2">
-        <div className="grid grid-cols-5 gap-1">
-          {EMOJI_OPTIONS.map((emoji) => (
-            <button
-              key={emoji}
-              type="button"
-              onClick={() => {
-                onChange(emoji);
-                setOpen(false);
-              }}
-              className={`flex h-10 w-10 items-center justify-center rounded-lg text-xl transition-colors hover:bg-accent ${
-                value === emoji
-                  ? "bg-primary/10 ring-2 ring-primary"
-                  : ""
-              }`}
-            >
-              {emoji}
-            </button>
-          ))}
-        </div>
-      </PopoverContent>
-    </Popover>
-  );
-}
-
 // ─── Item Card ──────────────────────────────────────────
 
 function CrisisItemCard({
@@ -381,7 +318,21 @@ function CrisisItemForm({
           {isEdit ? "Modifier l'activité" : "Qu'est-ce qui te fait du bien ?"}
         </Label>
         <div className="flex gap-2">
-          <EmojiPicker value={emoji} onChange={setEmoji} />
+          <EmojiPicker
+            value={emoji}
+            onSelect={setEmoji}
+            emojis={CRISIS_EMOJIS}
+            columns={5}
+            placeholder="😊"
+          >
+            <button
+              type="button"
+              className="flex h-10 w-16 shrink-0 items-center justify-center gap-1 rounded-md border bg-background text-xl transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <span>{emoji || <span className="opacity-50">😊</span>}</span>
+              <ChevronDown className="h-3 w-3 text-muted-foreground" />
+            </button>
+          </EmojiPicker>
           <div className="flex flex-1 gap-1">
             <Input
               id="crisis-label"


### PR DESCRIPTION
## Résumé technique

### Contexte
Le composant `EmojiPicker` créé dans la PR #23 était spécifique aux récompenses avec un trigger hardcodé (style InputGroup). Deux autres fonctionnalités avaient des implémentations divergentes :
- **Behavior Tracking** : input texte brut — les parents devaient taper/coller des emojis manuellement
- **Crisis List** : `EmojiPicker` local dupliqué avec styles différents (5 colonnes, `h-10 w-10`, `bg-primary/10`)

### Approche retenue
Rendre le composant `EmojiPicker` composable via un pattern `children` comme trigger personnalisable, plutôt qu'un système de `variant` props. Ajout d'un prop `columns` pour contrôler la grille.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/web/src/components/emoji-picker.tsx` | Ajout props `children` (trigger custom) et `columns` (défaut 8). Export des constantes `DEFAULT_EMOJIS` et `CRISIS_EMOJIS` | Composition over configuration — le trigger est la responsabilité du consommateur |
| `apps/web/src/components/barkley/behavior-tracking.tsx` | Remplacement du `InputGroupInput` texte par `EmojiPicker` | Correction du pire UX de l'app — les parents n'ont plus à taper des emojis |
| `apps/web/src/routes/_authenticated/crisis-list/index.tsx` | Suppression du `EmojiPicker` local et de `EMOJI_OPTIONS`. Import du composant partagé avec trigger custom (bouton + chevron, 5 colonnes) | Élimine la duplication et les divergences de style |

### Points d'attention pour la revue
- Le trigger par défaut (sans `children`) conserve le style `rounded-l-md border-r-0` pour l'intégration InputGroup — aucun impact sur les Rewards existantes
- La crise utilise un trigger custom via `children` avec `ChevronDown` — vérifier le rendu visuel
- Tester le popover dans les trois contextes : dialogue Rewards, dialogue Behavior, dialogue Crisis

### Tests
- Typecheck : 2 exécutés, 2 passés, 0 échoué
- Tests unitaires : 3 suites, tous passés, 0 échoué

### Prochaines étapes
- [ ] Revue de code
- [ ] Test visuel sur mobile (375px) dans les 3 dialogues
- [ ] Merge après approbation

---
_Implémentation générée automatiquement par IA_