### PR TITLE
feat(symptoms): add update and delete operations

### DIFF
--- a/apps/api/src/routes/symptoms.ts
+++ b/apps/api/src/routes/symptoms.ts
@@ -64,3 +64,77 @@ symptomsRoutes.post("/", async (c) => {
 
   return c.json(symptom, 201);
 });
+
+symptomsRoutes.patch("/:id", async (c) => {
+  const user = c.get("user");
+  const id = c.req.param("id");
+  const body = await c.req.json();
+  const parsed = updateSymptomSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return c.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      422
+    );
+  }
+
+  const [existing] = await db
+    .select()
+    .from(symptoms)
+    .where(eq(symptoms.id, id));
+
+  if (!existing) {
+    throw new AppError("NOT_FOUND", "Relevé non trouvé", 404);
+  }
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(
+      and(eq(children.id, existing.childId), eq(children.parentId, user.id))
+    );
+
+  if (!child) {
+    throw new AppError("FORBIDDEN", "Accès refusé", 403);
+  }
+
+  const [updated] = await db
+    .update(symptoms)
+    .set({ ...parsed.data, updatedAt: new Date() })
+    .where(eq(symptoms.id, id))
+    .returning();
+
+  if (!updated) {
+    throw new AppError("NOT_FOUND", "Relevé non trouvé", 404);
+  }
+
+  return c.json(updated);
+});
+
+symptomsRoutes.delete("/:id", async (c) => {
+  const user = c.get("user");
+  const id = c.req.param("id");
+
+  const [existing] = await db
+    .select()
+    .from(symptoms)
+    .where(eq(symptoms.id, id));
+
+  if (!existing) {
+    throw new AppError("NOT_FOUND", "Relevé non trouvé", 404);
+  }
+
+  const [child] = await db
+    .select()
+    .from(children)
+    .where(
+      and(eq(children.id, existing.childId), eq(children.parentId, user.id))
+    );
+
+  if (!child) {
+    throw new AppError("FORBIDDEN", "Accès refusé", 403);
+  }
+
+  await db.delete(symptoms).where(eq(symptoms.id, id));
+  return c.json({ ok: true });
+});

--- a/apps/web/src/components/symptoms/symptom-card.tsx
+++ b/apps/web/src/components/symptoms/symptom-card.tsx
@@ -1,6 +1,20 @@
+import { Pencil, Trash2 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { useDeleteSymptom } from "@/hooks/use-symptoms";
+import { useUiStore } from "@/stores/ui-store";
 import type { Symptom } from "@focusflow/validators";
 
 export const dimensionLabels: Record<string, { label: string; color: string }> = {
@@ -13,7 +27,16 @@ export const dimensionLabels: Record<string, { label: string; color: string }> =
   autonomy: { label: "Autonomie", color: "bg-chart-2" },
 };
 
-export function SymptomCard({ symptom }: { symptom: Symptom }) {
+export function SymptomCard({
+  symptom,
+  onEdit,
+}: {
+  symptom: Symptom;
+  onEdit: (symptom: Symptom) => void;
+}) {
+  const activeChildId = useUiStore((s) => s.activeChildId);
+  const deleteSymptom = useDeleteSymptom();
+
   return (
     <Card>
       <CardHeader className="pb-3">
@@ -25,9 +48,52 @@ export function SymptomCard({ symptom }: { symptom: Symptom }) {
               month: "long",
             })}
           </CardTitle>
-          {symptom.context && (
-            <Badge variant="secondary">{symptom.context}</Badge>
-          )}
+          <div className="flex items-center gap-1">
+            {symptom.context && (
+              <Badge variant="secondary">{symptom.context}</Badge>
+            )}
+            <button
+              onClick={() => onEdit(symptom)}
+              className="rounded p-1.5 text-muted-foreground/50 hover:text-foreground transition-colors"
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+            <AlertDialog>
+              <AlertDialogTrigger
+                render={
+                  <button
+                    disabled={deleteSymptom.isPending}
+                    className="rounded p-1.5 text-muted-foreground/30 hover:text-destructive transition-colors"
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                }
+              />
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Supprimer ce relevé ?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Cette action est irréversible. Les données de ce relevé
+                    seront définitivement supprimées.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Annuler</AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() =>
+                      activeChildId &&
+                      deleteSymptom.mutate({
+                        id: symptom.id,
+                        childId: activeChildId,
+                      })
+                    }
+                  >
+                    Supprimer
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
         </div>
       </CardHeader>
       <CardContent className="space-y-3">

--- a/apps/web/src/components/symptoms/symptom-form.tsx
+++ b/apps/web/src/components/symptoms/symptom-form.tsx
@@ -4,8 +4,9 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
 import { Textarea } from "@/components/ui/textarea";
-import { useCreateSymptom } from "@/hooks/use-symptoms";
+import { useCreateSymptom, useUpdateSymptom } from "@/hooks/use-symptoms";
 import { useUiStore } from "@/stores/ui-store";
+import type { Symptom } from "@focusflow/validators";
 
 const dimensions = [
   { key: "agitation", label: "Agitation" },
@@ -17,36 +18,62 @@ const dimensions = [
   { key: "autonomy", label: "Autonomie" },
 ] as const;
 
-export function SymptomForm({ onSuccess }: { onSuccess: () => void }) {
+type DimensionKey = (typeof dimensions)[number]["key"];
+
+export function SymptomForm({
+  initialData,
+  onSuccess,
+}: {
+  initialData?: Symptom | null;
+  onSuccess: () => void;
+}) {
   const activeChildId = useUiStore((s) => s.activeChildId);
   const createSymptom = useCreateSymptom();
+  const updateSymptom = useUpdateSymptom();
 
-  const [values, setValues] = useState({
-    agitation: 5,
-    focus: 5,
-    impulse: 5,
-    mood: 5,
-    sleep: 5,
-    social: 5,
-    autonomy: 5,
+  const isEdit = !!initialData;
+
+  const [values, setValues] = useState<Record<DimensionKey, number>>({
+    agitation: initialData?.agitation ?? 5,
+    focus: initialData?.focus ?? 5,
+    impulse: initialData?.impulse ?? 5,
+    mood: initialData?.mood ?? 5,
+    sleep: initialData?.sleep ?? 5,
+    social: initialData?.social ?? 5,
+    autonomy: initialData?.autonomy ?? 5,
   });
-  const [context, setContext] = useState("");
-  const [notes, setNotes] = useState("");
+  const [context, setContext] = useState(initialData?.context ?? "");
+  const [notes, setNotes] = useState(initialData?.notes ?? "");
+
+  const isPending = createSymptom.isPending || updateSymptom.isPending;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (!activeChildId) return;
 
-    createSymptom.mutate(
-      {
-        childId: activeChildId,
-        date: new Date().toISOString().split("T")[0]!,
-        ...values,
-        context: context || undefined,
-        notes: notes || undefined,
-      },
-      { onSuccess }
-    );
+    if (isEdit && initialData) {
+      updateSymptom.mutate(
+        {
+          id: initialData.id,
+          childId: activeChildId,
+          ...values,
+          context: context || undefined,
+          notes: notes || undefined,
+        },
+        { onSuccess }
+      );
+    } else {
+      createSymptom.mutate(
+        {
+          childId: activeChildId,
+          date: new Date().toISOString().split("T")[0]!,
+          ...values,
+          context: context || undefined,
+          notes: notes || undefined,
+        },
+        { onSuccess }
+      );
+    }
   };
 
   return (
@@ -97,9 +124,13 @@ export function SymptomForm({ onSuccess }: { onSuccess: () => void }) {
       <Button
         type="submit"
         className="w-full"
-        disabled={!activeChildId || createSymptom.isPending}
+        disabled={!activeChildId || isPending}
       >
-        {createSymptom.isPending ? "Enregistrement..." : "Enregistrer"}
+        {isPending
+          ? "Enregistrement..."
+          : isEdit
+            ? "Mettre à jour"
+            : "Enregistrer"}
       </Button>
     </form>
   );

--- a/apps/web/src/hooks/use-symptoms.ts
+++ b/apps/web/src/hooks/use-symptoms.ts
@@ -1,6 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
-import type { Symptom, CreateSymptom } from "@focusflow/validators";
+import type { Symptom, CreateSymptom, UpdateSymptom } from "@focusflow/validators";
+import { statsKeys } from "@/hooks/use-stats";
 
 export const symptomKeys = {
   all: (childId: string) => ["symptoms", childId] as const,
@@ -18,9 +19,49 @@ export function useCreateSymptom() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data: CreateSymptom) => api.post<Symptom>("/symptoms", data),
-    onSuccess: (_, variables) =>
+    onSuccess: (_, variables) => {
       queryClient.invalidateQueries({
         queryKey: symptomKeys.all(variables.childId),
-      }),
+      });
+      queryClient.invalidateQueries({
+        queryKey: statsKeys.child(variables.childId),
+      });
+    },
+  });
+}
+
+export function useUpdateSymptom() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      childId,
+      ...data
+    }: UpdateSymptom & { id: string; childId: string }) =>
+      api.patch<Symptom>(`/symptoms/${id}`, data),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: symptomKeys.all(variables.childId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: statsKeys.child(variables.childId),
+      });
+    },
+  });
+}
+
+export function useDeleteSymptom() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id }: { id: string; childId: string }) =>
+      api.delete<{ ok: true }>(`/symptoms/${id}`),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: symptomKeys.all(variables.childId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: statsKeys.child(variables.childId),
+      });
+    },
   });
 }

--- a/apps/web/src/routes/_authenticated/symptoms/index.tsx
+++ b/apps/web/src/routes/_authenticated/symptoms/index.tsx
@@ -8,13 +8,13 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from "@/components/ui/dialog";
 import { PageLoader } from "@/components/ui/page-loader";
 import { SymptomForm } from "@/components/symptoms/symptom-form";
 import { SymptomCard } from "@/components/symptoms/symptom-card";
 import { useSymptoms } from "@/hooks/use-symptoms";
 import { useUiStore } from "@/stores/ui-store";
+import type { Symptom } from "@focusflow/validators";
 
 export const Route = createFileRoute("/_authenticated/symptoms/")({
   component: SymptomsPage,
@@ -22,8 +22,24 @@ export const Route = createFileRoute("/_authenticated/symptoms/")({
 
 function SymptomsPage() {
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [editingItem, setEditingItem] = useState<Symptom | null>(null);
   const activeChildId = useUiStore((s) => s.activeChildId);
   const { data: symptoms, isLoading } = useSymptoms(activeChildId ?? "");
+
+  const openCreate = () => {
+    setEditingItem(null);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (symptom: Symptom) => {
+    setEditingItem(symptom);
+    setDialogOpen(true);
+  };
+
+  const closeDialog = () => {
+    setDialogOpen(false);
+    setEditingItem(null);
+  };
 
   return (
     <div className="space-y-6">
@@ -34,23 +50,26 @@ function SymptomsPage() {
             Suivi quotidien des symptômes TDAH
           </p>
         </div>
-        <Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
-          <DialogTrigger
-            render={
-              <Button>
-                <Plus className="mr-2 h-4 w-4" />
-                Ajouter
-              </Button>
-            }
-          />
-          <DialogContent className="sm:max-w-md">
-            <DialogHeader>
-              <DialogTitle>Nouveau relevé</DialogTitle>
-            </DialogHeader>
-            <SymptomForm onSuccess={() => setDialogOpen(false)} />
-          </DialogContent>
-        </Dialog>
+        <Button onClick={openCreate}>
+          <Plus className="mr-2 h-4 w-4" />
+          Ajouter
+        </Button>
       </div>
+
+      <Dialog open={dialogOpen} onOpenChange={(open) => !open && closeDialog()}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {editingItem ? "Modifier le relevé" : "Nouveau relevé"}
+            </DialogTitle>
+          </DialogHeader>
+          <SymptomForm
+            key={editingItem?.id ?? "create"}
+            initialData={editingItem}
+            onSuccess={closeDialog}
+          />
+        </DialogContent>
+      </Dialog>
 
       {!activeChildId ? (
         <Card>
@@ -69,7 +88,11 @@ function SymptomsPage() {
       ) : (
         <div className="grid gap-4">
           {symptoms.map((symptom) => (
-            <SymptomCard key={symptom.id} symptom={symptom} />
+            <SymptomCard
+              key={symptom.id}
+              symptom={symptom}
+              onEdit={openEdit}
+            />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Résumé technique

### Contexte
Les symptômes (relevés quotidiens TDAH) ne disposaient que des opérations de lecture et création. Les opérations de mise à jour et suppression étaient manquantes, alors que le validateur `updateSymptomSchema` existait déjà inutilisé. Toutes les autres entités (crisis-list, journal, children) avaient un CRUD complet — les symptômes étaient le seul gap de parité.

### Approche retenue
Réplication exacte du pattern CRUD établi par crisis-list : vérification d'ownership en deux étapes (lookup item → vérify parentId via children table), validation Zod, et invalidation des caches React Query (symptoms + stats). Le formulaire SymptomForm passe en mode dual (création/édition) via une prop `initialData` optionnelle, suivant le même pattern que CrisisItemForm.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/api/src/routes/symptoms.ts` | Ajout PATCH /:id et DELETE /:id avec ownership check | Pattern identique à crisis-list.ts — vérification .returning() pour TOCTOU safety |
| `apps/web/src/hooks/use-symptoms.ts` | Ajout useUpdateSymptom + useDeleteSymptom | Invalidation symptoms + stats query keys pour éviter données stale dans les graphiques |
| `apps/web/src/components/symptoms/symptom-form.tsx` | Mode dual create/edit via initialData prop | Préserve la date originale en édition, DimensionKey typé, branche create/update au submit |
| `apps/web/src/routes/_authenticated/symptoms/index.tsx` | Boutons Pencil/Trash2 inline + AlertDialog de confirmation | Icônes inline (pas de dropdown) pour accès rapide mobile, AlertDialog obligatoire car données médicales |

### Points d'attention pour la revue
- Ownership check : la vérification en deux étapes (fetch symptom → verify child.parentId) est critique pour prévenir les IDOR
- Le check `if (!updated)` après `.returning()` protège contre les race conditions TOCTOU
- L'invalidation des statsKeys en plus des symptomKeys garantit la cohérence des graphiques dashboard
- Le `key={editingItem?.id ?? "create"}` sur SymptomForm force le reset du state React entre create/edit

### Tests
- 3 suites exécutées, 3 passées, 0 échouées
- Typecheck clean sur apps/web et apps/api

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation des tests
- [ ] Merge après approbation

---
_Implémentation générée automatiquement par IA_