### PR TITLE
feat(email): daily reminder + weekly digest via Resend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,8 +34,19 @@ STRIPE_PRICE_ID=price_...
 # 3. Run 'pnpm stripe:listen' in a separate terminal, copy the whsec_... value
 STRIPE_WEBHOOK_SECRET=whsec_...
 
-# ─── Email (Resend — optional for MVP) ────────────────
+# ─── Email (Resend — optional) ────────────────────────
+# Sign up at https://resend.com and create an API key.
+# Without this key, reminder + digest emails silently no-op.
 RESEND_API_KEY=
+EMAIL_FROM="Tokō <no-reply@toko.app>"
+# Public app URL used in email links (defaults to http://localhost:5173)
+APP_URL=http://localhost:5173
+
+# ─── Cron jobs (optional) ─────────────────────────────
+# Required to enable POST /api/jobs/daily-reminders + /weekly-digest.
+# Your external scheduler (GitHub Actions, fly.io cron, etc.) sends this
+# value in the x-cron-secret header.
+CRON_SECRET=
 
 # ─── E2E tests (optional) ─────────────────────────────
 E2E_WEB_PORT=5176

--- a/apps/api/src/__tests__/email-templates.test.ts
+++ b/apps/api/src/__tests__/email-templates.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import {
+  dailyReminderTemplate,
+  weeklyDigestTemplate,
+} from "../lib/email-templates";
+
+describe("dailyReminderTemplate", () => {
+  it("produces French subject + html and escapes names", () => {
+    const { subject, html } = dailyReminderTemplate("Sophie & co <script>");
+    expect(subject).toMatch(/rappel/i);
+    expect(html).toContain("Bonjour Sophie &amp; co &lt;script&gt;");
+    expect(html).toContain("Logger une humeur");
+  });
+});
+
+describe("weeklyDigestTemplate", () => {
+  it("shows consistency score + trend arrow", () => {
+    const { subject, html } = weeklyDigestTemplate({
+      parentName: "Marc",
+      childName: "Lucas",
+      consistencyScore: 72,
+      moodTrend: "up",
+      entriesLogged: 6,
+      weeklyStars: 14,
+    });
+    expect(subject).toContain("Lucas");
+    expect(html).toContain("72/100");
+    expect(html).toContain("↗︎");
+    expect(html).toContain("<strong>6</strong>");
+    expect(html).toContain("<strong>14</strong>");
+  });
+
+  it("falls back to — when consistency score is null", () => {
+    const { html } = weeklyDigestTemplate({
+      parentName: "Marc",
+      childName: "Lucas",
+      consistencyScore: null,
+      moodTrend: null,
+      entriesLogged: 0,
+      weeklyStars: 0,
+    });
+    expect(html).toContain("—");
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -17,6 +17,8 @@ import { barkleyRoutes } from "./routes/barkley";
 import { accountRoutes } from "./routes/account";
 import { crisisListRoutes } from "./routes/crisis-list";
 import { medicationsRoutes } from "./routes/medications";
+import { jobsRoutes } from "./routes/jobs";
+import { preferencesRoutes } from "./routes/preferences";
 import { auth } from "./lib/auth";
 
 const app = new Hono();
@@ -66,5 +68,7 @@ app.route("/api/barkley", barkleyRoutes);
 app.route("/api/account", accountRoutes);
 app.route("/api/crisis-list", crisisListRoutes);
 app.route("/api/medications", medicationsRoutes);
+app.route("/api/preferences", preferencesRoutes);
+app.route("/api/jobs", jobsRoutes);
 
 export { app };

--- a/apps/api/src/jobs/email-jobs.ts
+++ b/apps/api/src/jobs/email-jobs.ts
@@ -1,0 +1,284 @@
+import { eq, and, gte, sql, inArray, count } from "drizzle-orm";
+import {
+  db,
+  user,
+  userPreferences,
+  children,
+  symptoms,
+  barkleyBehaviors,
+  barkleyBehaviorLogs,
+} from "@focusflow/db";
+import { sendEmail } from "../lib/email";
+import {
+  dailyReminderTemplate,
+  weeklyDigestTemplate,
+  type WeeklyDigestData,
+} from "../lib/email-templates";
+
+export type JobResult = {
+  processed: number;
+  sent: number;
+  skipped: number;
+  errors: number;
+};
+
+// Returns the local hour in the given IANA timezone at the current instant.
+// Uses Intl.DateTimeFormat so no external dep is needed.
+function localHourIn(timezone: string, now: Date = new Date()): number {
+  try {
+    const hourStr = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      hour: "2-digit",
+      hour12: false,
+    }).format(now);
+    return Number.parseInt(hourStr, 10);
+  } catch {
+    // Unknown tz → fall back to UTC
+    return now.getUTCHours();
+  }
+}
+
+function localWeekdayIn(timezone: string, now: Date = new Date()): number {
+  // Returns 0..6 with 0 = Sunday
+  try {
+    const fmt = new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      weekday: "short",
+    }).format(now);
+    return (
+      { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 }[fmt] ?? 0
+    );
+  } catch {
+    return now.getUTCDay();
+  }
+}
+
+function todayInTimezone(timezone: string, now: Date = new Date()): string {
+  try {
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(now);
+    return parts; // en-CA formats as YYYY-MM-DD
+  } catch {
+    return now.toISOString().split("T")[0]!;
+  }
+}
+
+function hoursSince(date: Date | null, now: Date = new Date()): number {
+  if (!date) return Number.POSITIVE_INFINITY;
+  return (now.getTime() - date.getTime()) / (60 * 60 * 1000);
+}
+
+// Sends a daily reminder to users whose local time is 9am, who opted in,
+// and who have not yet logged a symptom for today.
+// Intended to be invoked by an external cron every 15-60 minutes.
+export async function runDailyReminders(
+  now: Date = new Date()
+): Promise<JobResult> {
+  const result: JobResult = { processed: 0, sent: 0, skipped: 0, errors: 0 };
+
+  const rows = await db
+    .select({
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      timezone: userPreferences.timezone,
+      optIn: userPreferences.dailyReminderOptIn,
+      lastSent: userPreferences.lastDailyReminderAt,
+    })
+    .from(user)
+    .innerJoin(userPreferences, eq(userPreferences.userId, user.id))
+    .where(eq(userPreferences.dailyReminderOptIn, true));
+
+  for (const row of rows) {
+    result.processed++;
+    const localHour = localHourIn(row.timezone, now);
+    if (localHour !== 9) {
+      result.skipped++;
+      continue;
+    }
+    // Don't double-send within 20 hours
+    if (hoursSince(row.lastSent, now) < 20) {
+      result.skipped++;
+      continue;
+    }
+
+    const localToday = todayInTimezone(row.timezone, now);
+    const userChildren = await db
+      .select({ id: children.id })
+      .from(children)
+      .where(eq(children.parentId, row.userId));
+
+    if (userChildren.length === 0) {
+      result.skipped++;
+      continue;
+    }
+
+    const childIds = userChildren.map((c) => c.id);
+    const [todayCount] = await db
+      .select({ n: count() })
+      .from(symptoms)
+      .where(
+        and(
+          inArray(symptoms.childId, childIds),
+          eq(symptoms.date, localToday)
+        )
+      );
+
+    if ((todayCount?.n ?? 0) > 0) {
+      result.skipped++;
+      continue;
+    }
+
+    const { subject, html } = dailyReminderTemplate(row.name);
+    const send = await sendEmail({ to: row.email, subject, html });
+    if (send.sent || send.reason === "no-api-key") {
+      await db
+        .update(userPreferences)
+        .set({ lastDailyReminderAt: now, updatedAt: now })
+        .where(eq(userPreferences.userId, row.userId));
+    }
+    if (send.sent) result.sent++;
+    else if (send.reason === "error") result.errors++;
+    else result.skipped++;
+  }
+
+  return result;
+}
+
+// Sends a weekly digest on Sunday at 18:00 local time. One email per user
+// (covers their first child's stats). Multi-child aggregation is deferred.
+export async function runWeeklyDigests(
+  now: Date = new Date()
+): Promise<JobResult> {
+  const result: JobResult = { processed: 0, sent: 0, skipped: 0, errors: 0 };
+
+  const rows = await db
+    .select({
+      userId: user.id,
+      email: user.email,
+      name: user.name,
+      timezone: userPreferences.timezone,
+      optIn: userPreferences.weeklyDigestOptIn,
+      lastSent: userPreferences.lastWeeklyDigestAt,
+    })
+    .from(user)
+    .innerJoin(userPreferences, eq(userPreferences.userId, user.id))
+    .where(eq(userPreferences.weeklyDigestOptIn, true));
+
+  const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .split("T")[0]!;
+
+  for (const row of rows) {
+    result.processed++;
+    if (localWeekdayIn(row.timezone, now) !== 0) {
+      result.skipped++;
+      continue;
+    }
+    if (localHourIn(row.timezone, now) !== 18) {
+      result.skipped++;
+      continue;
+    }
+    if (hoursSince(row.lastSent, now) < 6 * 24) {
+      result.skipped++;
+      continue;
+    }
+
+    const [firstChild] = await db
+      .select()
+      .from(children)
+      .where(eq(children.parentId, row.userId))
+      .limit(1);
+    if (!firstChild) {
+      result.skipped++;
+      continue;
+    }
+
+    const weekSymptoms = await db
+      .select()
+      .from(symptoms)
+      .where(
+        and(
+          eq(symptoms.childId, firstChild.id),
+          gte(symptoms.date, weekAgo)
+        )
+      )
+      .orderBy(symptoms.date);
+
+    let moodTrend: "up" | "down" | "stable" | null = null;
+    if (weekSymptoms.length >= 4) {
+      const half = Math.floor(weekSymptoms.length / 2);
+      const firstAvg =
+        weekSymptoms.slice(0, half).reduce((s, x) => s + x.mood, 0) / half;
+      const secondAvg =
+        weekSymptoms.slice(half).reduce((s, x) => s + x.mood, 0) /
+        (weekSymptoms.length - half);
+      const delta = secondAvg - firstAvg;
+      moodTrend = delta > 0.5 ? "up" : delta < -0.5 ? "down" : "stable";
+    }
+
+    // 7-day consistency score (mirrors /stats endpoint formula)
+    let consistencyScore: number | null = null;
+    if (weekSymptoms.length > 0) {
+      const uniqueDates = new Set(weekSymptoms.map((s) => s.date));
+      const coverage = uniqueDates.size / 7;
+      const okDays = weekSymptoms.filter(
+        (s) => s.focus >= 6 || s.mood >= 6 || s.agitation <= 4 || s.impulse <= 4
+      ).length;
+      const stability = okDays / weekSymptoms.length;
+      consistencyScore = Math.round(coverage * stability * 100);
+    }
+
+    // Weekly stars
+    const behaviors = await db
+      .select({ id: barkleyBehaviors.id })
+      .from(barkleyBehaviors)
+      .where(eq(barkleyBehaviors.childId, firstChild.id));
+    let weeklyStars = 0;
+    if (behaviors.length > 0) {
+      const [starsRow] = await db
+        .select({ n: count() })
+        .from(barkleyBehaviorLogs)
+        .where(
+          and(
+            inArray(
+              barkleyBehaviorLogs.behaviorId,
+              behaviors.map((b) => b.id)
+            ),
+            eq(barkleyBehaviorLogs.completed, true),
+            gte(barkleyBehaviorLogs.date, weekAgo)
+          )
+        );
+      weeklyStars = starsRow?.n ?? 0;
+    }
+
+    const data: WeeklyDigestData = {
+      parentName: row.name,
+      childName: firstChild.name,
+      consistencyScore,
+      moodTrend,
+      entriesLogged: weekSymptoms.length,
+      weeklyStars,
+    };
+
+    const { subject, html } = weeklyDigestTemplate(data);
+    const send = await sendEmail({ to: row.email, subject, html });
+    if (send.sent || send.reason === "no-api-key") {
+      await db
+        .update(userPreferences)
+        .set({ lastWeeklyDigestAt: now, updatedAt: now })
+        .where(eq(userPreferences.userId, row.userId));
+    }
+    if (send.sent) result.sent++;
+    else if (send.reason === "error") result.errors++;
+    else result.skipped++;
+  }
+
+  // Silence the "sql" import warning if drizzle tree-shakes it
+  void sql;
+  return result;
+}

--- a/apps/api/src/lib/email-templates.ts
+++ b/apps/api/src/lib/email-templates.ts
@@ -1,0 +1,103 @@
+import { env } from "./env";
+
+function layout(innerHtml: string): string {
+  return `<!doctype html>
+<html lang="fr">
+  <body style="font-family: -apple-system, system-ui, sans-serif; background: #fafaf9; margin: 0; padding: 24px;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="max-width: 560px; margin: 0 auto; background: #fff; border-radius: 12px; padding: 32px; border: 1px solid #e7e5e4;">
+      <tr><td>
+        <div style="font-size: 20px; font-weight: 600; color: #44403c; margin-bottom: 16px;">Tokō</div>
+        ${innerHtml}
+        <hr style="border: none; border-top: 1px solid #e7e5e4; margin: 32px 0 16px;" />
+        <p style="font-size: 12px; color: #a8a29e; margin: 0;">
+          Vous recevez cet email parce que vous avez activé les rappels dans votre compte Tokō.
+          <a href="${env.APP_URL}/account" style="color: #78716c;">Gérer mes notifications</a>
+        </p>
+      </td></tr>
+    </table>
+  </body>
+</html>`;
+}
+
+export function dailyReminderTemplate(parentName: string): {
+  subject: string;
+  html: string;
+} {
+  return {
+    subject: "Tokō — Un petit rappel pour aujourd'hui",
+    html: layout(`
+      <p style="color: #44403c; font-size: 16px;">Bonjour ${escapeHtml(parentName)},</p>
+      <p style="color: #57534e;">
+        Rien de noté aujourd'hui pour l'instant. Un relevé rapide (30 secondes)
+        permet de garder votre suivi à jour.
+      </p>
+      <p style="margin: 24px 0;">
+        <a href="${env.APP_URL}/dashboard" style="display: inline-block; background: #7c6a58; color: #fff; text-decoration: none; padding: 12px 20px; border-radius: 8px; font-weight: 500;">
+          Logger une humeur
+        </a>
+      </p>
+      <p style="color: #78716c; font-size: 14px;">
+        Quatre emojis sur le dashboard, un clic, c'est tout.
+      </p>
+    `),
+  };
+}
+
+export type WeeklyDigestData = {
+  parentName: string;
+  childName: string;
+  consistencyScore: number | null;
+  moodTrend: "up" | "down" | "stable" | null;
+  entriesLogged: number;
+  weeklyStars: number;
+};
+
+export function weeklyDigestTemplate(data: WeeklyDigestData): {
+  subject: string;
+  html: string;
+} {
+  const trendLabel =
+    data.moodTrend === "up"
+      ? "en hausse ↗︎"
+      : data.moodTrend === "down"
+        ? "en baisse ↘︎"
+        : data.moodTrend === "stable"
+          ? "stable →"
+          : "—";
+
+  const consistencyLine =
+    data.consistencyScore !== null
+      ? `<strong>${data.consistencyScore}/100</strong>`
+      : "—";
+
+  return {
+    subject: `Tokō — Bilan de la semaine pour ${data.childName}`,
+    html: layout(`
+      <p style="color: #44403c; font-size: 16px;">Bonjour ${escapeHtml(data.parentName)},</p>
+      <p style="color: #57534e;">
+        Voici un résumé rapide de la semaine pour
+        <strong>${escapeHtml(data.childName)}</strong>.
+      </p>
+      <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="margin: 16px 0;">
+        <tr><td style="padding: 8px 0; color: #78716c;">Constance</td><td style="padding: 8px 0; text-align: right;">${consistencyLine}</td></tr>
+        <tr><td style="padding: 8px 0; color: #78716c;">Tendance humeur</td><td style="padding: 8px 0; text-align: right;"><strong>${trendLabel}</strong></td></tr>
+        <tr><td style="padding: 8px 0; color: #78716c;">Relevés enregistrés</td><td style="padding: 8px 0; text-align: right;"><strong>${data.entriesLogged}</strong></td></tr>
+        <tr><td style="padding: 8px 0; color: #78716c;">Étoiles Barkley</td><td style="padding: 8px 0; text-align: right;"><strong>${data.weeklyStars}</strong></td></tr>
+      </table>
+      <p style="margin: 24px 0;">
+        <a href="${env.APP_URL}/dashboard" style="display: inline-block; background: #7c6a58; color: #fff; text-decoration: none; padding: 12px 20px; border-radius: 8px; font-weight: 500;">
+          Voir le détail
+        </a>
+      </p>
+    `),
+  };
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/apps/api/src/lib/email.ts
+++ b/apps/api/src/lib/email.ts
@@ -1,0 +1,42 @@
+import { env } from "./env";
+
+export type EmailPayload = {
+  to: string;
+  subject: string;
+  html: string;
+};
+
+export type SendResult =
+  | { sent: true; id: string }
+  | { sent: false; reason: "no-api-key" | "error"; detail?: string };
+
+// Minimal Resend client via fetch — avoids pulling in the full SDK.
+// No-ops gracefully when RESEND_API_KEY is not configured so local dev and
+// CI keep working.
+export async function sendEmail(payload: EmailPayload): Promise<SendResult> {
+  if (!env.RESEND_API_KEY) {
+    return { sent: false, reason: "no-api-key" };
+  }
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${env.RESEND_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from: env.EMAIL_FROM,
+      to: payload.to,
+      subject: payload.subject,
+      html: payload.html,
+    }),
+  });
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => response.statusText);
+    return { sent: false, reason: "error", detail };
+  }
+
+  const data = (await response.json()) as { id: string };
+  return { sent: true, id: data.id };
+}

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -15,6 +15,11 @@ const envSchema = z.object({
     .enum(["development", "production", "test"])
     .default("development"),
   PORT: z.coerce.number().default(3001),
+  // Email + cron (all optional; emails gracefully no-op without RESEND_API_KEY)
+  RESEND_API_KEY: z.string().optional(),
+  EMAIL_FROM: z.string().default("Tokō <no-reply@toko.app>"),
+  APP_URL: z.string().default("http://localhost:5173"),
+  CRON_SECRET: z.string().optional(),
 });
 
 const testDefaults: Record<string, string> = {

--- a/apps/api/src/routes/jobs.ts
+++ b/apps/api/src/routes/jobs.ts
@@ -1,0 +1,34 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../types";
+import { env } from "../lib/env";
+import { AppError } from "../middleware/error-handler";
+import { runDailyReminders, runWeeklyDigests } from "../jobs/email-jobs";
+
+export const jobsRoutes = new Hono<AppEnv>();
+
+// Protected by CRON_SECRET header. If no secret is set, the endpoints are
+// disabled (returns 501) so a misconfigured deploy can't be abused.
+jobsRoutes.use("*", async (c, next) => {
+  if (!env.CRON_SECRET) {
+    throw new AppError(
+      "NOT_CONFIGURED",
+      "Cron jobs not configured (CRON_SECRET missing)",
+      501
+    );
+  }
+  const header = c.req.header("x-cron-secret");
+  if (header !== env.CRON_SECRET) {
+    throw new AppError("FORBIDDEN", "Invalid cron secret", 403);
+  }
+  await next();
+});
+
+jobsRoutes.post("/daily-reminders", async (c) => {
+  const result = await runDailyReminders();
+  return c.json(result);
+});
+
+jobsRoutes.post("/weekly-digest", async (c) => {
+  const result = await runWeeklyDigests();
+  return c.json(result);
+});

--- a/apps/api/src/routes/preferences.ts
+++ b/apps/api/src/routes/preferences.ts
@@ -1,0 +1,59 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../types";
+import { eq } from "drizzle-orm";
+import { db, userPreferences } from "@focusflow/db";
+import { updateUserPreferencesSchema } from "@focusflow/validators";
+import { authMiddleware } from "../middleware/auth";
+
+export const preferencesRoutes = new Hono<AppEnv>();
+
+preferencesRoutes.use("*", authMiddleware);
+
+const DEFAULTS = {
+  timezone: "Europe/Paris",
+  dailyReminderOptIn: true,
+  weeklyDigestOptIn: true,
+};
+
+preferencesRoutes.get("/", async (c) => {
+  const user = c.get("user");
+  const [row] = await db
+    .select()
+    .from(userPreferences)
+    .where(eq(userPreferences.userId, user.id));
+
+  if (!row) {
+    return c.json({ userId: user.id, ...DEFAULTS });
+  }
+  return c.json({
+    userId: row.userId,
+    timezone: row.timezone,
+    dailyReminderOptIn: row.dailyReminderOptIn,
+    weeklyDigestOptIn: row.weeklyDigestOptIn,
+  });
+});
+
+preferencesRoutes.patch("/", async (c) => {
+  const user = c.get("user");
+  const body = await c.req.json();
+  const parsed = updateUserPreferencesSchema.safeParse(body);
+
+  if (!parsed.success) {
+    return c.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      422
+    );
+  }
+
+  // Upsert — Better Auth doesn't create preference rows itself.
+  const [row] = await db
+    .insert(userPreferences)
+    .values({ userId: user.id, ...DEFAULTS, ...parsed.data })
+    .onConflictDoUpdate({
+      target: userPreferences.userId,
+      set: { ...parsed.data, updatedAt: new Date() },
+    })
+    .returning();
+
+  return c.json(row);
+});

--- a/apps/web/src/components/account/notifications-card.tsx
+++ b/apps/web/src/components/account/notifications-card.tsx
@@ -1,0 +1,75 @@
+import { Bell } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { usePreferences, useUpdatePreferences } from "@/hooks/use-preferences";
+
+export function NotificationsCard() {
+  const { data, isLoading } = usePreferences();
+  const update = useUpdatePreferences();
+
+  if (isLoading || !data) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Bell className="h-4 w-4 text-muted-foreground" />
+          Notifications
+        </CardTitle>
+        <CardDescription>
+          Emails envoyés selon votre fuseau horaire.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex items-center justify-between rounded-lg border border-border/60 px-3 py-2.5">
+          <Label
+            htmlFor="daily-reminder"
+            className="cursor-pointer space-y-0.5"
+          >
+            <span className="text-sm font-medium">Rappel quotidien</span>
+            <p className="text-xs text-muted-foreground">
+              Un email à 9h si rien n'a été noté.
+            </p>
+          </Label>
+          <input
+            id="daily-reminder"
+            type="checkbox"
+            checked={data.dailyReminderOptIn}
+            disabled={update.isPending}
+            onChange={(e) =>
+              update.mutate({ dailyReminderOptIn: e.target.checked })
+            }
+            className="h-4 w-4 cursor-pointer accent-primary"
+          />
+        </div>
+        <div className="flex items-center justify-between rounded-lg border border-border/60 px-3 py-2.5">
+          <Label
+            htmlFor="weekly-digest"
+            className="cursor-pointer space-y-0.5"
+          >
+            <span className="text-sm font-medium">Bilan hebdomadaire</span>
+            <p className="text-xs text-muted-foreground">
+              Le dimanche à 18h : constance, tendance, étoiles.
+            </p>
+          </Label>
+          <input
+            id="weekly-digest"
+            type="checkbox"
+            checked={data.weeklyDigestOptIn}
+            disabled={update.isPending}
+            onChange={(e) =>
+              update.mutate({ weeklyDigestOptIn: e.target.checked })
+            }
+            className="h-4 w-4 cursor-pointer accent-primary"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/hooks/use-preferences.ts
+++ b/apps/web/src/hooks/use-preferences.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api } from "@/lib/api-client";
+import type { UpdateUserPreferences } from "@focusflow/validators";
+
+export interface Preferences {
+  userId: string;
+  timezone: string;
+  dailyReminderOptIn: boolean;
+  weeklyDigestOptIn: boolean;
+}
+
+const preferencesKey = ["preferences"] as const;
+
+export function usePreferences() {
+  return useQuery({
+    queryKey: preferencesKey,
+    queryFn: () => api.get<Preferences>("/preferences"),
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useUpdatePreferences() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: UpdateUserPreferences) =>
+      api.patch<Preferences>("/preferences", data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: preferencesKey });
+      toast.success("Préférences enregistrées");
+    },
+    onError: () => toast.error("Impossible d'enregistrer les préférences"),
+  });
+}

--- a/apps/web/src/routes/_authenticated/account/index.tsx
+++ b/apps/web/src/routes/_authenticated/account/index.tsx
@@ -26,6 +26,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useDeleteAccount, useExportAccount } from "@/hooks/use-account";
 import { useBillingStatus, useCheckout, usePortal } from "@/hooks/use-billing";
+import { NotificationsCard } from "@/components/account/notifications-card";
 
 export const Route = createFileRoute("/_authenticated/account/")({
   component: AccountPage,
@@ -78,6 +79,8 @@ function AccountPage() {
           </div>
         </CardContent>
       </Card>
+
+      <NotificationsCard />
 
       {/* Billing */}
       <Card>

--- a/packages/db/drizzle/0015_add_user_preferences.sql
+++ b/packages/db/drizzle/0015_add_user_preferences.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "user_preferences" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"timezone" text DEFAULT 'Europe/Paris' NOT NULL,
+	"daily_reminder_opt_in" boolean DEFAULT true NOT NULL,
+	"weekly_digest_opt_in" boolean DEFAULT true NOT NULL,
+	"last_daily_reminder_at" timestamp,
+	"last_weekly_digest_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "user_preferences" ADD CONSTRAINT "user_preferences_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/drizzle/meta/0015_snapshot.json
+++ b/packages/db/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,1519 @@
+{
+  "id": "cdded79a-791d-46e9-9bd6-492c5f13d9d9",
+  "prevId": "cc8c1670-a4fd-4e5a-bc37-8c3e488ea5d9",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.children": {
+      "name": "children",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birth_date": {
+          "name": "birth_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_type": {
+          "name": "diagnosis_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undefined'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "children_parent_id_idx": {
+          "name": "children_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "children_parent_id_user_id_fk": {
+          "name": "children_parent_id_user_id_fk",
+          "tableFrom": "children",
+          "tableTo": "user",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.symptoms": {
+      "name": "symptoms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agitation": {
+          "name": "agitation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "focus": {
+          "name": "focus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impulse": {
+          "name": "impulse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood": {
+          "name": "mood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sleep": {
+          "name": "sleep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routines_ok": {
+          "name": "routines_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "symptoms_child_id_date_idx": {
+          "name": "symptoms_child_id_date_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "symptoms_child_id_children_id_fk": {
+          "name": "symptoms_child_id_children_id_fk",
+          "tableFrom": "symptoms",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entries": {
+      "name": "journal_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "journal_entries_child_id_date_idx": {
+          "name": "journal_entries_child_id_date_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_child_id_children_id_fk": {
+          "name": "journal_entries_child_id_children_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscription_user_id_idx": {
+          "name": "subscription_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscription_stripe_subscription_id_unique": {
+          "name": "subscription_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_behavior_logs": {
+      "name": "barkley_behavior_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "behavior_id": {
+          "name": "behavior_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_behavior_logs_behavior_id_idx": {
+          "name": "barkley_behavior_logs_behavior_id_idx",
+          "columns": [
+            {
+              "expression": "behavior_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_behavior_logs_behavior_id_barkley_behaviors_id_fk": {
+          "name": "barkley_behavior_logs_behavior_id_barkley_behaviors_id_fk",
+          "tableFrom": "barkley_behavior_logs",
+          "tableTo": "barkley_behaviors",
+          "columnsFrom": [
+            "behavior_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "barkley_behavior_logs_behavior_id_date_unique": {
+          "name": "barkley_behavior_logs_behavior_id_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "behavior_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_behaviors": {
+      "name": "barkley_behaviors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_behaviors_child_id_idx": {
+          "name": "barkley_behaviors_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_behaviors_child_id_children_id_fk": {
+          "name": "barkley_behaviors_child_id_children_id_fk",
+          "tableFrom": "barkley_behaviors",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_rewards": {
+      "name": "barkley_rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stars_required": {
+          "name": "stars_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "times_claimed": {
+          "name": "times_claimed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_rewards_child_id_idx": {
+          "name": "barkley_rewards_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_rewards_child_id_children_id_fk": {
+          "name": "barkley_rewards_child_id_children_id_fk",
+          "tableFrom": "barkley_rewards",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_steps": {
+      "name": "barkley_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_steps_child_id_idx": {
+          "name": "barkley_steps_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_steps_child_id_children_id_fk": {
+          "name": "barkley_steps_child_id_children_id_fk",
+          "tableFrom": "barkley_steps",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "barkley_steps_child_id_step_number_unique": {
+          "name": "barkley_steps_child_id_step_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "child_id",
+            "step_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crisis_items": {
+      "name": "crisis_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crisis_items_child_id_idx": {
+          "name": "crisis_items_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crisis_items_child_id_children_id_fk": {
+          "name": "crisis_items_child_id_children_id_fk",
+          "tableFrom": "crisis_items",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_logs": {
+      "name": "medication_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "medication_id": {
+          "name": "medication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taken": {
+          "name": "taken",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_effects": {
+          "name": "side_effects",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "medication_logs_medication_id_idx": {
+          "name": "medication_logs_medication_id_idx",
+          "columns": [
+            {
+              "expression": "medication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medication_logs_medication_id_medications_id_fk": {
+          "name": "medication_logs_medication_id_medications_id_fk",
+          "tableFrom": "medication_logs",
+          "tableTo": "medications",
+          "columnsFrom": [
+            "medication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "medication_logs_medication_id_date_unique": {
+          "name": "medication_logs_medication_id_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "medication_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medications": {
+      "name": "medications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose": {
+          "name": "dose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "medications_child_id_idx": {
+          "name": "medications_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medications_child_id_children_id_fk": {
+          "name": "medications_child_id_children_id_fk",
+          "tableFrom": "medications",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Europe/Paris'"
+        },
+        "daily_reminder_opt_in": {
+          "name": "daily_reminder_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weekly_digest_opt_in": {
+          "name": "weekly_digest_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_daily_reminder_at": {
+          "name": "last_daily_reminder_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_weekly_digest_at": {
+          "name": "last_weekly_digest_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_user_id_fk": {
+          "name": "user_preferences_user_id_user_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1775377076378,
       "tag": "0014_add_medications",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1775377750370,
+      "tag": "0015_add_user_preferences",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -6,3 +6,4 @@ export * from "./subscriptions";
 export * from "./barkley";
 export * from "./crisis-list";
 export * from "./medications";
+export * from "./user-preferences";

--- a/packages/db/src/schema/user-preferences.ts
+++ b/packages/db/src/schema/user-preferences.ts
@@ -1,0 +1,17 @@
+import { pgTable, text, boolean, timestamp } from "drizzle-orm/pg-core";
+import { user } from "./users";
+
+export const userPreferences = pgTable("user_preferences", {
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => user.id, { onDelete: "cascade" }),
+  // IANA timezone name, e.g. "Europe/Paris"
+  timezone: text("timezone").notNull().default("Europe/Paris"),
+  dailyReminderOptIn: boolean("daily_reminder_opt_in").notNull().default(true),
+  weeklyDigestOptIn: boolean("weekly_digest_opt_in").notNull().default(true),
+  // Timestamps to dedupe sends across cron invocations
+  lastDailyReminderAt: timestamp("last_daily_reminder_at"),
+  lastWeeklyDigestAt: timestamp("last_weekly_digest_at"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow(),
+});

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -5,3 +5,4 @@ export * from "./journal";
 export * from "./barkley";
 export * from "./crisis-item";
 export * from "./medication";
+export * from "./user-preferences";

--- a/packages/validators/src/user-preferences.ts
+++ b/packages/validators/src/user-preferences.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+export const userPreferencesSchema = z.object({
+  timezone: z.string().min(1).max(100),
+  dailyReminderOptIn: z.boolean(),
+  weeklyDigestOptIn: z.boolean(),
+});
+
+export const updateUserPreferencesSchema = userPreferencesSchema.partial();
+
+export type UserPreferences = z.infer<typeof userPreferencesSchema>;
+export type UpdateUserPreferences = z.infer<typeof updateUserPreferencesSchema>;


### PR DESCRIPTION
Closes #54, #55.

Completes Week 3 of the parent-workflow backlog. Adds timezone-aware email notifications (daily symptom reminder + Sunday digest) via Resend, with graceful no-op behavior when no API key is set so local dev and CI stay green.

## Schema
- New `user_preferences` table (PK = `userId`): `timezone`, `dailyReminderOptIn`, `weeklyDigestOptIn`, `lastDailyReminderAt`, `lastWeeklyDigestAt`
- Migration `0015_add_user_preferences.sql`

## Jobs
`POST /api/jobs/daily-reminders` and `POST /api/jobs/weekly-digest`, protected by the `x-cron-secret` header. The endpoints return **501** if `CRON_SECRET` is not set, so a misconfigured deploy can't be abused.

- **Daily reminder** — sends at each user's local 9am, skips if a symptom entry already exists today for any of their children, 20h dedupe guard
- **Weekly digest** — Sunday 18:00 local, 6-day dedupe guard, shows consistency score + mood trend + entries logged + weekly stars for the user's first child

Both use `Intl.DateTimeFormat` for timezone conversion (no external dep).

## Email client
- `apps/api/src/lib/email.ts` — 30-line Resend client via `fetch` (no `resend` SDK dependency)
- `apps/api/src/lib/email-templates.ts` — shared layout + two templates, HTML-escaped parent/child names

## User preferences UI
- `GET` + `PATCH /api/preferences` (upserts)
- `NotificationsCard` injected into the Account page with two toggles

## New env vars (all optional)
```
RESEND_API_KEY=
EMAIL_FROM="Tokō <no-reply@toko.app>"
APP_URL=http://localhost:5173
CRON_SECRET=
```

## Deploying
Point an external cron scheduler (GitHub Actions, fly.io cron, EasyCron, etc.) at both endpoints every **15-60 minutes**. The jobs are idempotent and self-gating on local time.

## Verification
- Typecheck ✅ (4/4 packages)
- Tests ✅ 42/42 (3 new email template cases)
- Migration generation clean
- No new npm deps

https://claude.ai/code/session_012PbLvJ1dGkwDPy4kgkGjJh