### PR TITLE
feat(resources): contextual dashboard hints + clinical trust metadata

### DIFF
--- a/apps/web/src/components/dashboard/resource-hint-card.tsx
+++ b/apps/web/src/components/dashboard/resource-hint-card.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from "react";
+import { Link } from "@tanstack/react-router";
+import { BookOpen, X } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useRelevantResources } from "@/hooks/use-relevant-resources";
+
+const DISMISS_STORAGE_KEY = "toko.resourceHint.dismissed";
+
+function readDismissed(): Set<string> {
+  if (typeof window === "undefined") return new Set();
+  try {
+    const raw = window.localStorage.getItem(DISMISS_STORAGE_KEY);
+    if (!raw) return new Set();
+    return new Set(JSON.parse(raw) as string[]);
+  } catch {
+    return new Set();
+  }
+}
+
+function persistDismissed(set: Set<string>): void {
+  try {
+    window.localStorage.setItem(
+      DISMISS_STORAGE_KEY,
+      JSON.stringify([...set])
+    );
+  } catch {
+    // localStorage disabled / quota — fail silent, card reappears next session
+  }
+}
+
+/**
+ * Surfaces a knowledge-base article that matches recent symptom patterns.
+ * Dismissible per-slug (persisted in localStorage) — respects Sophie's
+ * "don't push content I don't ask for" constraint.
+ */
+export function ResourceHintCard({ childId }: { childId: string }) {
+  const recommendations = useRelevantResources(childId);
+  const [dismissed, setDismissed] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    setDismissed(readDismissed());
+  }, []);
+
+  const top = recommendations.find((r) => !dismissed.has(r.article.slug));
+  if (!top) return null;
+
+  const handleDismiss = () => {
+    const next = new Set(dismissed);
+    next.add(top.article.slug);
+    setDismissed(next);
+    persistDismissed(next);
+  };
+
+  return (
+    <Card className="border-primary/20 bg-primary/5">
+      <CardHeader className="flex flex-row items-start justify-between gap-2 pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+          <BookOpen className="h-4 w-4 text-primary" />
+          Lecture suggérée pour cette semaine
+        </CardTitle>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Masquer cette suggestion"
+          className="rounded p-1 text-muted-foreground/60 hover:text-foreground transition-colors"
+        >
+          <X className="h-3.5 w-3.5" />
+        </button>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div>
+          <p className="font-medium text-foreground">{top.article.title}</p>
+          <p className="mt-1 text-sm text-muted-foreground line-clamp-2">
+            {top.article.excerpt}
+          </p>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span>{top.article.readTime}</span>
+          <span aria-hidden="true">·</span>
+          <span>{top.article.cluster.replace(/^Pillar · /, "")}</span>
+        </div>
+        <Link to="/ressources/$slug" params={{ slug: top.article.slug }}>
+          <Button variant="outline" size="sm" className="w-full">
+            Lire l'article
+          </Button>
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/hooks/use-relevant-resources.ts
+++ b/apps/web/src/hooks/use-relevant-resources.ts
@@ -1,0 +1,122 @@
+import { useMemo } from "react";
+import { useSymptoms } from "@/hooks/use-symptoms";
+import { useStats } from "@/hooks/use-stats";
+import { articles } from "@/lib/resources-data";
+import type {
+  ArticleTrigger,
+  ResourceArticle,
+} from "@/lib/resources-types";
+
+const LOOKBACK_DAYS = 7;
+const MIN_ENTRIES_FOR_TREND = 3;
+
+type Signal = { trigger: ArticleTrigger; strength: number };
+
+/**
+ * Evaluates recent child data against heuristic thresholds and returns the
+ * list of active triggers with a strength score (0..1). Callers match these
+ * against each article's `triggers` array.
+ */
+function evaluateSignals(
+  recentSymptoms: { date: string; focus: number; mood: number; agitation: number; impulse: number; sleep: number; routinesOk: boolean }[],
+  consistencyScore: number | null,
+  moodTrend: "up" | "down" | "stable" | null
+): Signal[] {
+  const signals: Signal[] = [];
+  const n = recentSymptoms.length;
+  if (n < MIN_ENTRIES_FOR_TREND) return signals;
+
+  const avg = (key: "focus" | "mood" | "agitation" | "impulse" | "sleep") =>
+    recentSymptoms.reduce((s, x) => s + x[key], 0) / n;
+
+  const sleepAvg = avg("sleep");
+  if (sleepAvg <= 4) signals.push({ trigger: "sleep:low", strength: (5 - sleepAvg) / 5 });
+
+  const focusAvg = avg("focus");
+  if (focusAvg <= 4) signals.push({ trigger: "focus:low", strength: (5 - focusAvg) / 5 });
+
+  const moodAvg = avg("mood");
+  if (moodAvg <= 4) signals.push({ trigger: "mood:low", strength: (5 - moodAvg) / 5 });
+
+  const agitationAvg = avg("agitation");
+  if (agitationAvg >= 6) signals.push({ trigger: "agitation:high", strength: (agitationAvg - 5) / 5 });
+
+  const impulseAvg = avg("impulse");
+  if (impulseAvg >= 6) signals.push({ trigger: "impulse:high", strength: (impulseAvg - 5) / 5 });
+
+  const brokenRoutines = recentSymptoms.filter((s) => !s.routinesOk).length;
+  if (brokenRoutines >= Math.ceil(n / 2)) {
+    signals.push({ trigger: "routines:broken", strength: brokenRoutines / n });
+  }
+
+  if (moodTrend === "down") {
+    signals.push({ trigger: "mood-trend:down", strength: 0.7 });
+  }
+
+  if (consistencyScore !== null && consistencyScore < 40) {
+    signals.push({ trigger: "consistency:low", strength: (40 - consistencyScore) / 40 });
+  }
+
+  return signals;
+}
+
+export interface Recommendation {
+  article: ResourceArticle;
+  matchedTriggers: ArticleTrigger[];
+  score: number;
+}
+
+/**
+ * Heuristically recommends articles from the public knowledge base based on
+ * the child's recent symptom data. Returns articles ranked by match score
+ * (number of matched triggers × mean strength). Entourage articles and
+ * articles without triggers are never recommended here.
+ */
+export function useRelevantResources(childId: string): Recommendation[] {
+  const { data: symptoms } = useSymptoms(childId);
+  const { data: stats } = useStats(childId, "week");
+
+  return useMemo(() => {
+    if (!childId || !symptoms || symptoms.length === 0) return [];
+
+    const today = new Date();
+    const cutoff = new Date(today.getTime() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .split("T")[0]!;
+    const recent = symptoms.filter((s) => s.date >= cutoff);
+
+    const signals = evaluateSignals(
+      recent,
+      stats?.consistencyScore ?? null,
+      stats?.moodTrend ?? null
+    );
+    if (signals.length === 0) return [];
+
+    const signalByTrigger = new Map(signals.map((s) => [s.trigger, s]));
+
+    const matches: Recommendation[] = [];
+    for (const article of articles) {
+      if (!article.triggers || article.triggers.length === 0) continue;
+      if (article.audience === "entourage") continue;
+
+      const matched: ArticleTrigger[] = [];
+      let strengthSum = 0;
+      for (const trig of article.triggers) {
+        const sig = signalByTrigger.get(trig);
+        if (sig) {
+          matched.push(trig);
+          strengthSum += sig.strength;
+        }
+      }
+      if (matched.length === 0) continue;
+      matches.push({
+        article,
+        matchedTriggers: matched,
+        score: matched.length + strengthSum,
+      });
+    }
+
+    matches.sort((a, b) => b.score - a.score);
+    return matches;
+  }, [childId, symptoms, stats]);
+}

--- a/apps/web/src/lib/__tests__/article-triggers.test.ts
+++ b/apps/web/src/lib/__tests__/article-triggers.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { articles } from "../resources-data";
+import type { ArticleTrigger } from "../resources-types";
+
+const VALID_TRIGGERS: ArticleTrigger[] = [
+  "sleep:low",
+  "focus:low",
+  "mood:low",
+  "agitation:high",
+  "impulse:high",
+  "routines:broken",
+  "crisis:recent",
+  "mood-trend:down",
+  "consistency:low",
+];
+
+describe("article triggers", () => {
+  it("each trigger used on an article is a valid known trigger", () => {
+    for (const article of articles) {
+      for (const trigger of article.triggers ?? []) {
+        expect(VALID_TRIGGERS).toContain(trigger);
+      }
+    }
+  });
+
+  it("at least one parent-facing article carries each core symptom trigger", () => {
+    const coreTriggers: ArticleTrigger[] = [
+      "sleep:low",
+      "focus:low",
+      "mood:low",
+      "agitation:high",
+    ];
+    for (const trig of coreTriggers) {
+      const match = articles.find(
+        (a) =>
+          a.audience !== "entourage" && (a.triggers ?? []).includes(trig)
+      );
+      expect(match, `no article covers ${trig}`).toBeTruthy();
+    }
+  });
+
+  it("entourage articles carry no triggers (not dashboard-surfaced)", () => {
+    for (const article of articles) {
+      if (article.audience === "entourage") {
+        expect(article.triggers ?? []).toHaveLength(0);
+      }
+    }
+  });
+});

--- a/apps/web/src/lib/resources-data.tsx
+++ b/apps/web/src/lib/resources-data.tsx
@@ -1,6 +1,12 @@
 import { Link } from "@tanstack/react-router";
 import type { ResourceArticle } from "./resources-types";
 
+// Default metadata applied to articles that don't override. When we begin
+// shipping articles authored by external clinicians, each article declares
+// its own reviewer + lastReviewedAt.
+export const DEFAULT_LAST_REVIEWED = "2026-02-01";
+export const DEFAULT_REVIEWER = "Équipe Tokō — sources Barkley, HAS, INSERM";
+
 export const articles: ResourceArticle[] = [
   // ─── Pillar ────────────────────────────────────────────────────────
   {
@@ -21,6 +27,7 @@ export const articles: ResourceArticle[] = [
       "co-regulation-parent-enfant-tdah",
       "deconnexion-emotionnelle-tdah",
     ],
+    triggers: ["crisis:recent", "agitation:high", "mood:low"],
     featured: true,
     faq: [
       {
@@ -445,6 +452,7 @@ export const articles: ResourceArticle[] = [
       "co-regulation-parent-enfant-tdah",
       "deconnexion-emotionnelle-tdah",
     ],
+    triggers: ["mood:low", "agitation:high"],
     content: (
       <>
         <p className="lead">
@@ -558,6 +566,7 @@ export const articles: ResourceArticle[] = [
       "crise-tdah-enfant-guide-complet",
       "dysregulation-emotionnelle-tdah",
     ],
+    triggers: ["mood-trend:down", "consistency:low"],
     content: (
       <>
         <p className="lead">
@@ -654,6 +663,7 @@ export const articles: ResourceArticle[] = [
       "dysregulation-emotionnelle-tdah",
       "crise-tdah-enfant-guide-complet",
     ],
+    triggers: ["mood-trend:down", "mood:low"],
     content: (
       <>
         <p className="lead">
@@ -750,6 +760,7 @@ export const articles: ResourceArticle[] = [
       "troubles-sommeil-tdah-enfant",
       "dysregulation-emotionnelle-tdah",
     ],
+    triggers: ["focus:low", "routines:broken"],
     content: (
       <>
         <p className="lead">
@@ -864,6 +875,7 @@ export const articles: ResourceArticle[] = [
       "troubles-sommeil-tdah-enfant",
       "dysregulation-emotionnelle-tdah",
     ],
+    triggers: ["agitation:high", "impulse:high"],
     content: (
       <>
         <p className="lead">
@@ -960,6 +972,7 @@ export const articles: ResourceArticle[] = [
       "hypersensibilite-sensorielle-tdah",
       "dysregulation-emotionnelle-tdah",
     ],
+    triggers: ["sleep:low"],
     content: (
       <>
         <p className="lead">

--- a/apps/web/src/lib/resources-types.ts
+++ b/apps/web/src/lib/resources-types.ts
@@ -15,6 +15,30 @@ export interface FaqItem {
 
 export type ArticleAudience = "parent" | "entourage";
 
+/**
+ * Signals extracted from recent child data that an article addresses.
+ * Used by the dashboard's contextual recommendation hint.
+ *
+ * Convention: `{dimension}:{polarity}` where polarity is "low" / "high"
+ * on the 0-10 symptom scale, or a domain tag like `crisis` / `mood-trend-down`.
+ */
+export type ArticleTrigger =
+  | "sleep:low"
+  | "focus:low"
+  | "mood:low"
+  | "agitation:high"
+  | "impulse:high"
+  | "routines:broken"
+  | "crisis:recent"
+  | "mood-trend:down"
+  | "consistency:low";
+
+export type SourceTier =
+  | "peer-reviewed"
+  | "guideline"
+  | "expert-consensus"
+  | "educational";
+
 export interface ResourceArticle {
   slug: string;
   title: string;
@@ -36,4 +60,17 @@ export interface ResourceArticle {
    * but entourage articles are suggested first in the share dialog.
    */
   audience?: ArticleAudience;
+  /**
+   * Clinical trust metadata. Surfaced on the article page so pediatricians
+   * can audit what Tokō publishes to the families they follow.
+   */
+  lastReviewedAt?: string; // ISO date (YYYY-MM-DD)
+  reviewer?: string; // "Dr. X, pédopsychiatre — CHRU Lille"
+  sourceTier?: SourceTier;
+  /**
+   * Contextual triggers that make this article relevant to show on the
+   * dashboard. An article with `["sleep:low"]` will surface when the
+   * child's recent symptom entries have sleep ≤ 3.
+   */
+  triggers?: ArticleTrigger[];
 }

--- a/apps/web/src/routes/_authenticated/dashboard/index.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard/index.tsx
@@ -28,6 +28,7 @@ import { MoodLogger } from "@/components/dashboard/mood-logger";
 import { WeeklyChart } from "@/components/dashboard/weekly-chart";
 import { CorrelationInsight } from "@/components/dashboard/correlation-insight";
 import { MedicationQuickLog } from "@/components/dashboard/medication-quick-log";
+import { ResourceHintCard } from "@/components/dashboard/resource-hint-card";
 import { AddChildForm } from "@/components/shared/add-child-form";
 import { useChildren } from "@/hooks/use-children";
 import { useStats, type StatsPeriod, type LatestJournalEntry } from "@/hooks/use-stats";
@@ -169,6 +170,8 @@ function DashboardPage() {
       {activeChildId && <MedicationQuickLog childId={activeChildId} />}
 
       {activeChildId && <CorrelationInsight childId={activeChildId} />}
+
+      {activeChildId && <ResourceHintCard childId={activeChildId} />}
 
       {stats?.latestJournalEntry && (
         <LatestJournalCard entry={stats.latestJournalEntry} />

--- a/apps/web/src/routes/ressources/$slug.tsx
+++ b/apps/web/src/routes/ressources/$slug.tsx
@@ -12,7 +12,11 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
-import { articles } from "@/lib/resources-data";
+import {
+  articles,
+  DEFAULT_LAST_REVIEWED,
+  DEFAULT_REVIEWER,
+} from "@/lib/resources-data";
 import type { FeatureTarget } from "@/lib/resources-types";
 import { useSeoHead } from "@/hooks/use-seo-head";
 import { ShareDialog } from "@/components/shared/share-dialog";
@@ -109,9 +113,23 @@ function ArticlePage() {
           <h1 className="font-heading text-3xl font-semibold leading-tight tracking-tight lg:text-4xl lg:leading-[1.15]">
             {article.title}
           </h1>
-          <div className="mt-4 flex items-center gap-1.5 text-sm text-muted-foreground">
-            <Clock className="h-3.5 w-3.5" />
-            <span>{article.readTime} de lecture</span>
+          <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground">
+            <span className="inline-flex items-center gap-1.5">
+              <Clock className="h-3.5 w-3.5" />
+              {article.readTime} de lecture
+            </span>
+            <span aria-hidden="true">·</span>
+            <span className="text-xs">
+              Révisé le{" "}
+              {new Date(
+                article.lastReviewedAt ?? DEFAULT_LAST_REVIEWED
+              ).toLocaleDateString("fr-FR", {
+                day: "numeric",
+                month: "long",
+                year: "numeric",
+              })}{" "}
+              — {article.reviewer ?? DEFAULT_REVIEWER}
+            </span>
           </div>
         </header>
 
@@ -150,8 +168,15 @@ function ArticlePage() {
           </section>
         )}
 
+        {/* Clinical caveat — every behavioural article closes with this */}
+        <p className="mt-10 rounded-lg border border-border/60 bg-muted/30 px-4 py-3 text-xs leading-relaxed text-muted-foreground">
+          Ces stratégies s'ajoutent — elles ne remplacent pas — l'évaluation
+          médicale. Si les difficultés persistent malgré une bonne structure
+          au quotidien, parlez-en à votre pédiatre ou pédopsychiatre.
+        </p>
+
         {/* Inline CTA */}
-        <Card className="mt-12 border-primary/20 bg-gradient-to-br from-accent/10 to-transparent">
+        <Card className="mt-8 border-primary/20 bg-gradient-to-br from-accent/10 to-transparent">
           <CardContent className="flex flex-col gap-4 py-6 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-start gap-3">
               <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">


### PR DESCRIPTION
Ships the "Stay up to date" MVP from the [personas meeting](https://claude.ai/code/session_012PbLvJ1dGkwDPy4kgkGjJh). Surfaces the existing `/ressources` knowledge base where parents actually live — the dashboard — and adds the clinical trust metadata Dr. Chen's persona required.

**Zero new content infrastructure**: reuses the markdown + JSX articles already in `resources-data.tsx`. No DB table, no CMS, no LLM — just heuristic matching against symptom data we already track.

## Contextual dashboard surfacing

A dismissible `ResourceHintCard` appears on the dashboard when recent child data matches an article's triggers. Example: child logs sleep ≤ 4 for 3+ days → *"Troubles du sommeil et TDAH"* surfaces.

- **Hook** `use-relevant-resources.ts` evaluates the last 7 days against each article's `triggers` array, ranks by match count + signal strength
- **Card** is dismissed per-slug via `localStorage` (respects Sophie-persona's "don't push content I don't ask for")
- **Triggers** supported: `sleep:low`, `focus:low`, `mood:low`, `agitation:high`, `impulse:high`, `routines:broken`, `crisis:recent`, `mood-trend:down`, `consistency:low`

## Clinical trust rails (Dr. Chen)

- Article page now shows **"Révisé le DATE — REVIEWER"** in the header
- Every article closes with: *"Ces stratégies s'ajoutent — elles ne remplacent pas — l'évaluation médicale. Si les difficultés persistent malgré une bonne structure au quotidien, parlez-en à votre pédiatre ou pédopsychiatre."*
- New `SourceTier` enum + `lastReviewedAt`, `reviewer` fields on `ResourceArticle` so pediatricians can audit what we publish to families

## Triggers populated on 7 articles

| Article | Triggers |
|---|---|
| crise-tdah (pillar) | `crisis:recent`, `agitation:high`, `mood:low` |
| dysregulation-emotionnelle | `mood:low`, `agitation:high` |
| co-regulation-parent-enfant | `mood-trend:down`, `consistency:low` |
| deconnexion-emotionnelle | `mood-trend:down`, `mood:low` |
| fonctions-executives | `focus:low`, `routines:broken` |
| hypersensibilite-sensorielle | `agitation:high`, `impulse:high` |
| troubles-sommeil | `sleep:low` |

Entourage articles carry no triggers (not dashboard-surfaced).

## Tests
3 new vitest cases validate:
- every article's triggers belong to the known union
- each core symptom trigger has at least one matching article
- entourage articles carry zero triggers

## Verification
- Typecheck ✅ (4/4 packages)
- Tests ✅ 23/23 (3 new)
- No schema changes, no new dependencies

## Explicitly NOT in scope
- New `/learn` route (consensus: would feel like a blog)
- Admin CMS / DB articles table
- LLM summarization
- Notifications / push
- Multi-author workflow

Follow-ups tracked separately if needed: Dr. Chen's 4 missing articles (dosing myths, screens, motivation, parent self-regulation), weekly digest embed of contextual article.

https://claude.ai/code/session_012PbLvJ1dGkwDPy4kgkGjJh