### PR TITLE
Extract breadcrumbs logic into custom hook and conditionally render

### DIFF
--- a/apps/web/src/components/layout/breadcrumbs.tsx
+++ b/apps/web/src/components/layout/breadcrumbs.tsx
@@ -17,16 +17,20 @@ declare module "@tanstack/react-router" {
   }
 }
 
-export function Breadcrumbs({ className }: { className?: string }) {
+export function useBreadcrumbs() {
   const { t } = useTranslation();
   const matches = useMatches();
 
-  const crumbs = matches
+  return matches
     .filter((m) => !!m.staticData?.crumb)
     .map((m) => ({
       to: m.pathname,
       label: t(m.staticData!.crumb!),
     }));
+}
+
+export function Breadcrumbs({ className }: { className?: string }) {
+  const crumbs = useBreadcrumbs();
 
   if (crumbs.length === 0) return null;
 

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -36,7 +36,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { ChildSelector } from "@/components/shared/child-selector";
 import { KoeWidget, useKoeTrigger } from "@/components/koe-widget";
 import { FloatingTipButton } from "@/components/shared/floating-tip-button";
-import { Breadcrumbs } from "@/components/layout/breadcrumbs";
+import { Breadcrumbs, useBreadcrumbs } from "@/components/layout/breadcrumbs";
 import { navGroups, navItems, primaryNavItems } from "@/config/nav";
 import {
   getCachedSession,
@@ -282,14 +282,23 @@ function UserMenu() {
 
 function AppHeader() {
   const { t } = useTranslation();
+  const hasBreadcrumbs = useBreadcrumbs().length > 0;
   return (
     <header className="sticky top-0 z-40 flex h-14 shrink-0 items-center gap-3 border-b border-border/60 bg-background/90 px-4 backdrop-blur-lg supports-[backdrop-filter]:bg-background/70 md:px-6 lg:px-8">
       <SidebarTrigger
         aria-label={t("nav.toggleSidebar")}
         className="-ml-1"
       />
-      <Separator orientation="vertical" className="h-4" />
-      <Breadcrumbs className="min-w-0 flex-1" />
+      {hasBreadcrumbs && (
+        <>
+          <Separator
+            orientation="vertical"
+            aria-hidden="true"
+            className="h-4"
+          />
+          <Breadcrumbs className="min-w-0 flex-1" />
+        </>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
Refactored the breadcrumbs component to extract breadcrumb computation logic into a custom hook (`useBreadcrumbs`), and updated the header to conditionally render breadcrumbs and separator only when breadcrumbs exist.

## Key Changes
- **Extracted `useBreadcrumbs` hook**: Moved breadcrumb filtering and mapping logic from the `Breadcrumbs` component into a reusable custom hook that returns the computed breadcrumb array
- **Conditional rendering in AppHeader**: Updated `AppHeader` to check if breadcrumbs exist before rendering the separator and breadcrumbs component, preventing unnecessary UI elements when no breadcrumbs are available
- **Improved accessibility**: Added `aria-hidden="true"` to the separator element to indicate it's a decorative element

## Implementation Details
- The `useBreadcrumbs` hook maintains the same logic for filtering route matches and translating breadcrumb labels
- The `Breadcrumbs` component now uses the hook internally, maintaining backward compatibility
- The header now uses `useBreadcrumbs().length > 0` to determine visibility, ensuring both the separator and breadcrumbs are shown/hidden together

https://claude.ai/code/session_01M7hiBJkpFcRWzh7xtTUApG