### PR TITLE
feat(web): desktop-first authenticated shell on shadcn Sidebar

### DIFF
--- a/apps/web/src/components/layout/breadcrumbs.tsx
+++ b/apps/web/src/components/layout/breadcrumbs.tsx
@@ -1,0 +1,58 @@
+import { Link, useMatches } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { Fragment } from "react";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+
+declare module "@tanstack/react-router" {
+  interface StaticDataRouteOption {
+    /** i18n key rendered in the breadcrumb trail for this route. */
+    crumb?: string;
+  }
+}
+
+export function Breadcrumbs({ className }: { className?: string }) {
+  const { t } = useTranslation();
+  const matches = useMatches();
+
+  const crumbs = matches
+    .filter((m) => !!m.staticData?.crumb)
+    .map((m) => ({
+      to: m.pathname,
+      label: t(m.staticData!.crumb!),
+    }));
+
+  if (crumbs.length === 0) return null;
+
+  return (
+    <Breadcrumb className={className}>
+      <BreadcrumbList>
+        {crumbs.map((c, i) => {
+          const isLast = i === crumbs.length - 1;
+          return (
+            <Fragment key={c.to}>
+              <BreadcrumbItem>
+                {isLast ? (
+                  <BreadcrumbPage>{c.label}</BreadcrumbPage>
+                ) : (
+                  <BreadcrumbLink
+                    render={<Link to={c.to} />}
+                  >
+                    {c.label}
+                  </BreadcrumbLink>
+                )}
+              </BreadcrumbItem>
+              {!isLast && <BreadcrumbSeparator />}
+            </Fragment>
+          );
+        })}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/apps/web/src/components/layout/page-header.tsx
+++ b/apps/web/src/components/layout/page-header.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/lib/utils";
+
+type PageHeaderProps = {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+  actions?: React.ReactNode;
+  className?: string;
+};
+
+export function PageHeader({
+  title,
+  description,
+  actions,
+  className,
+}: PageHeaderProps) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between",
+        className
+      )}
+    >
+      <div className="min-w-0 space-y-1">
+        <h1
+          id="page-title"
+          className="font-heading text-2xl font-semibold tracking-tight text-foreground lg:text-3xl"
+        >
+          {title}
+        </h1>
+        {description && (
+          <p className="text-sm text-muted-foreground lg:text-base">
+            {description}
+          </p>
+        )}
+      </div>
+      {actions && (
+        <div className="flex shrink-0 items-center gap-2">{actions}</div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/breadcrumb.tsx
+++ b/apps/web/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,125 @@
+import * as React from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, MoreHorizontalIcon } from "lucide-react"
+
+function Breadcrumb({ className, ...props }: React.ComponentProps<"nav">) {
+  return (
+    <nav
+      aria-label="breadcrumb"
+      data-slot="breadcrumb"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbList({ className, ...props }: React.ComponentProps<"ol">) {
+  return (
+    <ol
+      data-slot="breadcrumb-list"
+      className={cn(
+        "flex flex-wrap items-center gap-1.5 text-sm wrap-break-word text-muted-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-item"
+      className={cn("inline-flex items-center gap-1", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbLink({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"a">) {
+  return useRender({
+    defaultTagName: "a",
+    props: mergeProps<"a">(
+      {
+        className: cn("transition-colors hover:text-foreground", className),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "breadcrumb-link",
+    },
+  })
+}
+
+function BreadcrumbPage({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-page"
+      role="link"
+      aria-disabled="true"
+      aria-current="page"
+      className={cn("font-normal text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function BreadcrumbSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="breadcrumb-separator"
+      role="presentation"
+      aria-hidden="true"
+      className={cn("[&>svg]:size-3.5", className)}
+      {...props}
+    >
+      {children ?? (
+        <ChevronRightIcon />
+      )}
+    </li>
+  )
+}
+
+function BreadcrumbEllipsis({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="breadcrumb-ellipsis"
+      role="presentation"
+      aria-hidden="true"
+      className={cn(
+        "flex size-5 items-center justify-center [&>svg]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <MoreHorizontalIcon
+      />
+      <span className="sr-only">More</span>
+    </span>
+  )
+}
+
+export {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+  BreadcrumbEllipsis,
+}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -1,0 +1,723 @@
+"use client"
+
+import * as React from "react"
+import { mergeProps } from "@base-ui/react/merge-props"
+import { useRender } from "@base-ui/react/use-render"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { useIsMobile } from "@/hooks/use-mobile"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Separator } from "@/components/ui/separator"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { Skeleton } from "@/components/ui/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip"
+import { PanelLeftIcon } from "lucide-react"
+
+const SIDEBAR_COOKIE_NAME = "sidebar_state"
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
+const SIDEBAR_WIDTH = "16rem"
+const SIDEBAR_WIDTH_MOBILE = "18rem"
+const SIDEBAR_WIDTH_ICON = "3rem"
+const SIDEBAR_KEYBOARD_SHORTCUT = "b"
+
+type SidebarContextProps = {
+  state: "expanded" | "collapsed"
+  open: boolean
+  setOpen: (open: boolean) => void
+  openMobile: boolean
+  setOpenMobile: (open: boolean) => void
+  isMobile: boolean
+  toggleSidebar: () => void
+}
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null)
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext)
+  if (!context) {
+    throw new Error("useSidebar must be used within a SidebarProvider.")
+  }
+
+  return context
+}
+
+function SidebarProvider({
+  defaultOpen = true,
+  open: openProp,
+  onOpenChange: setOpenProp,
+  className,
+  style,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  defaultOpen?: boolean
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+}) {
+  const isMobile = useIsMobile()
+  const [openMobile, setOpenMobile] = React.useState(false)
+
+  // This is the internal state of the sidebar.
+  // We use openProp and setOpenProp for control from outside the component.
+  const [_open, _setOpen] = React.useState(defaultOpen)
+  const open = openProp ?? _open
+  const setOpen = React.useCallback(
+    (value: boolean | ((value: boolean) => boolean)) => {
+      const openState = typeof value === "function" ? value(open) : value
+      if (setOpenProp) {
+        setOpenProp(openState)
+      } else {
+        _setOpen(openState)
+      }
+
+      // This sets the cookie to keep the sidebar state.
+      document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
+    },
+    [setOpenProp, open]
+  )
+
+  // Helper to toggle the sidebar.
+  const toggleSidebar = React.useCallback(() => {
+    return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open)
+  }, [isMobile, setOpen, setOpenMobile])
+
+  // Adds a keyboard shortcut to toggle the sidebar.
+  React.useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+        (event.metaKey || event.ctrlKey)
+      ) {
+        event.preventDefault()
+        toggleSidebar()
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  }, [toggleSidebar])
+
+  // We add a state so that we can do data-state="expanded" or "collapsed".
+  // This makes it easier to style the sidebar with Tailwind classes.
+  const state = open ? "expanded" : "collapsed"
+
+  const contextValue = React.useMemo<SidebarContextProps>(
+    () => ({
+      state,
+      open,
+      setOpen,
+      isMobile,
+      openMobile,
+      setOpenMobile,
+      toggleSidebar,
+    }),
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+  )
+
+  return (
+    <SidebarContext.Provider value={contextValue}>
+      <div
+        data-slot="sidebar-wrapper"
+        style={
+          {
+            "--sidebar-width": SIDEBAR_WIDTH,
+            "--sidebar-width-icon": SIDEBAR_WIDTH_ICON,
+            ...style,
+          } as React.CSSProperties
+        }
+        className={cn(
+          "group/sidebar-wrapper flex min-h-svh w-full has-data-[variant=inset]:bg-sidebar",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    </SidebarContext.Provider>
+  )
+}
+
+function Sidebar({
+  side = "left",
+  variant = "sidebar",
+  collapsible = "offcanvas",
+  className,
+  children,
+  dir,
+  ...props
+}: React.ComponentProps<"div"> & {
+  side?: "left" | "right"
+  variant?: "sidebar" | "floating" | "inset"
+  collapsible?: "offcanvas" | "icon" | "none"
+}) {
+  const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+
+  if (collapsible === "none") {
+    return (
+      <div
+        data-slot="sidebar"
+        className={cn(
+          "flex h-full w-(--sidebar-width) flex-col bg-sidebar text-sidebar-foreground",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </div>
+    )
+  }
+
+  if (isMobile) {
+    return (
+      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <SheetContent
+          dir={dir}
+          data-sidebar="sidebar"
+          data-slot="sidebar"
+          data-mobile="true"
+          className="w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden"
+          style={
+            {
+              "--sidebar-width": SIDEBAR_WIDTH_MOBILE,
+            } as React.CSSProperties
+          }
+          side={side}
+        >
+          <SheetHeader className="sr-only">
+            <SheetTitle>Sidebar</SheetTitle>
+            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+          </SheetHeader>
+          <div className="flex h-full w-full flex-col">{children}</div>
+        </SheetContent>
+      </Sheet>
+    )
+  }
+
+  return (
+    <div
+      className="group peer hidden text-sidebar-foreground md:block"
+      data-state={state}
+      data-collapsible={state === "collapsed" ? collapsible : ""}
+      data-variant={variant}
+      data-side={side}
+      data-slot="sidebar"
+    >
+      {/* This is what handles the sidebar gap on desktop */}
+      <div
+        data-slot="sidebar-gap"
+        className={cn(
+          "relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear",
+          "group-data-[collapsible=offcanvas]:w-0",
+          "group-data-[side=right]:rotate-180",
+          variant === "floating" || variant === "inset"
+            ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4)))]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon)"
+        )}
+      />
+      <div
+        data-slot="sidebar-container"
+        data-side={side}
+        className={cn(
+          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex",
+          // Adjust the padding for floating and inset variants.
+          variant === "floating" || variant === "inset"
+            ? "p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]"
+            : "group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l",
+          className
+        )}
+        {...props}
+      >
+        <div
+          data-sidebar="sidebar"
+          data-slot="sidebar-inner"
+          className="flex size-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:shadow-sm group-data-[variant=floating]:ring-1 group-data-[variant=floating]:ring-sidebar-border"
+        >
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SidebarTrigger({
+  className,
+  onClick,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <Button
+      data-sidebar="trigger"
+      data-slot="sidebar-trigger"
+      variant="ghost"
+      size="icon-sm"
+      className={cn(className)}
+      onClick={(event) => {
+        onClick?.(event)
+        toggleSidebar()
+      }}
+      {...props}
+    >
+      <PanelLeftIcon />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  )
+}
+
+function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
+  const { toggleSidebar } = useSidebar()
+
+  return (
+    <button
+      data-sidebar="rail"
+      data-slot="sidebar-rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        "absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:start-1/2 after:w-[2px] hover:after:bg-sidebar-border sm:flex ltr:-translate-x-1/2 rtl:-translate-x-1/2",
+        "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",
+        "[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize",
+        "group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full hover:group-data-[collapsible=offcanvas]:bg-sidebar",
+        "[[data-side=left][data-collapsible=offcanvas]_&]:-right-2",
+        "[[data-side=right][data-collapsible=offcanvas]_&]:-left-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInset({ className, ...props }: React.ComponentProps<"main">) {
+  return (
+    <main
+      data-slot="sidebar-inset"
+      className={cn(
+        "relative flex w-full flex-1 flex-col bg-background md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarInput({
+  className,
+  ...props
+}: React.ComponentProps<typeof Input>) {
+  return (
+    <Input
+      data-slot="sidebar-input"
+      data-sidebar="input"
+      className={cn("h-8 w-full bg-background shadow-none", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-header"
+      data-sidebar="header"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-footer"
+      data-sidebar="footer"
+      className={cn("flex flex-col gap-2 p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="sidebar-separator"
+      data-sidebar="separator"
+      className={cn("mx-2 w-auto bg-sidebar-border", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-content"
+      data-sidebar="content"
+      className={cn(
+        "no-scrollbar flex min-h-0 flex-1 flex-col gap-0 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group"
+      data-sidebar="group"
+      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarGroupLabel({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"div"> & React.ComponentProps<"div">) {
+  return useRender({
+    defaultTagName: "div",
+    props: mergeProps<"div">(
+      {
+        className: cn(
+          "flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 ring-sidebar-ring outline-hidden transition-[margin,opacity] duration-200 ease-linear group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0 focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "sidebar-group-label",
+      sidebar: "group-label",
+    },
+  })
+}
+
+function SidebarGroupAction({
+  className,
+  render,
+  ...props
+}: useRender.ComponentProps<"button"> & React.ComponentProps<"button">) {
+  return useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        className: cn(
+          "absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "sidebar-group-action",
+      sidebar: "group-action",
+    },
+  })
+}
+
+function SidebarGroupContent({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-group-content"
+      data-sidebar="group-content"
+      className={cn("w-full text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenu({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu"
+      data-sidebar="menu"
+      className={cn("flex w-full min-w-0 flex-col gap-0", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuItem({ className, ...props }: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-item"
+      data-sidebar="menu-item"
+      className={cn("group/menu-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+const sidebarMenuButtonVariants = cva(
+  "peer/menu-button group/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm ring-sidebar-ring outline-hidden transition-[width,height,padding] group-has-data-[sidebar=menu-action]/menu-item:pr-8 group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:p-2! hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-open:hover:bg-sidebar-accent data-open:hover:text-sidebar-accent-foreground data-active:bg-sidebar-accent data-active:font-medium data-active:text-sidebar-accent-foreground [&_svg]:size-4 [&_svg]:shrink-0 [&>span:last-child]:truncate",
+  {
+    variants: {
+      variant: {
+        default: "hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+        outline:
+          "bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]",
+      },
+      size: {
+        default: "h-8 text-sm",
+        sm: "h-7 text-xs",
+        lg: "h-12 text-sm group-data-[collapsible=icon]:p-0!",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function SidebarMenuButton({
+  render,
+  isActive = false,
+  variant = "default",
+  size = "default",
+  tooltip,
+  className,
+  ...props
+}: useRender.ComponentProps<"button"> &
+  React.ComponentProps<"button"> & {
+    isActive?: boolean
+    tooltip?: string | React.ComponentProps<typeof TooltipContent>
+  } & VariantProps<typeof sidebarMenuButtonVariants>) {
+  const { isMobile, state } = useSidebar()
+  const comp = useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        className: cn(sidebarMenuButtonVariants({ variant, size }), className),
+      },
+      props
+    ),
+    render: !tooltip ? render : <TooltipTrigger render={render} />,
+    state: {
+      slot: "sidebar-menu-button",
+      sidebar: "menu-button",
+      size,
+      active: isActive,
+    },
+  })
+
+  if (!tooltip) {
+    return comp
+  }
+
+  if (typeof tooltip === "string") {
+    tooltip = {
+      children: tooltip,
+    }
+  }
+
+  return (
+    <Tooltip>
+      {comp}
+      <TooltipContent
+        side="right"
+        align="center"
+        hidden={state !== "collapsed" || isMobile}
+        {...tooltip}
+      />
+    </Tooltip>
+  )
+}
+
+function SidebarMenuAction({
+  className,
+  render,
+  showOnHover = false,
+  ...props
+}: useRender.ComponentProps<"button"> &
+  React.ComponentProps<"button"> & {
+    showOnHover?: boolean
+  }) {
+  return useRender({
+    defaultTagName: "button",
+    props: mergeProps<"button">(
+      {
+        className: cn(
+          "absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground ring-sidebar-ring outline-hidden transition-transform group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 after:absolute after:-inset-2 hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 md:after:hidden [&>svg]:size-4 [&>svg]:shrink-0",
+          showOnHover &&
+            "group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 peer-data-active/menu-button:text-sidebar-accent-foreground aria-expanded:opacity-100 md:opacity-0",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "sidebar-menu-action",
+      sidebar: "menu-action",
+    },
+  })
+}
+
+function SidebarMenuBadge({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sidebar-menu-badge"
+      data-sidebar="menu-badge"
+      className={cn(
+        "pointer-events-none absolute right-1 flex h-5 min-w-5 items-center justify-center rounded-md px-1 text-xs font-medium text-sidebar-foreground tabular-nums select-none group-data-[collapsible=icon]:hidden peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[size=default]/menu-button:top-1.5 peer-data-[size=lg]/menu-button:top-2.5 peer-data-[size=sm]/menu-button:top-1 peer-data-active/menu-button:text-sidebar-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSkeleton({
+  className,
+  showIcon = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showIcon?: boolean
+}) {
+  // Random width between 50 to 90%.
+  const [width] = React.useState(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`
+  })
+
+  return (
+    <div
+      data-slot="sidebar-menu-skeleton"
+      data-sidebar="menu-skeleton"
+      className={cn("flex h-8 items-center gap-2 rounded-md px-2", className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-(--skeleton-width) flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            "--skeleton-width": width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  )
+}
+
+function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
+  return (
+    <ul
+      data-slot="sidebar-menu-sub"
+      data-sidebar="menu-sub"
+      className={cn(
+        "mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5 group-data-[collapsible=icon]:hidden",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.ComponentProps<"li">) {
+  return (
+    <li
+      data-slot="sidebar-menu-sub-item"
+      data-sidebar="menu-sub-item"
+      className={cn("group/menu-sub-item relative", className)}
+      {...props}
+    />
+  )
+}
+
+function SidebarMenuSubButton({
+  render,
+  size = "md",
+  isActive = false,
+  className,
+  ...props
+}: useRender.ComponentProps<"a"> &
+  React.ComponentProps<"a"> & {
+    size?: "sm" | "md"
+    isActive?: boolean
+  }) {
+  return useRender({
+    defaultTagName: "a",
+    props: mergeProps<"a">(
+      {
+        className: cn(
+          "flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground ring-sidebar-ring outline-hidden group-data-[collapsible=icon]:hidden hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[size=md]:text-sm data-[size=sm]:text-xs data-active:bg-sidebar-accent data-active:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground",
+          className
+        ),
+      },
+      props
+    ),
+    render,
+    state: {
+      slot: "sidebar-menu-sub-button",
+      sidebar: "menu-sub-button",
+      size,
+      active: isActive,
+    },
+  })
+}
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+}

--- a/apps/web/src/components/ui/tooltip.tsx
+++ b/apps/web/src/components/ui/tooltip.tsx
@@ -17,14 +17,31 @@ function TooltipTrigger({ ...props }: TooltipPrimitive.Trigger.Props) {
   return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
 }
 
+type TooltipContentProps = TooltipPrimitive.Popup.Props & {
+  side?: TooltipPrimitive.Positioner.Props["side"]
+  align?: TooltipPrimitive.Positioner.Props["align"]
+  sideOffset?: TooltipPrimitive.Positioner.Props["sideOffset"]
+  hidden?: boolean
+}
+
 function TooltipContent({
   className,
   children,
+  side,
+  align,
+  sideOffset,
+  hidden,
   ...props
-}: TooltipPrimitive.Popup.Props) {
+}: TooltipContentProps) {
+  if (hidden) return null
   return (
     <TooltipPrimitive.Portal>
-      <TooltipPrimitive.Positioner className="z-[100]">
+      <TooltipPrimitive.Positioner
+        className="z-[100]"
+        side={side}
+        align={align}
+        sideOffset={sideOffset}
+      >
         <TooltipPrimitive.Popup
           data-slot="tooltip-content"
           className={cn(

--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -1,0 +1,42 @@
+import {
+  BarChart3,
+  BookOpen,
+  Activity,
+  HandHeart,
+  Trophy,
+  Pill,
+  ClipboardList,
+  Newspaper,
+  UserCog,
+} from "lucide-react";
+
+export type NavItem = {
+  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/crisis-list" | "/medications" | "/barkley" | "/actualites" | "/account";
+  labelKey: string;
+  shortLabelKey?: string;
+  icon: React.ComponentType<{ className?: string }>;
+  /** Surfaced in the mobile bottom tab bar (max 4). */
+  primary?: boolean;
+  /** Section grouping in the desktop sidebar. */
+  group: "tracking" | "care" | "account";
+};
+
+export const navItems: readonly NavItem[] = [
+  { to: "/dashboard", labelKey: "nav.dashboard", shortLabelKey: "nav.home", icon: BarChart3, primary: true, group: "tracking" },
+  { to: "/journal", labelKey: "nav.journal", icon: BookOpen, primary: true, group: "tracking" },
+  { to: "/symptoms", labelKey: "nav.symptoms", icon: Activity, group: "tracking" },
+  { to: "/rewards", labelKey: "nav.rewards", shortLabelKey: "nav.rewardsShort", icon: Trophy, primary: true, group: "tracking" },
+  { to: "/crisis-list", labelKey: "nav.crisisList", shortLabelKey: "nav.crisis", icon: HandHeart, primary: true, group: "care" },
+  { to: "/medications", labelKey: "nav.medications", icon: Pill, group: "care" },
+  { to: "/barkley", labelKey: "nav.barkley", icon: ClipboardList, group: "care" },
+  { to: "/actualites", labelKey: "nav.news", icon: Newspaper, group: "account" },
+  { to: "/account", labelKey: "nav.account", icon: UserCog, group: "account" },
+] as const;
+
+export const navGroups: { key: NavItem["group"]; labelKey: string }[] = [
+  { key: "tracking", labelKey: "nav.groupTracking" },
+  { key: "care", labelKey: "nav.groupCare" },
+  { key: "account", labelKey: "nav.groupAccount" },
+];
+
+export const primaryNavItems = navItems.filter((i) => i.primary);

--- a/apps/web/src/hooks/use-mobile.ts
+++ b/apps/web/src/hooks/use-mobile.ts
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+const MOBILE_BREAKPOINT = 768
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(undefined)
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    }
+    mql.addEventListener("change", onChange)
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
+    return () => mql.removeEventListener("change", onChange)
+  }, [])
+
+  return !!isMobile
+}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -212,7 +212,13 @@
     "loggedInAs": "Signed in as",
     "support": "Help & support",
     "userMenu": "User menu",
-    "buildAt": "Built on {{date}} at {{time}}"
+    "buildAt": "Built on {{date}} at {{time}}",
+    "skipToContent": "Skip to main content",
+    "toggleSidebar": "Toggle sidebar",
+    "groupTracking": "Tracking",
+    "groupCare": "Care",
+    "groupAccount": "Account",
+    "breadcrumbHome": "Home"
   },
   "contact": {
     "title": "Contact",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -212,7 +212,13 @@
     "loggedInAs": "Connecté en tant que",
     "support": "Aide & support",
     "userMenu": "Menu utilisateur",
-    "buildAt": "Build du {{date}} à {{time}}"
+    "buildAt": "Build du {{date}} à {{time}}",
+    "skipToContent": "Aller au contenu principal",
+    "toggleSidebar": "Afficher la navigation",
+    "groupTracking": "Suivi",
+    "groupCare": "Soins",
+    "groupAccount": "Compte",
+    "breadcrumbHome": "Accueil"
   },
   "contact": {
     "title": "Contact",

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -3,34 +3,48 @@ import {
   Outlet,
   Link,
   redirect,
+  useRouterState,
 } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import {
-  BarChart3,
-  BookOpen,
-  Activity,
-  Menu,
-  LogOut,
-  Heart,
-  ClipboardList,
-  Trophy,
-  UserCog,
-  HandHeart,
-  Pill,
-  Newspaper,
-  ChevronDown,
-  LifeBuoy,
-} from "lucide-react";
+import { Heart, LogOut, LifeBuoy, ChevronDown, Menu } from "lucide-react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
-import { Sheet, SheetContent, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { Separator } from "@/components/ui/separator";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
-import { useUiStore } from "@/stores/ui-store";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+  useSidebar,
+} from "@/components/ui/sidebar";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { ChildSelector } from "@/components/shared/child-selector";
 import { KoeWidget, useKoeTrigger } from "@/components/koe-widget";
 import { FloatingTipButton } from "@/components/shared/floating-tip-button";
-import { useState } from "react";
-import { getCachedSession, invalidateSessionCache, useSession, signOut } from "@/lib/auth-client";
+import { Breadcrumbs } from "@/components/layout/breadcrumbs";
+import { navGroups, navItems, primaryNavItems } from "@/config/nav";
+import {
+  getCachedSession,
+  invalidateSessionCache,
+  useSession,
+  signOut,
+} from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/_authenticated")({
   beforeLoad: async () => {
@@ -42,28 +56,58 @@ export const Route = createFileRoute("/_authenticated")({
   component: AuthenticatedLayout,
 });
 
-const navItems = [
-  { to: "/dashboard" as const, labelKey: "nav.dashboard", icon: BarChart3 },
-  { to: "/journal" as const, labelKey: "nav.journal", icon: BookOpen },
-  { to: "/symptoms" as const, labelKey: "nav.symptoms", icon: Activity },
-  { to: "/rewards" as const, labelKey: "nav.rewards", icon: Trophy },
-  { to: "/crisis-list" as const, labelKey: "nav.crisisList", icon: HandHeart },
-  { to: "/medications" as const, labelKey: "nav.medications", icon: Pill },
-  { to: "/barkley" as const, labelKey: "nav.barkley", icon: ClipboardList },
-  { to: "/actualites" as const, labelKey: "nav.news", icon: Newspaper },
-  { to: "/account" as const, labelKey: "nav.account", icon: UserCog },
-] as const;
+function AuthenticatedLayout() {
+  return (
+    <SidebarProvider>
+      <AuthenticatedShell />
+    </SidebarProvider>
+  );
+}
 
-// Primary items shown in the mobile bottom tab bar (4 slots + "More")
-const mobileTabItems = [
-  { to: "/dashboard" as const, labelKey: "nav.home", icon: BarChart3 },
-  { to: "/crisis-list" as const, labelKey: "nav.crisis", icon: HandHeart },
-  { to: "/journal" as const, labelKey: "nav.journal", icon: BookOpen },
-  { to: "/rewards" as const, labelKey: "nav.rewardsShort", icon: Trophy },
-] as const;
+function AuthenticatedShell() {
+  const { t } = useTranslation();
+  const isMobile = useIsMobile();
 
-function Sidebar({ onNavigate }: { onNavigate?: () => void }) {
+  return (
+    <>
+      <a
+        href="#main"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded-md focus:bg-primary focus:px-3 focus:py-2 focus:text-sm focus:font-medium focus:text-primary-foreground focus:shadow-lg"
+      >
+        {t("nav.skipToContent")}
+      </a>
+
+      <AppSidebar />
+
+      <SidebarInset
+        id="main"
+        tabIndex={-1}
+        aria-labelledby="page-title"
+        className={cn(
+          "min-w-0 focus:outline-none",
+          isMobile && "pb-[calc(4.5rem+env(safe-area-inset-bottom))]"
+        )}
+      >
+        <AppHeader />
+
+        <div className="mx-auto w-full max-w-screen-xl px-4 py-6 md:px-6 lg:px-8 lg:py-8">
+          <Outlet />
+        </div>
+
+        {isMobile && <MobileTabBar />}
+      </SidebarInset>
+
+      <FloatingTipButton />
+      <KoeWidget />
+    </>
+  );
+}
+
+function AppSidebar() {
   const { t, i18n } = useTranslation();
+  const { setOpenMobile } = useSidebar();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+
   const locale = i18n.resolvedLanguage === "en" ? "en-US" : "fr-FR";
   const buildDateObj = new Date(__BUILD_DATE__);
   const buildDate = buildDateObj.toLocaleDateString(locale, {
@@ -77,34 +121,86 @@ function Sidebar({ onNavigate }: { onNavigate?: () => void }) {
   });
 
   return (
-    <div className="flex h-full flex-col">
-      <nav className="flex flex-col gap-1 px-3 py-4">
-        {navItems.map((item) => (
-          <Link
-            key={item.to}
-            to={item.to}
-            onClick={onNavigate}
-            className="flex items-center gap-3 rounded-lg px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground lg:py-2 [&.active]:bg-primary/10 [&.active]:text-primary"
-          >
-            <item.icon className="h-4 w-4" />
-            {t(item.labelKey)}
-          </Link>
-        ))}
-      </nav>
-      <div className="mt-auto px-4 py-3 text-xs text-muted-foreground/50">
-        <p>v{__APP_VERSION__}</p>
-        <p>{t("nav.buildAt", { date: buildDate, time: buildTime })}</p>
-      </div>
-    </div>
+    <Sidebar collapsible="icon" variant="inset">
+      <SidebarHeader>
+        <Link
+          to="/dashboard"
+          onClick={() => setOpenMobile(false)}
+          className="flex h-10 items-center gap-2 rounded-md px-2 text-sidebar-foreground transition-colors hover:bg-sidebar-accent group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:px-0"
+        >
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg bg-primary text-primary-foreground">
+            <Heart className="h-3.5 w-3.5" />
+          </span>
+          <span className="font-heading text-lg font-semibold tracking-tight group-data-[collapsible=icon]:hidden">
+            Toko
+          </span>
+        </Link>
+        <div className="group-data-[collapsible=icon]:hidden">
+          <ChildSelector />
+        </div>
+      </SidebarHeader>
+
+      <SidebarContent>
+        {navGroups.map((group) => {
+          const items = navItems.filter((i) => i.group === group.key);
+          if (items.length === 0) return null;
+          return (
+            <SidebarGroup key={group.key}>
+              <SidebarGroupLabel>{t(group.labelKey)}</SidebarGroupLabel>
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  {items.map((item) => {
+                    const isActive =
+                      pathname === item.to || pathname.startsWith(`${item.to}/`);
+                    return (
+                      <SidebarMenuItem key={item.to}>
+                        <SidebarMenuButton
+                          isActive={isActive}
+                          tooltip={t(item.labelKey)}
+                          render={
+                            <Link
+                              to={item.to}
+                              onClick={() => setOpenMobile(false)}
+                              aria-current={isActive ? "page" : undefined}
+                            />
+                          }
+                        >
+                          <item.icon />
+                          <span>{t(item.labelKey)}</span>
+                        </SidebarMenuButton>
+                      </SidebarMenuItem>
+                    );
+                  })}
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+          );
+        })}
+      </SidebarContent>
+
+      <SidebarFooter>
+        <UserMenu />
+        <div className="px-2 pb-1 text-xs text-muted-foreground group-data-[collapsible=icon]:hidden">
+          <p>v{__APP_VERSION__}</p>
+          <p>{t("nav.buildAt", { date: buildDate, time: buildTime })}</p>
+        </div>
+      </SidebarFooter>
+
+      <SidebarRail />
+    </Sidebar>
   );
 }
 
-function AuthenticatedLayout() {
+function UserMenu() {
   const { t } = useTranslation();
-  const { sidebarOpen, toggleSidebar } = useUiStore();
   const session = useSession();
-  const [userMenuOpen, setUserMenuOpen] = useState(false);
+  const [open, setOpen] = useState(false);
   const { openKoe, available: koeAvailable } = useKoeTrigger();
+
+  const user = session.data?.user;
+  if (!user) return null;
+
+  const userInitial = user.name?.trim().charAt(0).toUpperCase() ?? "?";
 
   const handleSignOut = () => {
     invalidateSessionCache();
@@ -117,181 +213,134 @@ function AuthenticatedLayout() {
     });
   };
 
-  const user = session.data?.user;
-  const userInitial = user?.name?.trim().charAt(0).toUpperCase() ?? "?";
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <SidebarMenuButton
+            size="lg"
+            aria-label={t("nav.userMenu")}
+            className="group-data-[collapsible=icon]:px-0"
+          />
+        }
+      >
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-medium text-primary">
+          {userInitial}
+        </span>
+        <span className="flex min-w-0 flex-1 flex-col group-data-[collapsible=icon]:hidden">
+          <span className="truncate text-sm font-medium text-sidebar-foreground">
+            {user.name}
+          </span>
+          {user.email && (
+            <span className="truncate text-xs text-muted-foreground">
+              {user.email}
+            </span>
+          )}
+        </span>
+        <ChevronDown className="h-3.5 w-3.5 text-muted-foreground group-data-[collapsible=icon]:hidden" />
+      </PopoverTrigger>
+      <PopoverContent align="end" side="top" className="w-60 gap-0 p-1">
+        <div className="flex flex-col gap-0.5 px-3 py-2">
+          <span className="truncate text-sm font-medium text-foreground">
+            {user.name}
+          </span>
+          {user.email && (
+            <span className="truncate text-xs text-muted-foreground">
+              {user.email}
+            </span>
+          )}
+        </div>
+        <Separator className="my-1" />
+        {koeAvailable && (
+          <button
+            type="button"
+            onClick={() => {
+              setOpen(false);
+              openKoe();
+            }}
+            className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+          >
+            <LifeBuoy className="h-4 w-4 text-muted-foreground" />
+            {t("nav.support")}
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={() => {
+            setOpen(false);
+            handleSignOut();
+          }}
+          className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
+        >
+          <LogOut className="h-4 w-4 text-muted-foreground" />
+          {t("nav.logout")}
+        </button>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+function AppHeader() {
+  const { t } = useTranslation();
+  return (
+    <header className="sticky top-0 z-40 flex h-14 shrink-0 items-center gap-3 border-b border-border/60 bg-background/90 px-4 backdrop-blur-lg supports-[backdrop-filter]:bg-background/70 md:px-6 lg:px-8">
+      <SidebarTrigger
+        aria-label={t("nav.toggleSidebar")}
+        className="-ml-1"
+      />
+      <Separator orientation="vertical" className="h-4" />
+      <Breadcrumbs className="min-w-0 flex-1" />
+    </header>
+  );
+}
+
+function MobileTabBar() {
+  const { t } = useTranslation();
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const { setOpenMobile } = useSidebar();
+
+  const tabs = primaryNavItems.slice(0, 4);
 
   return (
-    <div className="flex min-h-dvh flex-col bg-background">
-      <header className="sticky top-0 z-50 border-b border-border/60 bg-background/90 backdrop-blur-lg supports-[backdrop-filter]:bg-background/70 pt-[env(safe-area-inset-top)]">
-        <div className="flex h-14 items-center gap-2 px-[max(0.75rem,env(safe-area-inset-left))] sm:gap-3 sm:px-[max(1rem,env(safe-area-inset-left))] lg:px-6">
-          <Link to="/dashboard" className="flex items-center gap-2">
-            <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-              <Heart className="h-3.5 w-3.5" />
-            </div>
-            <span className="font-heading text-lg font-semibold tracking-tight text-foreground">
-              Toko
-            </span>
-          </Link>
-
-          <div className="ml-auto flex items-center gap-2 sm:gap-3">
-            <ChildSelector />
-            {user && (
-              <Popover open={userMenuOpen} onOpenChange={setUserMenuOpen}>
-                <PopoverTrigger
-                  render={
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      aria-label={t("nav.userMenu")}
-                      className="hidden h-9 items-center gap-2 px-2 md:inline-flex"
-                    >
-                      <span className="flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 text-xs font-medium text-primary">
-                        {userInitial}
-                      </span>
-                      <span className="max-w-[10rem] truncate text-sm text-foreground">
-                        {user.name}
-                      </span>
-                      <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
-                    </Button>
-                  }
-                />
-                <PopoverContent align="end" className="w-60 gap-0 p-1">
-                  <div className="flex flex-col gap-0.5 px-3 py-2">
-                    <span className="truncate text-sm font-medium text-foreground">
-                      {user.name}
-                    </span>
-                    {user.email && (
-                      <span className="truncate text-xs text-muted-foreground">
-                        {user.email}
-                      </span>
-                    )}
-                  </div>
-                  <Separator className="my-1" />
-                  {koeAvailable && (
-                    <button
-                      type="button"
-                      onClick={() => {
-                        setUserMenuOpen(false);
-                        openKoe();
-                      }}
-                      className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
-                    >
-                      <LifeBuoy className="h-4 w-4 text-muted-foreground" />
-                      {t("nav.support")}
-                    </button>
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setUserMenuOpen(false);
-                      handleSignOut();
-                    }}
-                    className="flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-accent focus-visible:bg-accent focus-visible:outline-none"
-                  >
-                    <LogOut className="h-4 w-4 text-muted-foreground" />
-                    {t("nav.logout")}
-                  </button>
-                </PopoverContent>
-              </Popover>
-            )}
-          </div>
-        </div>
-      </header>
-
-      <div className="flex flex-1">
-        <aside className="hidden w-64 border-r border-border/60 bg-background lg:flex lg:flex-col">
-          <Sidebar />
-        </aside>
-        <main className="flex-1 p-4 pb-[calc(4.5rem+max(0.5rem,env(safe-area-inset-bottom)))] sm:p-6 lg:pb-[max(1rem,env(safe-area-inset-bottom))]">
-          <Outlet />
-        </main>
-      </div>
-
-      {/* Mobile bottom tab bar */}
-      <nav
-        aria-label={t("nav.primaryNav")}
-        className="fixed inset-x-0 bottom-0 z-40 border-t border-border/60 bg-background/95 backdrop-blur-lg supports-[backdrop-filter]:bg-background/80 pb-[env(safe-area-inset-bottom)] lg:hidden"
-      >
-        <ul className="grid grid-cols-5">
-          {mobileTabItems.map((item) => (
+    <nav
+      aria-label={t("nav.primaryNav")}
+      className="fixed inset-x-0 bottom-0 z-40 border-t border-border/60 bg-background/95 pb-[env(safe-area-inset-bottom)] backdrop-blur-lg supports-[backdrop-filter]:bg-background/80"
+    >
+      <ul className="grid grid-cols-5">
+        {tabs.map((item) => {
+          const isActive =
+            pathname === item.to || pathname.startsWith(`${item.to}/`);
+          const label = t(item.shortLabelKey ?? item.labelKey);
+          return (
             <li key={item.to}>
               <Link
                 to={item.to}
-                className="flex h-full min-h-14 flex-col items-center justify-center gap-0.5 px-1 py-1.5 text-2xs font-medium text-muted-foreground transition-colors active:bg-accent/60 [&.active]:text-primary"
+                aria-current={isActive ? "page" : undefined}
+                className={cn(
+                  "flex h-full min-h-14 flex-col items-center justify-center gap-0.5 px-1 py-1.5 text-[11px] font-medium transition-colors",
+                  isActive
+                    ? "text-primary"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
               >
                 <item.icon className="h-5 w-5" />
-                <span className="leading-tight">{t(item.labelKey)}</span>
+                <span className="line-clamp-1 leading-tight">{label}</span>
               </Link>
             </li>
-          ))}
-          <li>
-            <Sheet open={sidebarOpen} onOpenChange={toggleSidebar}>
-              <SheetTrigger
-                render={
-                  <button
-                    type="button"
-                    aria-label={t("nav.moreOptions")}
-                    className="flex h-full min-h-14 w-full flex-col items-center justify-center gap-0.5 px-1 py-1.5 text-2xs font-medium text-muted-foreground transition-colors active:bg-accent/60"
-                  >
-                    <Menu className="h-5 w-5" />
-                    <span className="leading-tight">{t("nav.more")}</span>
-                  </button>
-                }
-              />
-              <SheetContent side="left" className="max-w-[20rem] p-0">
-                <SheetTitle className="sr-only">{t("nav.moreOptions")}</SheetTitle>
-                <div className="flex h-14 items-center gap-2 px-6">
-                  <div className="flex h-7 w-7 items-center justify-center rounded-lg bg-primary text-primary-foreground">
-                    <Heart className="h-3.5 w-3.5" />
-                  </div>
-                  <span className="font-heading text-lg font-semibold tracking-tight">
-                    Toko
-                  </span>
-                </div>
-                <Separator />
-                <div className="flex h-[calc(100%-3.5rem-env(safe-area-inset-top))] flex-col">
-                  <Sidebar onNavigate={() => toggleSidebar()} />
-                  <Separator />
-                  <div className="px-3 py-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
-                    {session.data?.user?.name && (
-                      <p className="px-3 pb-2 text-xs text-muted-foreground">
-                        {t("nav.loggedInAs")}{" "}
-                        <span className="font-medium text-foreground">
-                          {session.data.user.name}
-                        </span>
-                      </p>
-                    )}
-                    {koeAvailable && (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          toggleSidebar();
-                          openKoe();
-                        }}
-                        className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-                      >
-                        <LifeBuoy className="h-4 w-4" />
-                        {t("nav.support")}
-                      </button>
-                    )}
-                    <button
-                      type="button"
-                      onClick={handleSignOut}
-                      className="flex w-full items-center gap-3 rounded-lg px-3 py-3 text-sm font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
-                    >
-                      <LogOut className="h-4 w-4" />
-                      {t("nav.logout")}
-                    </button>
-                  </div>
-                </div>
-              </SheetContent>
-            </Sheet>
-          </li>
-        </ul>
-      </nav>
-
-      <FloatingTipButton />
-      <KoeWidget />
-    </div>
+          );
+        })}
+        <li>
+          <button
+            type="button"
+            onClick={() => setOpenMobile(true)}
+            aria-label={t("nav.moreOptions")}
+            className="flex h-full min-h-14 w-full flex-col items-center justify-center gap-0.5 px-1 py-1.5 text-[11px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <Menu className="h-5 w-5" />
+            <span className="line-clamp-1 leading-tight">{t("nav.more")}</span>
+          </button>
+        </li>
+      </ul>
+    </nav>
   );
 }

--- a/apps/web/src/routes/_authenticated/account/index.tsx
+++ b/apps/web/src/routes/_authenticated/account/index.tsx
@@ -39,6 +39,7 @@ import { NotificationsCard } from "@/components/account/notifications-card";
 
 export const Route = createFileRoute("/_authenticated/account/")({
   component: AccountPage,
+  staticData: { crumb: "nav.account" },
 });
 
 function AccountPage() {

--- a/apps/web/src/routes/_authenticated/actualites/index.tsx
+++ b/apps/web/src/routes/_authenticated/actualites/index.tsx
@@ -14,6 +14,7 @@ import { useTranslation } from "react-i18next";
 
 export const Route = createFileRoute("/_authenticated/actualites/")({
   component: ActualitesIndex,
+  staticData: { crumb: "nav.news" },
 });
 
 function ActualitesIndex() {

--- a/apps/web/src/routes/_authenticated/barkley/index.tsx
+++ b/apps/web/src/routes/_authenticated/barkley/index.tsx
@@ -3,6 +3,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { Check, ChevronRight, BookOpen } from "lucide-react";
 import { PageLoader } from "@/components/ui/page-loader";
+import { PageHeader } from "@/components/layout/page-header";
 import { Card, CardContent } from "@/components/ui/card";
 import { Callout } from "@/components/ui/callout";
 import { Progress, ProgressLabel, ProgressValue } from "@/components/ui/progress";
@@ -12,6 +13,7 @@ import { getAllStepTitles } from "@/lib/barkley-content";
 
 export const Route = createFileRoute("/_authenticated/barkley/")({
   component: BarkleyPage,
+  staticData: { crumb: "nav.barkley" },
 });
 
 function BarkleyPage() {
@@ -21,12 +23,10 @@ function BarkleyPage() {
   if (!activeChildId) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
-            {t("barkley.title")}
-          </h1>
-          <p className="text-muted-foreground">{t("barkley.subtitle")}</p>
-        </div>
+        <PageHeader
+          title={t("barkley.title")}
+          description={t("barkley.subtitle")}
+        />
         <Card>
           <CardContent className="py-8 text-center text-muted-foreground">
             {t("barkley.selectChild")}
@@ -38,12 +38,10 @@ function BarkleyPage() {
 
   return (
     <div className="space-y-6">
-      <div>
-        <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
-          {t("barkley.title")}
-        </h1>
-        <p className="text-muted-foreground">{t("barkley.subtitle")}</p>
-      </div>
+      <PageHeader
+        title={t("barkley.title")}
+        description={t("barkley.subtitle")}
+      />
 
       {/* Disclaimer */}
       <Callout variant="info">

--- a/apps/web/src/routes/_authenticated/crisis-list/index.tsx
+++ b/apps/web/src/routes/_authenticated/crisis-list/index.tsx
@@ -57,6 +57,7 @@ import {
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
 import { PageLoader } from "@/components/ui/page-loader";
+import { PageHeader } from "@/components/layout/page-header";
 import { EmojiPicker, CRISIS_EMOJIS } from "@/components/emoji-picker";
 import {
   useCrisisItems,
@@ -70,6 +71,7 @@ import type { CrisisItem } from "@focusflow/validators";
 
 export const Route = createFileRoute("/_authenticated/crisis-list/")({
   component: CrisisListPage,
+  staticData: { crumb: "nav.crisisList" },
 });
 
 function CrisisListPage() {
@@ -129,30 +131,28 @@ function CrisisListPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
-            {t("crisis.title")}
-          </h1>
-          <p className="text-muted-foreground">{t("crisis.subtitle")}</p>
-        </div>
-        <div className="flex gap-2">
-          {items && items.length > 0 && (
-            <Button
-              variant="outline"
-              onClick={() => setCrisisMode(true)}
-              className="border-info-border bg-info-surface text-info-foreground hover:bg-info-surface/70"
-            >
-              <HandHeart className="mr-2 h-4 w-4" />
-              {t("crisis.crisisMode")}
+      <PageHeader
+        title={t("crisis.title")}
+        description={t("crisis.subtitle")}
+        actions={
+          <>
+            {items && items.length > 0 && (
+              <Button
+                variant="outline"
+                onClick={() => setCrisisMode(true)}
+                className="border-info-border bg-info-surface text-info-foreground hover:bg-info-surface/70"
+              >
+                <HandHeart className="mr-2 h-4 w-4" />
+                {t("crisis.crisisMode")}
+              </Button>
+            )}
+            <Button onClick={openCreate}>
+              <Plus className="mr-2 h-4 w-4" />
+              {t("crisis.addButton")}
             </Button>
-          )}
-          <Button onClick={openCreate}>
-            <Plus className="mr-2 h-4 w-4" />
-            {t("crisis.addButton")}
-          </Button>
-        </div>
-      </div>
+          </>
+        }
+      />
 
       <Dialog open={dialogOpen} onOpenChange={(open) => !open && closeDialog()}>
         <DialogContent className="sm:max-w-md">

--- a/apps/web/src/routes/_authenticated/dashboard/index.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard/index.tsx
@@ -26,6 +26,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { PageLoader } from "@/components/ui/page-loader";
+import { PageHeader } from "@/components/layout/page-header";
 import { DailyChecklist } from "@/components/dashboard/daily-checklist";
 import { QuickActions } from "@/components/dashboard/quick-actions";
 import { MoodLogger } from "@/components/dashboard/mood-logger";
@@ -45,6 +46,7 @@ import type { JournalTag } from "@focusflow/validators";
 
 export const Route = createFileRoute("/_authenticated/dashboard/")({
   component: DashboardPage,
+  staticData: { crumb: "nav.dashboard" },
 });
 
 // Map a 0-10 mood score (from symptoms) to one of the 4 translation keys.
@@ -87,7 +89,10 @@ function DashboardPage() {
   if (!children?.length) {
     return (
       <div className="mx-auto max-w-lg py-12 text-center">
-        <h1 className="text-xl font-bold sm:text-2xl">
+        <h1
+          id="page-title"
+          className="font-heading text-2xl font-semibold tracking-tight lg:text-3xl"
+        >
           {t("dashboard.welcome")}
         </h1>
         <p className="mt-2 text-muted-foreground">
@@ -142,12 +147,10 @@ function DashboardPage() {
     <div className="space-y-6">
       {/* ── Zone A: Aujourd'hui ────────────────────────────── */}
       <motion.section {...sectionAnim(0)} aria-label={t("dashboard.todaySection")}>
-        <div>
-          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
-            {t("dashboard.title")}
-          </h1>
-          <p className="text-muted-foreground">{t("dashboard.subtitle")}</p>
-        </div>
+        <PageHeader
+          title={t("dashboard.title")}
+          description={t("dashboard.subtitle")}
+        />
 
         {showInactiveAlert && (
           <div className="mt-4">

--- a/apps/web/src/routes/_authenticated/journal/index.tsx
+++ b/apps/web/src/routes/_authenticated/journal/index.tsx
@@ -16,6 +16,7 @@ import {
   DialogClose,
 } from "@/components/ui/dialog";
 import { PageLoader } from "@/components/ui/page-loader";
+import { PageHeader } from "@/components/layout/page-header";
 import {
   JournalCard,
   tagConfig,
@@ -27,6 +28,7 @@ import type { JournalEntry, JournalTag } from "@focusflow/validators";
 
 export const Route = createFileRoute("/_authenticated/journal/")({
   component: JournalPage,
+  staticData: { crumb: "nav.journal" },
 });
 
 function JournalPage() {
@@ -103,18 +105,16 @@ function JournalPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
-            {t("journal.title")}
-          </h1>
-          <p className="text-muted-foreground">{t("journal.subtitle")}</p>
-        </div>
-        <Button onClick={openCreate}>
-          <Plus className="mr-2 h-4 w-4" />
-          {t("journal.writeButton")}
-        </Button>
-      </div>
+      <PageHeader
+        title={t("journal.title")}
+        description={t("journal.subtitle")}
+        actions={
+          <Button onClick={openCreate}>
+            <Plus className="mr-2 h-4 w-4" />
+            {t("journal.writeButton")}
+          </Button>
+        }
+      />
 
       {/* Filter bar */}
       {entries && entries.length > 0 && (

--- a/apps/web/src/routes/_authenticated/medications/index.tsx
+++ b/apps/web/src/routes/_authenticated/medications/index.tsx
@@ -22,6 +22,7 @@ import {
   SelectItem,
 } from "@/components/ui/select";
 import { PageLoader } from "@/components/ui/page-loader";
+import { PageHeader } from "@/components/layout/page-header";
 import {
   useMedications,
   useCreateMedication,
@@ -37,6 +38,7 @@ import type {
 
 export const Route = createFileRoute("/_authenticated/medications/")({
   component: MedicationsPage,
+  staticData: { crumb: "nav.medications" },
 });
 
 function useScheduleLabels(): Record<MedicationSchedule, string> {
@@ -76,18 +78,16 @@ function MedicationsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
-            {t("medications.title")}
-          </h1>
-          <p className="text-muted-foreground">{t("medications.subtitle")}</p>
-        </div>
-        <Button onClick={openCreate} disabled={!activeChildId}>
-          <Plus className="mr-2 h-4 w-4" />
-          {t("medications.add")}
-        </Button>
-      </div>
+      <PageHeader
+        title={t("medications.title")}
+        description={t("medications.subtitle")}
+        actions={
+          <Button onClick={openCreate} disabled={!activeChildId}>
+            <Plus className="mr-2 h-4 w-4" />
+            {t("medications.add")}
+          </Button>
+        }
+      />
 
       {!activeChildId ? (
         <Card>

--- a/apps/web/src/routes/_authenticated/rewards/index.tsx
+++ b/apps/web/src/routes/_authenticated/rewards/index.tsx
@@ -15,6 +15,7 @@ import {
   Settings,
 } from "lucide-react";
 import { PageLoader } from "@/components/ui/page-loader";
+import { PageHeader } from "@/components/layout/page-header";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -54,6 +55,7 @@ import type { BarkleyReward } from "@focusflow/validators";
 
 export const Route = createFileRoute("/_authenticated/rewards/")({
   component: RewardsPage,
+  staticData: { crumb: "nav.rewards" },
 });
 
 // ─── Page ────────────────────────────────────────────────
@@ -65,12 +67,10 @@ function RewardsPage() {
   if (!activeChildId) {
     return (
       <div className="space-y-6">
-        <div>
-          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
-            {t("rewards.title")}
-          </h1>
-          <p className="text-muted-foreground">{t("rewards.subtitle")}</p>
-        </div>
+        <PageHeader
+          title={t("rewards.title")}
+          description={t("rewards.subtitle")}
+        />
         <Card>
           <CardContent className="py-12 text-center text-muted-foreground">
             <Gift className="mx-auto mb-3 h-10 w-10 text-muted-foreground/50" />
@@ -136,54 +136,51 @@ function RewardBoard({ childId }: { childId: string }) {
 
   return (
     <div className="space-y-6">
-      {/* Page header */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
-            {t("rewards.title")}
-          </h1>
-          <p className="text-muted-foreground">{t("rewards.subtitle")}</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button size="sm" variant="ghost" onClick={toggleKidView}>
-            {kidView ? (
-              <>
-                <Settings className="mr-1.5 h-4 w-4" />
-                {t("rewards.parentView")}
-              </>
-            ) : (
-              <>
-                <Baby className="mr-1.5 h-4 w-4" />
-                {t("rewards.kidView")}
-              </>
-            )}
-          </Button>
-          {!kidView && (
-            <Dialog
-              open={rewardDialogOpen}
-              onOpenChange={setRewardDialogOpen}
-            >
-              <DialogTrigger
-                render={
-                  <Button>
-                    <Plus className="mr-2 h-4 w-4" />
-                    {t("rewards.addButton")}
-                  </Button>
-                }
-              />
-              <DialogContent className="sm:max-w-md">
-                <DialogHeader>
-                  <DialogTitle>{t("rewards.newReward")}</DialogTitle>
-                </DialogHeader>
-                <RewardForm
-                  childId={childId}
-                  onSuccess={() => setRewardDialogOpen(false)}
+      <PageHeader
+        title={t("rewards.title")}
+        description={t("rewards.subtitle")}
+        actions={
+          <>
+            <Button size="sm" variant="ghost" onClick={toggleKidView}>
+              {kidView ? (
+                <>
+                  <Settings className="mr-1.5 h-4 w-4" />
+                  {t("rewards.parentView")}
+                </>
+              ) : (
+                <>
+                  <Baby className="mr-1.5 h-4 w-4" />
+                  {t("rewards.kidView")}
+                </>
+              )}
+            </Button>
+            {!kidView && (
+              <Dialog
+                open={rewardDialogOpen}
+                onOpenChange={setRewardDialogOpen}
+              >
+                <DialogTrigger
+                  render={
+                    <Button>
+                      <Plus className="mr-2 h-4 w-4" />
+                      {t("rewards.addButton")}
+                    </Button>
+                  }
                 />
-              </DialogContent>
-            </Dialog>
-          )}
-        </div>
-      </div>
+                <DialogContent className="sm:max-w-md">
+                  <DialogHeader>
+                    <DialogTitle>{t("rewards.newReward")}</DialogTitle>
+                  </DialogHeader>
+                  <RewardForm
+                    childId={childId}
+                    onSuccess={() => setRewardDialogOpen(false)}
+                  />
+                </DialogContent>
+              </Dialog>
+            )}
+          </>
+        }
+      />
 
       {/* Behavior tracking — parent only */}
       {!kidView && <BehaviorTracking childId={childId} />}

--- a/apps/web/src/routes/_authenticated/symptoms/index.tsx
+++ b/apps/web/src/routes/_authenticated/symptoms/index.tsx
@@ -11,6 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { PageLoader } from "@/components/ui/page-loader";
+import { PageHeader } from "@/components/layout/page-header";
 import { SymptomForm } from "@/components/symptoms/symptom-form";
 import { SymptomCard } from "@/components/symptoms/symptom-card";
 import { useSymptoms } from "@/hooks/use-symptoms";
@@ -19,6 +20,7 @@ import type { Symptom } from "@focusflow/validators";
 
 export const Route = createFileRoute("/_authenticated/symptoms/")({
   component: SymptomsPage,
+  staticData: { crumb: "nav.symptoms" },
 });
 
 type DimensionFilter =
@@ -84,18 +86,16 @@ function SymptomsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div>
-          <h1 className="text-xl font-bold tracking-tight sm:text-2xl">
-            {t("symptoms.title")}
-          </h1>
-          <p className="text-muted-foreground">{t("symptoms.subtitle")}</p>
-        </div>
-        <Button onClick={openCreate}>
-          <Plus className="mr-2 h-4 w-4" />
-          {t("symptoms.addButton")}
-        </Button>
-      </div>
+      <PageHeader
+        title={t("symptoms.title")}
+        description={t("symptoms.subtitle")}
+        actions={
+          <Button onClick={openCreate}>
+            <Plus className="mr-2 h-4 w-4" />
+            {t("symptoms.addButton")}
+          </Button>
+        }
+      />
 
       {/* Filter bar */}
       {symptoms && symptoms.length > 0 && (

--- a/apps/web/src/stores/ui-store.ts
+++ b/apps/web/src/stores/ui-store.ts
@@ -2,11 +2,9 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 interface UiState {
-  sidebarOpen: boolean;
   activeChildId: string | null;
   dismissedTips: string[];
   rewardsKidView: boolean;
-  toggleSidebar: () => void;
   setActiveChild: (id: string | null) => void;
   dismissTip: (id: string) => void;
   toggleRewardsKidView: () => void;
@@ -15,11 +13,9 @@ interface UiState {
 export const useUiStore = create<UiState>()(
   persist(
     (set) => ({
-      sidebarOpen: false,
       activeChildId: null,
       dismissedTips: [],
       rewardsKidView: false,
-      toggleSidebar: () => set((s) => ({ sidebarOpen: !s.sidebarOpen })),
       setActiveChild: (id) => set({ activeChildId: id }),
       dismissTip: (id) =>
         set((s) =>


### PR DESCRIPTION
Rebuild the authenticated layout around the canonical shadcn `Sidebar`
primitive to replace the hand-rolled mobile-first shell. Collapsible icon
rail on desktop (md+), Sheet drawer on mobile, with a max-width content
container so the dashboard stops stretching edge-to-edge on wide screens.

- Add shadcn `sidebar` + `breadcrumb` primitives (Base UI flavor) and
  extend `TooltipContent` to forward `side`/`align`/`sideOffset` to the
  Positioner so the sidebar tooltip API compiles.
- Introduce `config/nav.ts` as the single nav source of truth (groups +
  `primary` flag for the mobile tab bar); drop the duplicated
  `mobileTabItems` array and the `sidebarOpen` state from `ui-store`
  (SidebarProvider owns open/collapsed state + Cmd/Ctrl+B shortcut).
- Add `<PageHeader>` (h1 `id=page-title`, `font-semibold tracking-tight`,
  2xl/3xl at lg) and migrate dashboard, journal, symptoms, medications,
  rewards, crisis-list and barkley to use it.
- Add `<Breadcrumbs>` driven by TanStack Router `useMatches()` +
  `staticData.crumb`; wire crumb keys on each authenticated leaf route.
- Accessibility: skip-to-content link, `aria-current="page"` on nav
  links, `main#main` with `aria-labelledby="page-title"`, bottom tab
  bar conditionally rendered on mobile only so it's absent from the
  desktop DOM.