### PR TITLE
fix(rewards): fix update not working

### DIFF
--- a/apps/web/src/routes/_authenticated/rewards/index.tsx
+++ b/apps/web/src/routes/_authenticated/rewards/index.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
 import { createFileRoute } from "@tanstack/react-router";
+import { toast } from "sonner";
 import {
   Gift,
   Lock,
@@ -327,7 +328,7 @@ function SortableRewardCard({
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: reward.id });
+  } = useSortable({ id: reward.id, disabled: isEditing });
 
   const style = {
     transform: CSS.Transform.toString(transform),
@@ -336,13 +337,11 @@ function SortableRewardCard({
 
   if (isEditing) {
     return (
-      <div ref={setNodeRef} style={style}>
-        <RewardCardEdit
-          reward={reward}
-          childId={childId}
-          onDone={onStopEdit}
-        />
-      </div>
+      <RewardCardEdit
+        reward={reward}
+        childId={childId}
+        onDone={onStopEdit}
+      />
     );
   }
 
@@ -475,15 +474,23 @@ function RewardCardEdit({
   );
   const handleSave = () => {
     if (!name.trim()) return;
+    const safeStar = Number.isFinite(starsRequired) ? starsRequired : 0;
     updateReward.mutate(
       {
         id: reward.id,
         childId,
         name: name.trim(),
         icon: icon || undefined,
-        starsRequired,
+        starsRequired: safeStar,
       },
-      { onSuccess: onDone }
+      {
+        onSuccess: onDone,
+        onError: (err) => {
+          toast.error(
+            err instanceof Error ? err.message : "Erreur lors de la mise à jour"
+          );
+        },
+      }
     );
   };
 
@@ -520,6 +527,14 @@ function RewardCardEdit({
             <Star className="h-3.5 w-3.5 fill-amber-400 text-amber-400" />
           </div>
         </div>
+
+        {updateReward.isError && (
+          <p className="text-xs text-destructive">
+            {updateReward.error instanceof Error
+              ? updateReward.error.message
+              : "Erreur lors de la mise à jour"}
+          </p>
+        )}
 
         <div className="flex justify-end gap-2">
           <Button size="sm" variant="ghost" onClick={onDone}>


### PR DESCRIPTION
## Résumé technique

### Contexte
Les utilisateurs peuvent ajouter et supprimer des récompenses, mais la modification ne fonctionne pas. Analyse de réunion rapide avec 3 experts (Backend, Frontend, QA) a identifié deux causes principales.

### Approche retenue
Correction d'un conflit dnd-kit + ajout de gestion d'erreurs manquante.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/web/src/routes/_authenticated/rewards/index.tsx` | Suppression du wrapper sortable (`setNodeRef`, `style`) autour de `RewardCardEdit` + ajout `disabled: isEditing` à `useSortable` | Le `PointerSensor` de dnd-kit interfère avec les événements pointer du formulaire d'édition (bouton Save, EmojiPicker), empêchant les clics d'atteindre leur cible |
| `apps/web/src/routes/_authenticated/rewards/index.tsx` | Ajout `onError` avec `toast.error()` au `handleSave` de `RewardCardEdit` | Les erreurs PATCH (409 récompense réclamée, 422 validation, 500) étaient complètement silencieuses — aucun feedback utilisateur |
| `apps/web/src/routes/_authenticated/rewards/index.tsx` | Affichage inline de l'erreur (`updateReward.isError`) | Double canal de feedback : toast + message inline dans le formulaire |
| `apps/web/src/routes/_authenticated/rewards/index.tsx` | Protection NaN sur `starsRequired` via `Number.isFinite()` | Si l'utilisateur vide le champ étoiles, `Number("")` = 0 (OK) mais `Number("abc")` = NaN → JSON null → Zod 422 silencieux |

### Points d'attention pour la revue
- Le `useSortable` hook est toujours appelé (règle des hooks React) mais avec `disabled: isEditing` pour désactiver le tracking
- Le formulaire d'édition n'est plus wrappé dans le `ref={setNodeRef}` sortable — les interactions pointer (click, touch) ne sont plus interceptées par dnd-kit
- La gestion d'erreurs est locale au composant `RewardCardEdit` — un audit similaire serait bénéfique pour les autres mutations du fichier `use-barkley.ts`

### Tests
- Typecheck : ✅ 2/2 passés
- Tests unitaires : ✅ 3/3 passés (cached)
- Pas de tests E2E existants pour le CRUD des récompenses

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation manuelle de l'édition de récompenses
- [ ] Ajouter des tests E2E pour le CRUD des récompenses (actuellement absent de `e2e/barkley.spec.ts`)
- [ ] Auditer les autres mutations sans `onError` dans `use-barkley.ts`

---
_Implémentation générée automatiquement par IA_