### PR TITLE
Expand EmojiPicker with categories, search and pagination

### DIFF
--- a/apps/web/src/components/emoji-data.ts
+++ b/apps/web/src/components/emoji-data.ts
@@ -1,0 +1,340 @@
+/**
+ * Catalogue d'emojis curatés pour Tokō — organisés par catégories
+ * pertinentes pour la gestion ADHD d'enfants.
+ */
+
+export interface EmojiCategory {
+  id: string;
+  label: string;
+  icon: string;
+  emojis: string[];
+}
+
+export const EMOJI_CATALOG: EmojiCategory[] = [
+  {
+    id: "smileys",
+    label: "Visages",
+    icon: "😊",
+    emojis: [
+      "😀", "😃", "😄", "😁", "😆", "😅", "🤣", "😂",
+      "🙂", "😊", "😇", "🥰", "😍", "🤩", "😘", "😋",
+      "😛", "😜", "🤪", "😝", "🤑", "🤗", "🤭", "🤫",
+      "🤔", "😐", "😑", "😶", "😏", "😒", "🙄", "😬",
+      "😌", "😔", "😪", "🤤", "😴", "😷", "🤒", "🤕",
+      "🤢", "🤮", "🥵", "🥶", "😵", "🤯", "🥳", "😎",
+      "🤓", "😤", "😠", "😡", "🥺", "😢", "😭", "😱",
+      "😰", "😥", "😓", "🫣", "🫡", "🫠", "🫢", "😮",
+    ],
+  },
+  {
+    id: "people",
+    label: "Personnes",
+    icon: "👋",
+    emojis: [
+      "👋", "🤚", "🖐️", "✋", "👌", "🤌", "✌️", "🤞",
+      "🫰", "🤟", "🤘", "🤙", "👈", "👉", "👆", "👇",
+      "👍", "👎", "✊", "👊", "🤛", "🤜", "👏", "🙌",
+      "🫶", "👐", "🤲", "🤝", "🙏", "💪", "🦶", "🦵",
+      "👶", "🧒", "👦", "👧", "👨", "👩", "🧑", "👴",
+      "👵", "🧓", "👮", "🧑‍🎓", "🧑‍🏫", "🧑‍⚕️", "🧑‍🍳", "🧑‍🎨",
+      "🧑‍🚀", "🦸", "🦹", "🧙", "🧚", "🧛", "🧜", "🧝",
+    ],
+  },
+  {
+    id: "animals",
+    label: "Animaux",
+    icon: "🐾",
+    emojis: [
+      "🐶", "🐱", "🐭", "🐹", "🐰", "🦊", "🐻", "🐼",
+      "🐨", "🐯", "🦁", "🐮", "🐷", "🐸", "🐵", "🐔",
+      "🐧", "🐦", "🐤", "🦆", "🦅", "🦉", "🦇", "🐺",
+      "🐗", "🐴", "🦄", "🐝", "🐛", "🦋", "🐌", "🐞",
+      "🐢", "🐍", "🦎", "🐙", "🦑", "🦐", "🦀", "🐡",
+      "🐠", "🐟", "🐬", "🐳", "🐋", "🦈", "🐊", "🐘",
+      "🦏", "🦛", "🐪", "🦒", "🦘", "🐾", "🦩", "🦜",
+    ],
+  },
+  {
+    id: "food",
+    label: "Nourriture",
+    icon: "🍕",
+    emojis: [
+      "🍎", "🍐", "🍊", "🍋", "🍌", "🍉", "🍇", "🍓",
+      "🫐", "🍒", "🍑", "🥭", "🍍", "🥥", "🥝", "🍅",
+      "🥑", "🥦", "🥬", "🌽", "🥕", "🧄", "🧅", "🥔",
+      "🍕", "🍔", "🍟", "🌭", "🍿", "🧀", "🥚", "🍳",
+      "🥞", "🧇", "🥓", "🥩", "🍗", "🍖", "🌮", "🌯",
+      "🍝", "🍜", "🍲", "🍛", "🍣", "🍱", "🍙", "🍘",
+      "🍦", "🍧", "🍨", "🍩", "🍪", "🎂", "🍰", "🧁",
+      "🍫", "🍬", "🍭", "🍮", "☕", "🍵", "🧃", "🥤",
+    ],
+  },
+  {
+    id: "activities",
+    label: "Activités",
+    icon: "⚽",
+    emojis: [
+      "⚽", "🏀", "🏈", "⚾", "🥎", "🎾", "🏐", "🏉",
+      "🥏", "🎱", "🏓", "🏸", "🏒", "🥊", "🥋", "🎯",
+      "⛳", "🏊", "🚴", "🏃", "🧘", "🧗", "🤸", "🤺",
+      "🎮", "🕹️", "🎲", "🧩", "♟️", "🎯", "🎳", "🎪",
+      "🎨", "🖍️", "✏️", "🖌️", "🎵", "🎶", "🎤", "🎧",
+      "🎸", "🎹", "🥁", "🎷", "🎺", "🎻", "📖", "📚",
+      "🛝", "🛴", "🛹", "🚀", "🎬", "📺", "🎠", "🎡",
+    ],
+  },
+  {
+    id: "objects",
+    label: "Objets",
+    icon: "🎁",
+    emojis: [
+      "🎁", "🎀", "🎈", "🎉", "🎊", "🏆", "🥇", "🥈",
+      "🥉", "🏅", "🎖️", "👑", "💎", "🌟", "⭐", "✨",
+      "💫", "🌈", "☀️", "🌙", "🌳", "🌸", "🌻", "🍀",
+      "🧸", "🪁", "🛁", "🛏️", "💤", "🕐", "📱", "💻",
+      "🎒", "📝", "✅", "❤️", "🧡", "💛", "💚", "💙",
+      "💜", "🩷", "🖤", "🤍", "💯", "🔥", "💧", "🫧",
+      "🐾", "🤗", "🫂", "👕", "🧹", "🦷", "🍽️", "🚿",
+    ],
+  },
+];
+
+/** Toutes les catégories sous forme de liste plate */
+export const ALL_EMOJIS = EMOJI_CATALOG.flatMap((c) => c.emojis);
+
+/**
+ * Labels français pour la recherche — couvre les emojis les plus courants.
+ * Clé = emoji, valeur = mots-clés séparés par des espaces.
+ */
+export const EMOJI_LABELS: Record<string, string> = {
+  // Visages
+  "😀": "sourire heureux joie content",
+  "😃": "sourire heureux grand",
+  "😄": "rire heureux joie",
+  "😁": "sourire large dents",
+  "😆": "rire mort plié",
+  "😅": "rire sueur gêne",
+  "🤣": "mort de rire mdr",
+  "😂": "rire larmes joie pleure",
+  "🙂": "sourire léger content",
+  "😊": "sourire rougir content heureux",
+  "😇": "ange innocent gentil",
+  "🥰": "amour coeurs sourire",
+  "😍": "amour yeux coeurs",
+  "🤩": "étoiles wow impressionné",
+  "😘": "bisou amour",
+  "😋": "miam délicieux gourmand",
+  "😛": "langue taquin",
+  "😜": "clin oeil langue",
+  "🤪": "fou dingue folie",
+  "🤗": "câlin bisou caresse",
+  "🤔": "réfléchir penser hmm",
+  "😐": "neutre rien indifférent",
+  "😏": "malin sourire narquois",
+  "😒": "ennui pas content",
+  "🙄": "yeux ciel agacé",
+  "😬": "grimace gêne oups",
+  "😌": "calme soulagé zen serein",
+  "😔": "triste pensif",
+  "😪": "fatigué endormi",
+  "😴": "dort sommeil dodo",
+  "🤒": "malade thermomètre fièvre",
+  "🤕": "blessé bandage bobo",
+  "🥵": "chaud chaleur",
+  "🥶": "froid gelé",
+  "🤯": "esprit explosé choqué",
+  "🥳": "fête anniversaire célébration",
+  "😎": "cool lunettes soleil",
+  "🤓": "intello lunettes nerd",
+  "😤": "énervé frustré souffle",
+  "😠": "colère fâché",
+  "😡": "colère rouge furieux",
+  "🥺": "suppliant triste yeux",
+  "😢": "triste larme pleure",
+  "😭": "pleure fort triste larmes",
+  "😱": "peur horrifié cri",
+  "😰": "anxieux sueur inquiet",
+  "😮": "surpris choqué oh",
+
+  // Personnes & gestes
+  "👋": "salut bonjour coucou main",
+  "👍": "pouce bien ok super",
+  "👎": "pouce bas non mauvais",
+  "👏": "bravo applaudir félicitations",
+  "🙌": "hourra mains levées victoire",
+  "🫶": "coeur mains amour",
+  "🤝": "poignée main accord",
+  "🙏": "merci prière svp s'il vous plaît",
+  "💪": "muscle fort force",
+  "👶": "bébé enfant petit",
+  "🧒": "enfant gamin",
+  "👦": "garçon fils",
+  "👧": "fille",
+  "🦸": "héros super",
+  "🧚": "fée magie",
+  "🧙": "magicien sorcier",
+
+  // Animaux
+  "🐶": "chien toutou",
+  "🐱": "chat minou",
+  "🐭": "souris",
+  "🐹": "hamster",
+  "🐰": "lapin",
+  "🦊": "renard",
+  "🐻": "ours",
+  "🐼": "panda",
+  "🐨": "koala",
+  "🐯": "tigre",
+  "🦁": "lion roi",
+  "🐮": "vache",
+  "🐷": "cochon",
+  "🐸": "grenouille",
+  "🐵": "singe",
+  "🐔": "poule poulet",
+  "🐧": "pingouin manchot",
+  "🐦": "oiseau",
+  "🦋": "papillon",
+  "🐢": "tortue",
+  "🐬": "dauphin",
+  "🐳": "baleine",
+  "🐘": "éléphant",
+  "🦄": "licorne magique",
+  "🐾": "pattes traces animal",
+  "🦜": "perroquet",
+  "🦩": "flamant rose",
+  "🐞": "coccinelle",
+
+  // Nourriture
+  "🍎": "pomme fruit rouge",
+  "🍌": "banane fruit",
+  "🍉": "pastèque melon",
+  "🍇": "raisin",
+  "🍓": "fraise",
+  "🍒": "cerise",
+  "🍍": "ananas",
+  "🍕": "pizza",
+  "🍔": "hamburger burger",
+  "🍟": "frites",
+  "🌭": "hot dog saucisse",
+  "🍿": "popcorn cinéma",
+  "🍝": "pâtes spaghetti",
+  "🍦": "glace crème glacée",
+  "🍩": "donut beignet",
+  "🍪": "cookie biscuit gâteau",
+  "🎂": "gâteau anniversaire",
+  "🍰": "gâteau part",
+  "🧁": "cupcake muffin",
+  "🍫": "chocolat",
+  "🍬": "bonbon",
+  "🍭": "sucette",
+  "☕": "café",
+  "🧃": "jus brique",
+  "🥤": "boisson soda",
+
+  // Activités
+  "⚽": "football foot ballon",
+  "🏀": "basket ball",
+  "🎾": "tennis",
+  "🏊": "nager piscine natation",
+  "🚴": "vélo cyclisme",
+  "🏃": "courir course",
+  "🧘": "yoga méditation zen calme",
+  "🤸": "gymnastique acrobatie",
+  "🎮": "jeu vidéo manette",
+  "🕹️": "arcade joystick jeu",
+  "🎲": "dé jeu hasard",
+  "🧩": "puzzle casse-tête",
+  "🎯": "cible objectif but",
+  "🎪": "cirque spectacle",
+  "🎨": "peinture art palette",
+  "🖍️": "crayon couleur dessin coloriage",
+  "✏️": "crayon écrire",
+  "🎵": "musique note",
+  "🎶": "musique notes mélodie",
+  "🎤": "micro chanter karaoké",
+  "🎧": "casque musique écouter",
+  "🎸": "guitare musique",
+  "🎹": "piano musique clavier",
+  "🥁": "batterie tambour musique",
+  "📖": "livre lire lecture",
+  "📚": "livres bibliothèque étude",
+  "🛝": "toboggan parc jeu",
+  "🛴": "trottinette",
+  "🎬": "cinéma film",
+  "📺": "télé écran",
+  "🎠": "manège carrousel",
+
+  // Objets & symboles
+  "🎁": "cadeau surprise",
+  "🎈": "ballon fête",
+  "🎉": "fête confetti célébration",
+  "🎊": "confetti fête",
+  "🏆": "trophée victoire champion",
+  "🥇": "médaille or premier",
+  "🥈": "médaille argent deuxième",
+  "🥉": "médaille bronze troisième",
+  "🏅": "médaille sport",
+  "👑": "couronne roi reine",
+  "💎": "diamant bijou précieux",
+  "🌟": "étoile brillante",
+  "⭐": "étoile",
+  "✨": "étincelles briller magie",
+  "🌈": "arc en ciel couleurs",
+  "☀️": "soleil beau temps",
+  "🌙": "lune nuit",
+  "🌳": "arbre nature forêt",
+  "🌸": "fleur cerisier",
+  "🌻": "tournesol fleur",
+  "🍀": "trèfle chance",
+  "🧸": "peluche ours doudou",
+  "🪁": "cerf-volant vent",
+  "🛁": "bain baignoire",
+  "🛏️": "lit dormir chambre",
+  "💤": "sommeil dodo dormir",
+  "🎒": "sac dos école",
+  "📝": "note écrire",
+  "✅": "validé fait terminé",
+  "❤️": "coeur amour rouge",
+  "💙": "coeur bleu",
+  "💚": "coeur vert",
+  "💛": "coeur jaune",
+  "💜": "coeur violet",
+  "🩷": "coeur rose",
+  "💯": "cent parfait score",
+  "🔥": "feu flamme top",
+  "🫧": "bulles savon",
+  "🫂": "accolade câlin réconfort",
+  "👕": "vêtement habit t-shirt",
+  "🧹": "balai ménage ranger",
+  "🦷": "dent brosser",
+  "🍽️": "assiette manger repas table",
+  "🚿": "douche laver",
+  "🚀": "fusée espace rapide",
+};
+
+/** Nombre max d'emojis récents à conserver */
+export const MAX_RECENTS = 16;
+const RECENTS_KEY = "toko-emoji-recents";
+
+export function getRecentEmojis(): string[] {
+  try {
+    const stored = localStorage.getItem(RECENTS_KEY);
+    if (!stored) return [];
+    return JSON.parse(stored) as string[];
+  } catch {
+    return [];
+  }
+}
+
+export function addRecentEmoji(emoji: string): void {
+  try {
+    const recents = getRecentEmojis().filter((e) => e !== emoji);
+    recents.unshift(emoji);
+    localStorage.setItem(
+      RECENTS_KEY,
+      JSON.stringify(recents.slice(0, MAX_RECENTS)),
+    );
+  } catch {
+    // localStorage indisponible — on ignore silencieusement
+  }
+}

--- a/apps/web/src/components/emoji-picker.tsx
+++ b/apps/web/src/components/emoji-picker.tsx
@@ -1,9 +1,15 @@
-import type { ReactElement } from "react";
+import { type ReactElement, useDeferredValue, useMemo, useState } from "react";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import {
+  EMOJI_CATALOG,
+  EMOJI_LABELS,
+  addRecentEmoji,
+  getRecentEmojis,
+} from "./emoji-data";
 
 export const DEFAULT_EMOJIS = [
   "🎁", "🎮", "🎨", "🍦", "🍕", "🍿", "🎬", "🎪",
@@ -28,10 +34,217 @@ const GRID_COLS: Record<number, string> = {
   8: "grid-cols-8",
 };
 
+const ITEMS_PER_PAGE = 40;
+
+function EmojiGrid({
+  emojis,
+  value,
+  onSelect,
+  columns,
+}: {
+  emojis: string[];
+  value: string;
+  onSelect: (emoji: string) => void;
+  columns: number;
+}) {
+  return (
+    <div className={`grid gap-1 ${GRID_COLS[columns] ?? "grid-cols-8"}`}>
+      {emojis.map((emoji, i) => (
+        <button
+          key={`${emoji}-${i}`}
+          type="button"
+          onClick={() => onSelect(emoji)}
+          className={`flex h-9 w-9 items-center justify-center rounded-md text-lg transition-all hover:bg-accent hover:scale-110 ${
+            value === emoji ? "bg-accent ring-2 ring-primary" : ""
+          }`}
+        >
+          {emoji}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function CatalogPicker({
+  value,
+  onSelect,
+}: {
+  value: string;
+  onSelect: (emoji: string) => void;
+}) {
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [page, setPage] = useState(0);
+  const deferredSearch = useDeferredValue(search);
+  const [recents, setRecents] = useState(getRecentEmojis);
+
+  const filteredEmojis = useMemo(() => {
+    if (!deferredSearch.trim()) return null;
+    const query = deferredSearch.toLowerCase().trim();
+    const results: string[] = [];
+    for (const [emoji, labels] of Object.entries(EMOJI_LABELS)) {
+      if (labels.toLowerCase().includes(query)) {
+        results.push(emoji);
+      }
+    }
+    for (const cat of EMOJI_CATALOG) {
+      for (const emoji of cat.emojis) {
+        if (emoji.includes(query) && !results.includes(emoji)) {
+          results.push(emoji);
+        }
+      }
+    }
+    return results;
+  }, [deferredSearch]);
+
+  const currentCategory = activeCategory
+    ? EMOJI_CATALOG.find((c) => c.id === activeCategory)
+    : null;
+
+  const displayEmojis = filteredEmojis
+    ? filteredEmojis
+    : currentCategory
+      ? currentCategory.emojis
+      : EMOJI_CATALOG.flatMap((c) => c.emojis);
+
+  const totalPages = Math.ceil(displayEmojis.length / ITEMS_PER_PAGE);
+  const pagedEmojis = displayEmojis.slice(
+    page * ITEMS_PER_PAGE,
+    (page + 1) * ITEMS_PER_PAGE,
+  );
+
+  const handleCategoryChange = (catId: string | null) => {
+    setActiveCategory(catId);
+    setPage(0);
+  };
+
+  const handleSearchChange = (val: string) => {
+    setSearch(val);
+    setPage(0);
+  };
+
+  const handleSelect = (emoji: string) => {
+    addRecentEmoji(emoji);
+    setRecents(getRecentEmojis());
+    onSelect(emoji);
+  };
+
+  return (
+    <div className="flex w-72 flex-col gap-2">
+      {/* Recherche */}
+      <input
+        type="text"
+        placeholder="Rechercher un emoji..."
+        value={search}
+        onChange={(e) => handleSearchChange(e.target.value)}
+        className="w-full rounded-md border bg-background px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-ring"
+      />
+
+      {/* Onglets catégories */}
+      {!filteredEmojis && (
+        <div className="flex gap-1 overflow-x-auto pb-1">
+          <button
+            type="button"
+            onClick={() => handleCategoryChange(null)}
+            className={`flex-none rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+              activeCategory === null
+                ? "bg-primary text-primary-foreground"
+                : "hover:bg-accent"
+            }`}
+          >
+            Tous
+          </button>
+          {EMOJI_CATALOG.map((cat) => (
+            <button
+              key={cat.id}
+              type="button"
+              onClick={() => handleCategoryChange(cat.id)}
+              className={`flex flex-none items-center gap-1 rounded-md px-2 py-1 text-xs font-medium transition-colors ${
+                activeCategory === cat.id
+                  ? "bg-primary text-primary-foreground"
+                  : "hover:bg-accent"
+              }`}
+              title={cat.label}
+            >
+              <span>{cat.icon}</span>
+              <span className="hidden sm:inline">{cat.label}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Récents */}
+      {!filteredEmojis && !activeCategory && recents.length > 0 && page === 0 && (
+        <div>
+          <p className="mb-1 text-xs font-medium text-muted-foreground">
+            Récents
+          </p>
+          <div className="grid grid-cols-8 gap-1">
+            {recents.map((emoji, i) => (
+              <button
+                key={`recent-${emoji}-${i}`}
+                type="button"
+                onClick={() => handleSelect(emoji)}
+                className={`flex h-9 w-9 items-center justify-center rounded-md text-lg transition-all hover:bg-accent hover:scale-110 ${
+                  value === emoji ? "bg-accent ring-2 ring-primary" : ""
+                }`}
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
+          <div className="my-1 border-b" />
+        </div>
+      )}
+
+      {/* Grille d'emojis */}
+      <div className="max-h-64 overflow-y-auto">
+        {filteredEmojis && filteredEmojis.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">
+            Aucun emoji trouvé
+          </p>
+        ) : (
+          <EmojiGrid
+            emojis={pagedEmojis}
+            value={value}
+            onSelect={handleSelect}
+            columns={8}
+          />
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between border-t pt-1">
+          <button
+            type="button"
+            disabled={page === 0}
+            onClick={() => setPage((p) => p - 1)}
+            className="rounded-md px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent disabled:opacity-30 disabled:pointer-events-none"
+          >
+            ← Préc.
+          </button>
+          <span className="text-xs text-muted-foreground">
+            {page + 1} / {totalPages}
+          </span>
+          <button
+            type="button"
+            disabled={page >= totalPages - 1}
+            onClick={() => setPage((p) => p + 1)}
+            className="rounded-md px-2 py-0.5 text-xs font-medium transition-colors hover:bg-accent disabled:opacity-30 disabled:pointer-events-none"
+          >
+            Suiv. →
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
 export function EmojiPicker({
   value,
   onSelect,
-  emojis = DEFAULT_EMOJIS,
+  emojis,
   placeholder = "🎁",
   columns = 8,
   children,
@@ -43,6 +256,15 @@ export function EmojiPicker({
   columns?: number;
   children?: ReactElement;
 }) {
+  const isFlatMode = emojis !== undefined;
+
+  const handleSelect = (emoji: string) => {
+    if (!isFlatMode) {
+      addRecentEmoji(emoji);
+    }
+    onSelect(emoji);
+  };
+
   return (
     <Popover>
       {children ? (
@@ -58,20 +280,16 @@ export function EmojiPicker({
         sideOffset={4}
         className="w-auto p-2"
       >
-        <div className={`grid gap-1 ${GRID_COLS[columns] ?? "grid-cols-8"}`}>
-          {emojis.map((emoji) => (
-            <button
-              key={emoji}
-              type="button"
-              onClick={() => onSelect(emoji)}
-              className={`flex h-9 w-9 items-center justify-center rounded-md text-lg transition-colors hover:bg-accent ${
-                value === emoji ? "bg-accent ring-2 ring-primary" : ""
-              }`}
-            >
-              {emoji}
-            </button>
-          ))}
-        </div>
+        {isFlatMode ? (
+          <EmojiGrid
+            emojis={emojis}
+            value={value}
+            onSelect={handleSelect}
+            columns={columns}
+          />
+        ) : (
+          <CatalogPicker value={value} onSelect={onSelect} />
+        )}
       </PopoverContent>
     </Popover>
   );


### PR DESCRIPTION
## Résumé technique

### Contexte
Le composant EmojiPicker proposait un catalogue fixe de 40 emojis sans recherche ni navigation. Les utilisateurs avaient besoin de plus de choix pour personnaliser visuellement les comportements, récompenses et éléments de liste de crise.

### Approche retenue
Extension interne du composant sans aucune dépendance externe (emoji-mart rejeté : 140KB+, style incompatible shadcn/ui). Catalogue curated de ~200 emojis en 6 catégories avec recherche par mots-clés français, pagination et section "récemment utilisés" via localStorage.

### Changements implémentés
| Fichier | Modification | Justification technique |
|---------|-------------|------------------------|
| `apps/web/src/components/emoji-data.ts` | Nouveau fichier — catalogue 6 catégories, labels FR, helpers recents | Séparation données/présentation, labels français pour la recherche |
| `apps/web/src/components/emoji-picker.tsx` | Refactoring — dual mode (flat/catalog), CatalogPicker interne | Rétrocompatibilité via détection `emojis` prop, `useDeferredValue` pour la recherche non-bloquante |

### Points d'attention pour la revue
- La prop `emojis` quand passée déclenche le mode flat (ancien comportement exact) — les 3 call sites existants ne changent pas
- Le mode catalogue (`emojis` non passé) remplace le default précédent (`DEFAULT_EMOJIS`) par le catalogue complet
- Les rewards et behavior-tracking utilisent `<EmojiPicker value={icon} onSelect={setIcon} />` sans `emojis` → ils bénéficient automatiquement du catalogue complet
- La crisis-list passe `emojis={CRISIS_EMOJIS}` → elle conserve son grid flat spécifique
- `useDeferredValue` évite le blocage UI pendant la recherche sur ~200 emojis

### Tests
- Typecheck : 2/2 passés (API + Web)
- Tests unitaires : 3/3 passés (schema-drift)
- Aucun test spécifique au composant EmojiPicker (composant UI sans logique métier)

### Prochaines étapes
- [ ] Revue de code par l'équipe
- [ ] Validation visuelle sur mobile (taille popover bornée à max-h-64)
- [ ] Merge après approbation

---
Closes #40

_Implémentation générée automatiquement par IA_