### PR TITLE
chore(deploy): wire EMAIL_FROM, APP_URL, CRON_SECRET through deploy pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Check for leaked secrets in frontend
         run: |
-          if grep -r 'BETTER_AUTH_SECRET\|RESEND_API_KEY\|STRIPE_SECRET_KEY\|STRIPE_WEBHOOK_SECRET\|GOOGLE_CLIENT_SECRET' apps/web/src/ packages/; then
+          if grep -r 'BETTER_AUTH_SECRET\|RESEND_API_KEY\|CRON_SECRET\|STRIPE_SECRET_KEY\|STRIPE_WEBHOOK_SECRET\|GOOGLE_CLIENT_SECRET' apps/web/src/ packages/; then
             echo "::error::Secrets found in frontend or shared packages!"
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Check for leaked secrets
         run: |
-          if grep -r 'BETTER_AUTH_SECRET\|RESEND_API_KEY\|STRIPE_SECRET_KEY\|STRIPE_WEBHOOK_SECRET\|GOOGLE_CLIENT_SECRET' apps/web/src/ packages/; then
+          if grep -r 'BETTER_AUTH_SECRET\|RESEND_API_KEY\|CRON_SECRET\|STRIPE_SECRET_KEY\|STRIPE_WEBHOOK_SECRET\|GOOGLE_CLIENT_SECRET' apps/web/src/ packages/; then
             echo "::error::Secrets found in frontend or shared packages!"
             exit 1
           fi

--- a/compose.yml
+++ b/compose.yml
@@ -25,6 +25,9 @@ services:
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID:-}
       - GOOGLE_CLIENT_SECRET=${GOOGLE_CLIENT_SECRET:-}
       - RESEND_API_KEY=${RESEND_API_KEY:-}
+      - EMAIL_FROM=${EMAIL_FROM:-Tokō <no-reply@toko.app>}
+      - APP_URL=${APP_URL:-https://toko.battistella.ovh}
+      - CRON_SECRET=${CRON_SECRET:-}
     depends_on:
       postgres:
         condition: service_healthy

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,6 +43,35 @@ Le conteneur final inclut :
 | `STRIPE_WEBHOOK_SECRET` | Secret webhook Stripe | `whsec_...` |
 | `STRIPE_PRICE_ID` | Identifiant du plan tarifaire | `price_...` |
 | `RESEND_API_KEY` | Clé API Resend pour les emails (optionnel) | — |
+| `EMAIL_FROM` | Expéditeur des emails — domaine vérifié Resend | `Tokō <no-reply@toko.app>` |
+| `APP_URL` | URL publique utilisée dans les liens email | `https://toko.battistella.ovh` |
+| `CRON_SECRET` | Secret pour déclencher les jobs (rappels, bilan) | `openssl rand -hex 32` |
+
+## Jobs planifiés (emails)
+
+Deux endpoints déclenchent l'envoi des emails (désactivés tant que `CRON_SECRET` n'est pas défini → renvoient 501) :
+
+- `POST /api/jobs/daily-reminders` — rappel quotidien à 9h locale si aucun relevé
+- `POST /api/jobs/weekly-digest` — bilan hebdomadaire le dimanche à 18h locale
+
+Les jobs sont idempotents (garde-fou 20h / 6 jours) et auto-filtrent sur l'heure locale de chaque utilisateur, donc un scheduler externe peut les appeler toutes les 15-60 minutes.
+
+Exemple avec GitHub Actions (`.github/workflows/cron.yml`) :
+
+```yaml
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -sS -X POST https://toko.battistella.ovh/api/jobs/daily-reminders \
+            -H "x-cron-secret: ${{ secrets.CRON_SECRET }}"
+          curl -sS -X POST https://toko.battistella.ovh/api/jobs/weekly-digest \
+            -H "x-cron-secret: ${{ secrets.CRON_SECRET }}"
+```
 
 ## Pipeline de déploiement
 

--- a/turbo.json
+++ b/turbo.json
@@ -17,6 +17,9 @@
     "VITE_STRIPE_PUBLISHABLE_KEY",
     "VITE_APP_VERSION",
     "RESEND_API_KEY",
+    "EMAIL_FROM",
+    "APP_URL",
+    "CRON_SECRET",
     "E2E_WEB_PORT"
   ],
   "tasks": {


### PR DESCRIPTION
Small follow-up to #61. The email job infrastructure merged in #61 introduced `EMAIL_FROM`, `APP_URL`, and `CRON_SECRET`, but only documented them in `.env.example`. They weren't actually propagated to the production pipeline, so the jobs couldn't run end-to-end.

## Changes

- **`compose.yml`** — pipe `EMAIL_FROM`, `APP_URL`, `CRON_SECRET` into the container. Sensible production defaults (`APP_URL` → `https://toko.battistella.ovh`, `EMAIL_FROM` → `Tokō <no-reply@toko.app>`).
- **`turbo.json`** — add the three vars to `globalEnv` so turbo cache invalidation behaves correctly when they change.
- **`docs/deployment.md`** — document the new vars, add a "Jobs planifiés" section with a GitHub Actions cron example that hits both endpoints every 30 minutes.
- **`.github/workflows/ci.yml` + `release.yml`** — add `CRON_SECRET` to the secret-leak scanner so it can't accidentally land in the frontend bundle.

## To go live with emails

1. `RESEND_API_KEY` — already configured ✅ (Tokō is set up in Resend)
2. Verify the `toko.app` domain in Resend so `no-reply@toko.app` is accepted as sender
3. Set `CRON_SECRET=$(openssl rand -hex 32)` in production env
4. Add the GitHub Actions cron workflow (snippet in `docs/deployment.md`)

## Verification
- Typecheck ✅
- No schema changes
- No code changes — config/docs only

https://claude.ai/code/session_012PbLvJ1dGkwDPy4kgkGjJh