### PR TITLE
Fix logout redirect to homepage

### DIFF
--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -83,7 +83,7 @@ function AuthenticatedLayout() {
 
   const handleSignOut = async () => {
     await signOut();
-    window.location.href = "/login";
+    window.location.href = "/";
   };
 
   return (


### PR DESCRIPTION
## Résumé technique

### Contexte
La déconnexion redirige vers `/login` (formulaire nu) alors que la suppression de compte redirige vers `/` (page d'accueil). Incohérence UX signalée.

### Approche retenue
Changer la redirection post-logout de `/login` vers `/`. La page d'accueil est le point d'entrée naturel pour les utilisateurs déconnectés — elle offre le branding, les fonctionnalités, les tarifs, et un bouton Connexion dans le header sticky. Le guard `beforeLoad` de `_authenticated` reste sur `/login` car il gère un intent différent (accès non authentifié à une page protégée).

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/web/src/routes/_authenticated.tsx` | `window.location.href` de `/login` → `/` | Cohérence avec `use-account.ts` et meilleure UX post-logout |

### Points d'attention pour la revue
- Le guard `beforeLoad` dans `_authenticated.tsx:30` reste sur `/login` — c'est intentionnel (intent différent : session expirée vs logout volontaire)
- La homepage redirige déjà les utilisateurs authentifiés vers `/dashboard` via son propre `beforeLoad`
- Aucune race condition : `await signOut()` invalide la session côté serveur avant la redirection

### Tests
- 3 tâches exécutées, 3 passées, 0 échouée (cached)

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation manuelle : logout → homepage → Connexion → login
- [ ] Merge après approbation

---
Closes #38

_Implémentation générée automatiquement par IA_