### PR TITLE
fix(web): pipe VITE_KOE_API_URL + VITE_KOE_PROJECT_KEY through to the frontend build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,8 @@ jobs:
             VERSION=${{ steps.version.outputs.new_version }}
             BUILD_DATE=${{ github.event.repository.updated_at }}
             VCS_REF=${{ github.sha }}
+            VITE_KOE_API_URL=${{ vars.VITE_KOE_API_URL }}
+            VITE_KOE_PROJECT_KEY=${{ vars.VITE_KOE_PROJECT_KEY }}
           cache-from: type=gha
           cache-to: type=gha,mode=max,ignore-error=true
           platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,12 @@ COPY packages/validators ./packages/validators
 COPY apps/web ./apps/web
 
 ARG VERSION
+ARG VITE_KOE_API_URL=""
+ARG VITE_KOE_PROJECT_KEY=""
 ENV VITE_APP_VERSION=${VERSION}
 ENV VITE_API_URL=""
+ENV VITE_KOE_API_URL=${VITE_KOE_API_URL}
+ENV VITE_KOE_PROJECT_KEY=${VITE_KOE_PROJECT_KEY}
 RUN pnpm --filter @focusflow/web run build
 
 # Stage 3: Production runtime (reuses node_modules from deps — no second install)


### PR DESCRIPTION
## Summary

The Koe widget (`apps/web/src/components/koe-widget.tsx`) is gated on `VITE_KOE_API_URL` and `VITE_KOE_PROJECT_KEY`. Vite env vars are baked in at **build time**, but the `frontend-builder` stage only forwarded `VITE_APP_VERSION` and `VITE_API_URL`. Production bundles therefore shipped with both Koe vars as `undefined` and the widget returned `null`.

- Dockerfile: accept `VITE_KOE_API_URL` and `VITE_KOE_PROJECT_KEY` as `ARG`s and export them as `ENV`s before `pnpm run build`.
- release.yml: pass them via `build-args`, sourced from repo variables (`vars.VITE_KOE_API_URL`, `vars.VITE_KOE_PROJECT_KEY`). Both are public-safe — the identity secret stays server-side in `.env`.

Repo variables already set:
- `VITE_KOE_API_URL=https://koe.battistella.ovh`
- `VITE_KOE_PROJECT_KEY=toko`

## Test plan

- [ ] Merge → `Release` workflow publishes a new image tag
- [ ] Homelab deploy workflow pulls & reconciles
- [ ] https://toko.battistella.ovh/ shows the Koe widget for logged-in users
- [ ] Bug submissions succeed (CORS + identity already validated server-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)