### PR TITLE
Extract reusable components and enforce separation of concerns

### DIFF
--- a/apps/web/src/components/journal/journal-card.tsx
+++ b/apps/web/src/components/journal/journal-card.tsx
@@ -1,0 +1,55 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { JournalTag, JournalEntry } from "@focusflow/validators";
+
+const tagConfig: Record<
+  JournalTag,
+  { label: string; variant: "default" | "secondary" | "outline" | "destructive" }
+> = {
+  school: { label: "École", variant: "default" },
+  victory: { label: "Victoire", variant: "default" },
+  crisis: { label: "Crise", variant: "destructive" },
+  medication: { label: "Traitement", variant: "secondary" },
+  sleep: { label: "Sommeil", variant: "secondary" },
+  sport: { label: "Sport", variant: "outline" },
+  therapy: { label: "Thérapie", variant: "outline" },
+};
+
+const moodEmojis = ["😢", "😐", "🙂", "😄"];
+
+export { tagConfig, moodEmojis };
+
+export function JournalCard({ entry }: { entry: JournalEntry }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm font-medium">
+            {new Date(entry.date).toLocaleDateString("fr-FR", {
+              weekday: "long",
+              day: "numeric",
+              month: "long",
+            })}
+          </CardTitle>
+          <span className="text-lg">{moodEmojis[entry.moodRating - 1]}</span>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <p className="text-sm text-foreground">{entry.text}</p>
+        {entry.tags.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {entry.tags.map((tag) => (
+              <Badge
+                key={tag}
+                variant={tagConfig[tag as JournalTag]?.variant ?? "secondary"}
+                className="text-xs"
+              >
+                {tagConfig[tag as JournalTag]?.label ?? tag}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/journal/journal-form.tsx
+++ b/apps/web/src/components/journal/journal-form.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { useCreateJournalEntry } from "@/hooks/use-journal";
+import { useUiStore } from "@/stores/ui-store";
+import { tagConfig, moodEmojis } from "@/components/journal/journal-card";
+import type { JournalTag } from "@focusflow/validators";
+
+export function JournalForm({ onSuccess }: { onSuccess: () => void }) {
+  const activeChildId = useUiStore((s) => s.activeChildId);
+  const createEntry = useCreateJournalEntry();
+  const [text, setText] = useState("");
+  const [selectedTags, setSelectedTags] = useState<JournalTag[]>([]);
+  const [moodRating, setMoodRating] = useState(3);
+
+  const toggleTag = (tag: JournalTag) => {
+    setSelectedTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    );
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!activeChildId) return;
+
+    createEntry.mutate(
+      {
+        childId: activeChildId,
+        date: new Date().toISOString().split("T")[0]!,
+        text,
+        tags: selectedTags,
+        moodRating,
+      },
+      { onSuccess }
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label>Humeur du jour</Label>
+        <div className="flex justify-around">
+          {moodEmojis.map((emoji, i) => (
+            <button
+              key={i}
+              type="button"
+              onClick={() => setMoodRating(i + 1)}
+              className={`rounded-xl px-4 py-2 text-2xl transition-all ${
+                moodRating === i + 1
+                  ? "bg-primary/10 ring-2 ring-primary"
+                  : "hover:bg-accent"
+              }`}
+            >
+              {emoji}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label>Tags</Label>
+        <div className="flex flex-wrap gap-2">
+          {(
+            Object.entries(tagConfig) as [
+              JournalTag,
+              (typeof tagConfig)[JournalTag],
+            ][]
+          ).map(([tag, config]) => (
+            <Badge
+              key={tag}
+              variant={selectedTags.includes(tag) ? "default" : "outline"}
+              className="cursor-pointer"
+              onClick={() => toggleTag(tag)}
+            >
+              {config.label}
+            </Badge>
+          ))}
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="journal-text">Notes</Label>
+        <Textarea
+          id="journal-text"
+          placeholder="Comment s'est passée la journée ?"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={5}
+          required
+        />
+      </div>
+
+      <Button
+        type="submit"
+        className="w-full"
+        disabled={!activeChildId || createEntry.isPending}
+      >
+        {createEntry.isPending ? "Enregistrement..." : "Enregistrer"}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/components/shared/add-child-form.tsx
+++ b/apps/web/src/components/shared/add-child-form.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import { Shuffle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useCreateChild } from "@/hooks/use-children";
+import { useUiStore } from "@/stores/ui-store";
+
+const RANDOM_FIRSTNAMES = [
+  "Petit Loup", "Étoile", "Chouette", "Papillon", "Ourson",
+  "Luciole", "Panda", "Colibri", "Renardeau", "Coccinelle",
+  "Doudou", "Câlin", "Perle", "Nuage", "Soleil",
+];
+
+function getRandomFirstname() {
+  return RANDOM_FIRSTNAMES[Math.floor(Math.random() * RANDOM_FIRSTNAMES.length)]!;
+}
+
+export function AddChildForm({ onSuccess }: { onSuccess: () => void }) {
+  const createChild = useCreateChild();
+  const setActiveChild = useUiStore((s) => s.setActiveChild);
+  const [name, setName] = useState("");
+  const [birthDate, setBirthDate] = useState("");
+  const [gender, setGender] = useState<string>("");
+  const [diagnosisType, setDiagnosisType] = useState<string>("undefined");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    createChild.mutate(
+      {
+        name,
+        birthDate,
+        ...(gender && { gender: gender as "male" | "female" | "other" }),
+        diagnosisType: diagnosisType as "inattentive" | "hyperactive" | "mixed" | "undefined",
+      },
+      {
+        onSuccess: (data) => {
+          setActiveChild(data.id);
+          onSuccess();
+        },
+      }
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="child-name">Prénom</Label>
+        <div className="flex gap-2">
+          <Input
+            id="child-name"
+            placeholder="Prénom de l'enfant"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="icon"
+                  className="shrink-0"
+                  onClick={() => setName(getRandomFirstname())}
+                />
+              }
+            >
+              <Shuffle className="h-4 w-4" />
+            </TooltipTrigger>
+            <TooltipContent>
+              Générer un surnom aléatoire pour protéger la vie privée de votre enfant
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="child-birth">Date de naissance</Label>
+        <Input
+          id="child-birth"
+          type="date"
+          value={birthDate}
+          onChange={(e) => setBirthDate(e.target.value)}
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="child-gender">Genre</Label>
+        <Select
+          value={gender}
+          onValueChange={(v) => v && setGender(v)}
+          items={{ male: "Garçon", female: "Fille", other: "Autre" }}
+        >
+          <SelectTrigger>
+            <SelectValue placeholder="Non renseigné" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="male" label="Garçon">Garçon</SelectItem>
+            <SelectItem value="female" label="Fille">Fille</SelectItem>
+            <SelectItem value="other" label="Autre">Autre</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="child-diagnosis">Type de diagnostic</Label>
+        <Select
+          value={diagnosisType}
+          onValueChange={(v) => v && setDiagnosisType(v)}
+          items={{ undefined: "Non défini", inattentive: "Inattentif", hyperactive: "Hyperactif", mixed: "Mixte" }}
+        >
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="undefined" label="Non défini">Non défini</SelectItem>
+            <SelectItem value="inattentive" label="Inattentif">Inattentif</SelectItem>
+            <SelectItem value="hyperactive" label="Hyperactif">Hyperactif</SelectItem>
+            <SelectItem value="mixed" label="Mixte">Mixte</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+      <Button
+        type="submit"
+        className="w-full"
+        disabled={createChild.isPending}
+      >
+        {createChild.isPending ? "Ajout..." : "Ajouter"}
+      </Button>
+    </form>
+  );
+}

--- a/apps/web/src/components/shared/child-selector.tsx
+++ b/apps/web/src/components/shared/child-selector.tsx
@@ -1,9 +1,7 @@
 import { useEffect, useState } from "react";
-import { Plus, Shuffle } from "lucide-react";
+import { Plus } from "lucide-react";
 import { getChildEmoji, formatChildAge } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectTrigger,
@@ -18,13 +16,9 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import { useChildren, useCreateChild } from "@/hooks/use-children";
+import { useChildren } from "@/hooks/use-children";
 import { useUiStore } from "@/stores/ui-store";
+import { AddChildForm } from "@/components/shared/add-child-form";
 
 export function ChildSelector() {
   const { data: children, isLoading } = useChildren();
@@ -115,130 +109,5 @@ export function ChildSelector() {
         </DialogContent>
       </Dialog>
     </div>
-  );
-}
-
-const RANDOM_FIRSTNAMES = [
-  "Petit Loup", "Étoile", "Chouette", "Papillon", "Ourson",
-  "Luciole", "Panda", "Colibri", "Renardeau", "Coccinelle",
-  "Doudou", "Câlin", "Perle", "Nuage", "Soleil",
-];
-
-function getRandomFirstname() {
-  return RANDOM_FIRSTNAMES[Math.floor(Math.random() * RANDOM_FIRSTNAMES.length)]!;
-}
-
-function AddChildForm({ onSuccess }: { onSuccess: () => void }) {
-  const createChild = useCreateChild();
-  const setActiveChild = useUiStore((s) => s.setActiveChild);
-  const [name, setName] = useState("");
-  const [birthDate, setBirthDate] = useState("");
-  const [gender, setGender] = useState<string>("");
-  const [diagnosisType, setDiagnosisType] = useState<string>("undefined");
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    createChild.mutate(
-      {
-        name,
-        birthDate,
-        ...(gender && { gender: gender as "male" | "female" | "other" }),
-        diagnosisType: diagnosisType as "inattentive" | "hyperactive" | "mixed" | "undefined",
-      },
-      {
-        onSuccess: (data) => {
-          setActiveChild(data.id);
-          onSuccess();
-        },
-      }
-    );
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="space-y-2">
-        <Label htmlFor="child-name">Prénom</Label>
-        <div className="flex gap-2">
-          <Input
-            id="child-name"
-            placeholder="Prénom de l'enfant"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-          />
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  className="shrink-0"
-                  onClick={() => setName(getRandomFirstname())}
-                />
-              }
-            >
-              <Shuffle className="h-4 w-4" />
-            </TooltipTrigger>
-            <TooltipContent>
-              Générer un surnom aléatoire pour protéger la vie privée de votre enfant
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="child-birth">Date de naissance</Label>
-        <Input
-          id="child-birth"
-          type="date"
-          value={birthDate}
-          onChange={(e) => setBirthDate(e.target.value)}
-          required
-        />
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="child-gender">Genre</Label>
-        <Select
-          value={gender}
-          onValueChange={(v) => v && setGender(v)}
-          items={{ male: "Garçon", female: "Fille", other: "Autre" }}
-        >
-          <SelectTrigger>
-            <SelectValue placeholder="Non renseigné" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="male" label="Garçon">Garçon</SelectItem>
-            <SelectItem value="female" label="Fille">Fille</SelectItem>
-            <SelectItem value="other" label="Autre">Autre</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="child-diagnosis">Type de diagnostic</Label>
-        <Select
-          value={diagnosisType}
-          onValueChange={(v) => v && setDiagnosisType(v)}
-          items={{ undefined: "Non défini", inattentive: "Inattentif", hyperactive: "Hyperactif", mixed: "Mixte" }}
-        >
-          <SelectTrigger>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="undefined" label="Non défini">Non défini</SelectItem>
-            <SelectItem value="inattentive" label="Inattentif">Inattentif</SelectItem>
-            <SelectItem value="hyperactive" label="Hyperactif">Hyperactif</SelectItem>
-            <SelectItem value="mixed" label="Mixte">Mixte</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <Button
-        type="submit"
-        className="w-full"
-        disabled={createChild.isPending}
-      >
-        {createChild.isPending ? "Ajout..." : "Ajouter"}
-      </Button>
-    </form>
   );
 }

--- a/apps/web/src/components/symptoms/symptom-card.tsx
+++ b/apps/web/src/components/symptoms/symptom-card.tsx
@@ -1,0 +1,52 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Badge } from "@/components/ui/badge";
+import type { Symptom } from "@focusflow/validators";
+
+export const dimensionLabels: Record<string, { label: string; color: string }> = {
+  agitation: { label: "Agitation", color: "bg-status-danger" },
+  focus: { label: "Concentration", color: "bg-status-success" },
+  impulse: { label: "Impulsivité", color: "bg-status-warning" },
+  mood: { label: "Régulation ém.", color: "bg-primary" },
+  sleep: { label: "Sommeil", color: "bg-chart-5" },
+  social: { label: "Comp. social", color: "bg-chart-4" },
+  autonomy: { label: "Autonomie", color: "bg-chart-2" },
+};
+
+export function SymptomCard({ symptom }: { symptom: Symptom }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm font-medium">
+            {new Date(symptom.date).toLocaleDateString("fr-FR", {
+              weekday: "long",
+              day: "numeric",
+              month: "long",
+            })}
+          </CardTitle>
+          {symptom.context && (
+            <Badge variant="secondary">{symptom.context}</Badge>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {Object.entries(dimensionLabels).map(([key, { label, color }]) => {
+          const value = symptom[key as keyof typeof symptom] as number;
+          return (
+            <div key={key} className="space-y-1">
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-muted-foreground">{label}</span>
+                <span className="font-medium">{value}/10</span>
+              </div>
+              <Progress value={value * 10} className={`h-2 ${color}`} />
+            </div>
+          );
+        })}
+        {symptom.notes && (
+          <p className="mt-2 text-sm text-muted-foreground">{symptom.notes}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/routes/_authenticated/dashboard/index.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard/index.tsx
@@ -1,18 +1,9 @@
 import { useState, useEffect } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { toast } from "sonner";
-import { Flame, Calendar, SmilePlus, Plus, Shuffle } from "lucide-react";
+import { Flame, Calendar, SmilePlus, Plus } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from "@/components/ui/select";
 import {
   Dialog,
   DialogContent,
@@ -20,15 +11,11 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
 import { PageLoader } from "@/components/ui/page-loader";
 import { MoodLogger } from "@/components/dashboard/mood-logger";
 import { WeeklyChart } from "@/components/dashboard/weekly-chart";
-import { useChildren, useCreateChild } from "@/hooks/use-children";
+import { AddChildForm } from "@/components/shared/add-child-form";
+import { useChildren } from "@/hooks/use-children";
 import { useStats } from "@/hooks/use-stats";
 import { useUiStore } from "@/stores/ui-store";
 
@@ -158,130 +145,5 @@ function KpiCard({
         <p className="text-xs text-muted-foreground">{subtitle}</p>
       </CardContent>
     </Card>
-  );
-}
-
-const RANDOM_FIRSTNAMES = [
-  "Petit Loup", "Étoile", "Chouette", "Papillon", "Ourson",
-  "Luciole", "Panda", "Colibri", "Renardeau", "Coccinelle",
-  "Doudou", "Câlin", "Perle", "Nuage", "Soleil",
-];
-
-function getRandomFirstname() {
-  return RANDOM_FIRSTNAMES[Math.floor(Math.random() * RANDOM_FIRSTNAMES.length)]!;
-}
-
-function AddChildForm({ onSuccess }: { onSuccess: () => void }) {
-  const createChild = useCreateChild();
-  const setActiveChild = useUiStore((s) => s.setActiveChild);
-  const [name, setName] = useState("");
-  const [birthDate, setBirthDate] = useState("");
-  const [gender, setGender] = useState<string>("");
-  const [diagnosisType, setDiagnosisType] = useState<string>("undefined");
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-
-    createChild.mutate(
-      {
-        name,
-        birthDate,
-        ...(gender && { gender: gender as "male" | "female" | "other" }),
-        diagnosisType: diagnosisType as "inattentive" | "hyperactive" | "mixed" | "undefined",
-      },
-      {
-        onSuccess: (data) => {
-          setActiveChild(data.id);
-          onSuccess();
-        },
-      }
-    );
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="space-y-2">
-        <Label htmlFor="child-name">Prénom</Label>
-        <div className="flex gap-2">
-          <Input
-            id="child-name"
-            placeholder="Prénom de l'enfant"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-          />
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="icon"
-                  className="shrink-0"
-                  onClick={() => setName(getRandomFirstname())}
-                />
-              }
-            >
-              <Shuffle className="h-4 w-4" />
-            </TooltipTrigger>
-            <TooltipContent>
-              Générer un surnom aléatoire pour protéger la vie privée de votre enfant
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="child-birth">Date de naissance</Label>
-        <Input
-          id="child-birth"
-          type="date"
-          value={birthDate}
-          onChange={(e) => setBirthDate(e.target.value)}
-          required
-        />
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="child-gender">Genre</Label>
-        <Select
-          value={gender}
-          onValueChange={(v) => v && setGender(v)}
-          items={{ male: "Garçon", female: "Fille", other: "Autre" }}
-        >
-          <SelectTrigger>
-            <SelectValue placeholder="Non renseigné" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="male" label="Garçon">Garçon</SelectItem>
-            <SelectItem value="female" label="Fille">Fille</SelectItem>
-            <SelectItem value="other" label="Autre">Autre</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="child-diagnosis">Type de diagnostic</Label>
-        <Select
-          value={diagnosisType}
-          onValueChange={(v) => v && setDiagnosisType(v)}
-          items={{ undefined: "Non défini", inattentive: "Inattentif", hyperactive: "Hyperactif", mixed: "Mixte" }}
-        >
-          <SelectTrigger>
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="undefined" label="Non défini">Non défini</SelectItem>
-            <SelectItem value="inattentive" label="Inattentif">Inattentif</SelectItem>
-            <SelectItem value="hyperactive" label="Hyperactif">Hyperactif</SelectItem>
-            <SelectItem value="mixed" label="Mixte">Mixte</SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
-      <Button
-        type="submit"
-        className="w-full"
-        disabled={createChild.isPending}
-      >
-        {createChild.isPending ? "Ajout..." : "Ajouter"}
-      </Button>
-    </form>
   );
 }

--- a/apps/web/src/routes/_authenticated/journal/index.tsx
+++ b/apps/web/src/routes/_authenticated/journal/index.tsx
@@ -1,11 +1,8 @@
 import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { Plus, BookOpen } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
@@ -14,28 +11,14 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { PageLoader } from "@/components/ui/page-loader";
-import { useJournal, useCreateJournalEntry } from "@/hooks/use-journal";
+import { JournalCard } from "@/components/journal/journal-card";
+import { JournalForm } from "@/components/journal/journal-form";
+import { useJournal } from "@/hooks/use-journal";
 import { useUiStore } from "@/stores/ui-store";
-import type { JournalTag, JournalEntry } from "@focusflow/validators";
 
 export const Route = createFileRoute("/_authenticated/journal/")({
   component: JournalPage,
 });
-
-const tagConfig: Record<
-  JournalTag,
-  { label: string; variant: "default" | "secondary" | "outline" | "destructive" }
-> = {
-  school: { label: "École", variant: "default" },
-  victory: { label: "Victoire", variant: "default" },
-  crisis: { label: "Crise", variant: "destructive" },
-  medication: { label: "Traitement", variant: "secondary" },
-  sleep: { label: "Sommeil", variant: "secondary" },
-  sport: { label: "Sport", variant: "outline" },
-  therapy: { label: "Thérapie", variant: "outline" },
-};
-
-const moodEmojis = ["😢", "😐", "🙂", "😄"];
 
 function JournalPage() {
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -95,135 +78,5 @@ function JournalPage() {
         </div>
       )}
     </div>
-  );
-}
-
-function JournalCard({ entry }: { entry: JournalEntry }) {
-  return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-sm font-medium">
-            {new Date(entry.date).toLocaleDateString("fr-FR", {
-              weekday: "long",
-              day: "numeric",
-              month: "long",
-            })}
-          </CardTitle>
-          <span className="text-lg">{moodEmojis[entry.moodRating - 1]}</span>
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-2">
-        <p className="text-sm text-foreground">{entry.text}</p>
-        {entry.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {entry.tags.map((tag) => (
-              <Badge
-                key={tag}
-                variant={tagConfig[tag as JournalTag]?.variant ?? "secondary"}
-                className="text-xs"
-              >
-                {tagConfig[tag as JournalTag]?.label ?? tag}
-              </Badge>
-            ))}
-          </div>
-        )}
-      </CardContent>
-    </Card>
-  );
-}
-
-function JournalForm({ onSuccess }: { onSuccess: () => void }) {
-  const activeChildId = useUiStore((s) => s.activeChildId);
-  const createEntry = useCreateJournalEntry();
-  const [text, setText] = useState("");
-  const [selectedTags, setSelectedTags] = useState<JournalTag[]>([]);
-  const [moodRating, setMoodRating] = useState(3);
-
-  const toggleTag = (tag: JournalTag) => {
-    setSelectedTags((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
-    );
-  };
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!activeChildId) return;
-
-    createEntry.mutate(
-      {
-        childId: activeChildId,
-        date: new Date().toISOString().split("T")[0]!,
-        text,
-        tags: selectedTags,
-        moodRating,
-      },
-      { onSuccess }
-    );
-  };
-
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <div className="space-y-2">
-        <Label>Humeur du jour</Label>
-        <div className="flex justify-around">
-          {moodEmojis.map((emoji, i) => (
-            <button
-              key={i}
-              type="button"
-              onClick={() => setMoodRating(i + 1)}
-              className={`rounded-xl px-4 py-2 text-2xl transition-all ${
-                moodRating === i + 1
-                  ? "bg-primary/10 ring-2 ring-primary"
-                  : "hover:bg-accent"
-              }`}
-            >
-              {emoji}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      <div className="space-y-2">
-        <Label>Tags</Label>
-        <div className="flex flex-wrap gap-2">
-          {(
-            Object.entries(tagConfig) as [
-              JournalTag,
-              (typeof tagConfig)[JournalTag],
-            ][]
-          ).map(([tag, config]) => (
-            <Badge
-              key={tag}
-              variant={selectedTags.includes(tag) ? "default" : "outline"}
-              className="cursor-pointer"
-              onClick={() => toggleTag(tag)}
-            >
-              {config.label}
-            </Badge>
-          ))}
-        </div>
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="journal-text">Notes</Label>
-        <Textarea
-          id="journal-text"
-          placeholder="Comment s'est passée la journée ?"
-          value={text}
-          onChange={(e) => setText(e.target.value)}
-          rows={5}
-          required
-        />
-      </div>
-
-      <Button
-        type="submit"
-        className="w-full"
-        disabled={!activeChildId || createEntry.isPending}
-      >
-        {createEntry.isPending ? "Enregistrement..." : "Enregistrer"}
-      </Button>
-    </form>
   );
 }

--- a/apps/web/src/routes/_authenticated/symptoms/index.tsx
+++ b/apps/web/src/routes/_authenticated/symptoms/index.tsx
@@ -1,10 +1,8 @@
 import { useState } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { Plus } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Progress } from "@/components/ui/progress";
-import { Badge } from "@/components/ui/badge";
 import {
   Dialog,
   DialogContent,
@@ -14,9 +12,9 @@ import {
 } from "@/components/ui/dialog";
 import { PageLoader } from "@/components/ui/page-loader";
 import { SymptomForm } from "@/components/symptoms/symptom-form";
+import { SymptomCard } from "@/components/symptoms/symptom-card";
 import { useSymptoms } from "@/hooks/use-symptoms";
 import { useUiStore } from "@/stores/ui-store";
-import type { Symptom } from "@focusflow/validators";
 
 export const Route = createFileRoute("/_authenticated/symptoms/")({
   component: SymptomsPage,
@@ -76,53 +74,5 @@ function SymptomsPage() {
         </div>
       )}
     </div>
-  );
-}
-
-const dimensionLabels: Record<string, { label: string; color: string }> = {
-  agitation: { label: "Agitation", color: "bg-status-danger" },
-  focus: { label: "Concentration", color: "bg-status-success" },
-  impulse: { label: "Impulsivité", color: "bg-status-warning" },
-  mood: { label: "Régulation ém.", color: "bg-primary" },
-  sleep: { label: "Sommeil", color: "bg-chart-5" },
-  social: { label: "Comp. social", color: "bg-chart-4" },
-  autonomy: { label: "Autonomie", color: "bg-chart-2" },
-};
-
-function SymptomCard({ symptom }: { symptom: Symptom }) {
-  return (
-    <Card>
-      <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
-          <CardTitle className="text-sm font-medium">
-            {new Date(symptom.date).toLocaleDateString("fr-FR", {
-              weekday: "long",
-              day: "numeric",
-              month: "long",
-            })}
-          </CardTitle>
-          {symptom.context && (
-            <Badge variant="secondary">{symptom.context}</Badge>
-          )}
-        </div>
-      </CardHeader>
-      <CardContent className="space-y-3">
-        {Object.entries(dimensionLabels).map(([key, { label, color }]) => {
-          const value = symptom[key as keyof typeof symptom] as number;
-          return (
-            <div key={key} className="space-y-1">
-              <div className="flex items-center justify-between text-sm">
-                <span className="text-muted-foreground">{label}</span>
-                <span className="font-medium">{value}/10</span>
-              </div>
-              <Progress value={value * 10} className={`h-2 ${color}`} />
-            </div>
-          );
-        })}
-        {symptom.notes && (
-          <p className="mt-2 text-sm text-muted-foreground">{symptom.notes}</p>
-        )}
-      </CardContent>
-    </Card>
   );
 }


### PR DESCRIPTION
## Résumé technique

### Contexte
Plusieurs composants UI étaient définis directement dans les fichiers de routes (journal, symptômes, dashboard) au lieu d'être des composants réutilisables extraits. Le formulaire `AddChildForm` était dupliqué à l'identique (~115 lignes) entre `child-selector.tsx` et `dashboard/index.tsx`.

### Approche retenue
Extraction chirurgicale des composants sans changement de comportement. Les fichiers de routes deviennent de purs orchestrateurs (composition + layout). Approche validée par fast-meeting avec 4 personas : Hugo (Frontend), Damien (Architecte), Sarah (PO), Nico (QA).

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `components/shared/add-child-form.tsx` | **Nouveau** — formulaire d'ajout d'enfant extrait | Élimine la duplication entre child-selector et dashboard (~115 lignes x2) |
| `components/shared/child-selector.tsx` | Suppression du `AddChildForm` embarqué, import du composant partagé | Séparation des responsabilités |
| `components/journal/journal-card.tsx` | **Nouveau** — carte d'entrée journal avec config tags/emojis | Extraction depuis route, réutilisable et testable indépendamment |
| `components/journal/journal-form.tsx` | **Nouveau** — formulaire de création journal | Extraction depuis route, importe les constantes partagées depuis journal-card |
| `components/symptoms/symptom-card.tsx` | **Nouveau** — carte symptôme avec `dimensionLabels` exporté | Extraction depuis route, `dimensionLabels` disponible pour d'autres modules (ex: report) |
| `routes/_authenticated/dashboard/index.tsx` | Suppression `AddChildForm` dupliqué + imports inutilisés, import du composant partagé | Route allégée : -125 lignes, KpiCard conservé (usage unique) |
| `routes/_authenticated/journal/index.tsx` | Suppression `JournalCard` + `JournalForm` + constantes, imports composants extraits | Route pure orchestrateur : -132 lignes |
| `routes/_authenticated/symptoms/index.tsx` | Suppression `SymptomCard` + `dimensionLabels`, import composant extrait | Route pure orchestrateur : -48 lignes |

### Points d'attention pour la revue
- Les routes sont maintenant des orchestrateurs purs — vérifier que le wiring des props et callbacks est identique
- `tagConfig` et `moodEmojis` sont exportés depuis `journal-card.tsx` et importés dans `journal-form.tsx` — dépendance intra-domaine acceptable
- `dimensionLabels` est exporté depuis `symptom-card.tsx` pour réutilisation future (ex: `report/index.tsx`)
- KpiCard reste dans `dashboard/index.tsx` (usage unique, 27 lignes — pas de bénéfice à extraire)
- BehaviorTracking (542 lignes) n'est **pas** touché — reporté au prochain changement fonctionnel Barkley (risque de régression sans couverture de test)

### Tests
- TypeScript typecheck : ✅ 2 packages vérifiés
- Unit tests : ✅ 14 tests passés (3 packages), 0 échoués
- Bilan net : **-111 lignes** (367 ajoutées, 478 supprimées)

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation des tests E2E
- [ ] Merge après approbation
- [ ] (Futur) Décomposer `BehaviorTracking` lors du prochain changement Barkley
- [ ] (Futur) Extraire composants de `rewards/index.tsx` (721 lignes) et `crisis-list/index.tsx` (482 lignes)

---
_Implémentation générée automatiquement par IA_