### PR TITLE
Improve Stripe SaaS integration

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "url";
 import { app } from "./app";
 import { migrate } from "@focusflow/db";
 import { seedDemoUser } from "./seed";
+import { validateStripeEnv } from "./lib/stripe";
 
 const port = Number(process.env.PORT) || 3001;
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -28,6 +29,7 @@ if (process.env.NODE_ENV === "production") {
 }
 
 async function start() {
+  validateStripeEnv();
   await migrate();
   await seedDemoUser();
 

--- a/apps/api/src/lib/stripe.ts
+++ b/apps/api/src/lib/stripe.ts
@@ -1,0 +1,38 @@
+import Stripe from "stripe";
+
+let _stripe: Stripe | undefined;
+
+export function getStripe(): Stripe {
+  if (!_stripe) {
+    _stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
+  }
+  return _stripe;
+}
+
+export function getPriceId(): string {
+  return process.env.STRIPE_PRICE_ID!;
+}
+
+export function getWebhookSecret(): string {
+  return process.env.STRIPE_WEBHOOK_SECRET!;
+}
+
+/**
+ * Validate all required Stripe environment variables at startup.
+ * Call this before the server starts accepting connections.
+ */
+export function validateStripeEnv(): void {
+  const required = [
+    "STRIPE_SECRET_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+    "STRIPE_PRICE_ID",
+  ] as const;
+
+  const missing = required.filter((key) => !process.env[key]);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Variables d'environnement Stripe manquantes : ${missing.join(", ")}`
+    );
+  }
+}

--- a/apps/api/src/routes/account.ts
+++ b/apps/api/src/routes/account.ts
@@ -1,5 +1,4 @@
 import { Hono } from "hono";
-import Stripe from "stripe";
 import type { AppEnv } from "../types";
 import { authMiddleware } from "../middleware/auth";
 import { deleteAccountSchema } from "@focusflow/validators";
@@ -15,16 +14,11 @@ import {
   barkleyBehaviorLogs,
 } from "@focusflow/db";
 import { eq, inArray } from "drizzle-orm";
+import { getStripe } from "../lib/stripe";
 
 export const accountRoutes = new Hono<AppEnv>();
 
 accountRoutes.use("*", authMiddleware);
-
-let _stripe: Stripe | undefined;
-function getStripe() {
-  if (!_stripe) _stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
-  return _stripe;
-}
 
 /**
  * DELETE /api/account

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -4,16 +4,7 @@ import type { AppEnv } from "../types";
 import { authMiddleware } from "../middleware/auth";
 import { db, subscription } from "@focusflow/db";
 import { eq } from "drizzle-orm";
-
-let _stripe: Stripe | undefined;
-function getStripe() {
-  if (!_stripe) _stripe = new Stripe(process.env.STRIPE_SECRET_KEY!);
-  return _stripe;
-}
-
-function getPriceId() {
-  return process.env.STRIPE_PRICE_ID!;
-}
+import { getStripe, getPriceId, getWebhookSecret } from "../lib/stripe";
 
 function getPeriodEnd(sub: Record<string, unknown>): Date {
   const ts =
@@ -52,6 +43,9 @@ billingRoutes.post("/checkout", authMiddleware, async (c) => {
     client_reference_id: currentUser.id,
     line_items: [{ price: getPriceId(), quantity: 1 }],
     mode: "subscription",
+    subscription_data: {
+      trial_period_days: 14,
+    },
     success_url: `${process.env.CORS_ORIGIN || "http://localhost:5173"}/dashboard?billing=success`,
     cancel_url: `${process.env.CORS_ORIGIN || "http://localhost:5173"}/#tarifs`,
     locale: "fr",
@@ -82,6 +76,28 @@ billingRoutes.get("/status", authMiddleware, async (c) => {
   });
 });
 
+// Customer portal — requires auth
+billingRoutes.post("/portal", authMiddleware, async (c) => {
+  const currentUser = c.get("user");
+
+  const [sub] = await db
+    .select()
+    .from(subscription)
+    .where(eq(subscription.userId, currentUser.id))
+    .limit(1);
+
+  if (!sub?.stripeCustomerId) {
+    return c.json({ error: "Aucun abonnement trouvé" }, 404);
+  }
+
+  const session = await getStripe().billingPortal.sessions.create({
+    customer: sub.stripeCustomerId,
+    return_url: `${process.env.CORS_ORIGIN || "http://localhost:5173"}/account`,
+  });
+
+  return c.json({ url: session.url });
+});
+
 // Webhook — no auth, raw body for signature verification
 export const stripeWebhookRoute = new Hono();
 
@@ -98,7 +114,7 @@ stripeWebhookRoute.post("/", async (c) => {
     event = getStripe().webhooks.constructEvent(
       rawBody,
       sig,
-      process.env.STRIPE_WEBHOOK_SECRET!
+      getWebhookSecret()
     );
   } catch {
     return c.json({ error: "Invalid signature" }, 400);

--- a/apps/api/src/routes/children.ts
+++ b/apps/api/src/routes/children.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import type { AppEnv } from "../types";
 import { eq } from "drizzle-orm";
-import { db, children } from "@focusflow/db";
+import { db, children, subscription } from "@focusflow/db";
 import { createChildSchema, updateChildSchema } from "@focusflow/validators";
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
@@ -28,6 +28,32 @@ childrenRoutes.post("/", async (c) => {
     return c.json(
       { error: "Données invalides", details: parsed.error.flatten() },
       422
+    );
+  }
+
+  // Enforce child limit based on subscription plan
+  const existingChildren = await db
+    .select()
+    .from(children)
+    .where(eq(children.parentId, user.id));
+
+  const [sub] = await db
+    .select()
+    .from(subscription)
+    .where(eq(subscription.userId, user.id))
+    .limit(1);
+
+  const isActive =
+    sub && (sub.status === "active" || sub.status === "trialing");
+  const maxChildren = isActive ? 3 : 1;
+
+  if (existingChildren.length >= maxChildren) {
+    throw new AppError(
+      "FORBIDDEN",
+      isActive
+        ? "Limite de 3 profils enfant atteinte pour le plan Famille."
+        : "Limite de 1 profil enfant atteinte. Passez au plan Famille pour en ajouter jusqu'à 3.",
+      403
     );
   }
 

--- a/apps/web/src/hooks/use-billing.ts
+++ b/apps/web/src/hooks/use-billing.ts
@@ -27,3 +27,12 @@ export function useCheckout() {
     },
   });
 }
+
+export function usePortal() {
+  return useMutation({
+    mutationFn: () => api.post<{ url: string }>("/billing/portal", {}),
+    onSuccess: (data) => {
+      window.location.href = data.url;
+    },
+  });
+}

--- a/apps/web/src/routes/_authenticated/account/index.tsx
+++ b/apps/web/src/routes/_authenticated/account/index.tsx
@@ -25,7 +25,7 @@ import { useSession } from "@/lib/auth-client";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDeleteAccount, useExportAccount } from "@/hooks/use-account";
-import { useBillingStatus, useCheckout } from "@/hooks/use-billing";
+import { useBillingStatus, useCheckout, usePortal } from "@/hooks/use-billing";
 
 export const Route = createFileRoute("/_authenticated/account/")({
   component: AccountPage,
@@ -37,6 +37,7 @@ function AccountPage() {
   const exportAccount = useExportAccount();
   const billing = useBillingStatus();
   const checkout = useCheckout();
+  const portal = usePortal();
   const [confirmation, setConfirmation] = useState("");
   const [dialogOpen, setDialogOpen] = useState(false);
 
@@ -128,6 +129,16 @@ function AccountPage() {
                   })}
                 </p>
               )}
+              <Button
+                variant="outline"
+                onClick={() => portal.mutate()}
+                disabled={portal.isPending}
+              >
+                {portal.isPending && (
+                  <Loader2 className="h-4 w-4 animate-spin" data-icon="inline-start" />
+                )}
+                Gerer mon abonnement
+              </Button>
             </div>
           ) : (
             <div className="space-y-3">


### PR DESCRIPTION
## Résumé technique

### Contexte
L'intégration Stripe présentait plusieurs lacunes : client dupliqué dans deux fichiers, absence de validation des variables d'environnement, essai gratuit promis sur la landing page mais non configuré, aucun portail client self-service, et limites de profils enfants non appliquées côté API.

### Approche retenue
Consolidation du client Stripe, activation des fonctionnalités SaaS critiques (trial, portal, enforcement), et validation fail-fast au démarrage. Approche choisie pour maximiser la confiance utilisateur et appliquer le modèle freemium sans sur-ingénierie.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/api/src/lib/stripe.ts` | Nouveau module partagé avec `getStripe()`, `getPriceId()`, `getWebhookSecret()`, `validateStripeEnv()` | Éliminer la duplication du client Stripe entre billing.ts et account.ts, valider les env vars au démarrage |
| `apps/api/src/routes/billing.ts` | Import du module partagé, ajout `subscription_data.trial_period_days: 14`, nouvel endpoint `POST /portal`, utilisation de `getWebhookSecret()` | Activer l'essai gratuit 14j (promis sur la landing page), ajouter le Customer Portal Stripe |
| `apps/api/src/routes/account.ts` | Import du module Stripe partagé, suppression du code dupliqué | SRP — un seul endroit pour la config Stripe |
| `apps/api/src/routes/children.ts` | Ajout de la vérification de limite de profils enfants (Free: 1, Famille: 3) | Enforcement du modèle freemium côté API |
| `apps/api/src/index.ts` | Appel de `validateStripeEnv()` au démarrage | Fail-fast si env vars manquantes plutôt qu'erreur silencieuse en runtime |
| `apps/web/src/hooks/use-billing.ts` | Ajout du hook `usePortal()` | Mutation pour rediriger vers le portail client Stripe |
| `apps/web/src/routes/_authenticated/account/index.tsx` | Ajout du bouton "Gérer mon abonnement" pour les abonnés actifs | Self-service : annulation, changement de carte, consultation des factures |

### Points d'attention pour la revue
- L'enforcement de la limite d'enfants se fait sur `POST /api/children` uniquement — les enfants existants ne sont pas supprimés si un abonnement expire
- Le Customer Portal Stripe doit être configuré dans le dashboard Stripe (branding, actions autorisées) avant utilisation en production
- L'essai gratuit de 14 jours démarre au checkout — vérifier la cohérence avec le CTA de la landing page

### Tests
- 14 tests exécutés, 14 passés, 0 échoué (validators: 10, db: 3, api: 1)
- Typecheck réussi sur tous les packages

### Étapes restantes
- [ ] Ajouter l'idempotency des webhooks (table `stripe_events` avec dedup par event ID)
- [ ] Ajouter les handlers `invoice.payment_failed` et `invoice.paid`
- [ ] Configurer le Customer Portal dans le dashboard Stripe
- [ ] Ajouter un rate limiting sur `POST /billing/checkout`

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation des tests
- [ ] Merge après approbation

---
Closes #34

_Implémentation générée automatiquement par IA_