### PR TITLE
chore(web): bump @wifsimster/koe to 1.28.2

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,7 +20,7 @@
     "@fontsource-variable/source-serif-4": "^5.2.9",
     "@tanstack/react-query": "^5.62.0",
     "@tanstack/react-router": "^1.92.0",
-    "@wifsimster/koe": "^1.28.1",
+    "@wifsimster/koe": "^1.28.2",
     "better-auth": "^1.5.6",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^1.92.0
         version: 1.168.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@wifsimster/koe':
-        specifier: ^1.28.1
-        version: 1.28.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: ^1.28.2
+        version: 1.28.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       better-auth:
         specifier: ^1.5.6
         version: 1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(gel@2.2.0)(kysely@0.28.14)(postgres@3.4.8))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)))
@@ -1636,8 +1636,8 @@ packages:
   '@vitest/utils@4.1.0':
     resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
-  '@wifsimster/koe@1.28.1':
-    resolution: {integrity: sha512-XajoBcWwlTYOR786O/FPaMU8Bn8yPisXGDjDUnphiGVjppR4+7iVkXzWU/KgQBRPsN9Y+6KkmZBUz1S23XTJoQ==}
+  '@wifsimster/koe@1.28.2':
+    resolution: {integrity: sha512-+0Jui+0rPglx8HpPrcTzHls7Yt+2rP8fcm86mlEbav61gwR1IFe+63eYQWrXA1ZpM6ZDD9eQqZmF6HiYa0Kgzw==}
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
@@ -4861,7 +4861,7 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@wifsimster/koe@1.28.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+  '@wifsimster/koe@1.28.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       clsx: 2.1.1
       react: 19.2.5


### PR DESCRIPTION
## Summary
- Bumps `@wifsimster/koe` from `^1.28.1` to `^1.28.2` in `apps/web`.

## Test plan
- [x] `pnpm install` resolves cleanly
- [x] `pnpm --filter @focusflow/web typecheck` passes
- [ ] Smoke-test the Koe widget in the running web app before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)