### PR TITLE
test(e2e): scope Ajouter button lookup to main

### DIFF
--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -20,7 +20,9 @@ setup("authenticate as demo user", async ({ page }) => {
   await page.goto("/dashboard")
 
   await expect(
-    page.getByText("Tableau de bord").or(page.getByText("Bienvenue sur Tokō"))
+    page
+      .getByRole("heading", { name: "Tableau de bord" })
+      .or(page.getByRole("heading", { name: "Bienvenue sur Tokō" }))
   ).toBeVisible({ timeout: 15_000 })
 
   await page.context().storageState({ path: authFile })

--- a/e2e/children.spec.ts
+++ b/e2e/children.spec.ts
@@ -1,32 +1,38 @@
 import { test, expect } from "@playwright/test";
 
 test.describe("Child management", () => {
-  test("child selector is visible in header", async ({ page }) => {
+  test("child selector is visible in sidebar", async ({ page }) => {
     await page.goto("/dashboard");
     await page.waitForLoadState("networkidle");
 
-    // Either a child selector or "Ajouter un enfant" should be visible
-    const hasSelector = await page.getByText("Enfant").isVisible().catch(() => false);
+    const sidebar = page.locator('[data-slot="sidebar"]').first();
     const hasWelcome = await page.getByText("Bienvenue sur Tokō").isVisible().catch(() => false);
-    const hasChild = await page.locator("header").getByRole("combobox").isVisible().catch(() => false);
+    const hasChildCombobox = await sidebar
+      .getByRole("combobox")
+      .first()
+      .isVisible()
+      .catch(() => false);
 
-    expect(hasSelector || hasWelcome || hasChild).toBeTruthy();
+    expect(hasWelcome || hasChildCombobox).toBeTruthy();
   });
 
   test("add child dialog shows form with required fields", async ({ page }) => {
     await page.goto("/dashboard");
     await page.waitForLoadState("networkidle");
 
-    // Try to open add child dialog from dashboard or header
+    // Try to open add child dialog from the welcome screen or the sidebar +.
     const welcomeBtn = page.locator("main").getByText("Ajouter un enfant");
-    const headerBtn = page.locator("header").getByRole("button", { name: "Ajouter" });
+    const sidebarAddBtn = page
+      .locator('[data-slot="sidebar"]')
+      .first()
+      .getByRole("button", { name: "Ajouter un enfant" });
 
     if (await welcomeBtn.isVisible().catch(() => false)) {
       await welcomeBtn.click();
-    } else if (await headerBtn.isVisible().catch(() => false)) {
-      await headerBtn.click();
+    } else if (await sidebarAddBtn.isVisible().catch(() => false)) {
+      await sidebarAddBtn.click();
     } else {
-      // No add button available (child already exists), skip
+      // No add button available, skip
       return;
     }
 

--- a/e2e/crisis-list.spec.ts
+++ b/e2e/crisis-list.spec.ts
@@ -26,7 +26,9 @@ test.describe("Crisis list page", () => {
     await page.goto("/crisis-list");
     await page.waitForLoadState("networkidle");
 
-    const addBtn = page.getByRole("button", { name: "Ajouter" });
+    const addBtn = page
+      .locator("main")
+      .getByRole("button", { name: "Ajouter", exact: true });
 
     if (await addBtn.isVisible().catch(() => false)) {
       await addBtn.click();
@@ -42,7 +44,9 @@ test.describe("Crisis list page", () => {
     await page.goto("/crisis-list");
     await page.waitForLoadState("networkidle");
 
-    const addBtn = page.getByRole("button", { name: "Ajouter" });
+    const addBtn = page
+      .locator("main")
+      .getByRole("button", { name: "Ajouter", exact: true });
 
     if (await addBtn.isVisible().catch(() => false)) {
       await addBtn.click();
@@ -63,7 +67,9 @@ test.describe("Crisis list page", () => {
     await page.goto("/crisis-list");
     await page.waitForLoadState("networkidle");
 
-    const addBtn = page.getByRole("button", { name: "Ajouter" });
+    const addBtn = page
+      .locator("main")
+      .getByRole("button", { name: "Ajouter", exact: true });
 
     if (await addBtn.isVisible().catch(() => false)) {
       await addBtn.click();

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -6,7 +6,9 @@ test.describe("Dashboard", () => {
 
     // Wait for either the dashboard heading or welcome heading to appear
     await expect(
-      page.getByText("Tableau de bord").or(page.getByText("Bienvenue sur Tokō"))
+      page
+        .getByRole("heading", { name: "Tableau de bord" })
+        .or(page.getByRole("heading", { name: "Bienvenue sur Tokō" }))
     ).toBeVisible({ timeout: 10_000 });
   });
 

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -26,7 +26,9 @@ test.describe("Login page", () => {
 
     await page.waitForURL("**/dashboard", { timeout: 15_000 });
     await expect(
-      page.getByText("Tableau de bord").or(page.getByText("Bienvenue sur Tokō"))
+      page
+        .getByRole("heading", { name: "Tableau de bord" })
+        .or(page.getByRole("heading", { name: "Bienvenue sur Tokō" }))
     ).toBeVisible();
   });
 

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -21,7 +21,9 @@ test.describe("Navigation", () => {
     await sidebar.locator("a[href='/dashboard']").first().click();
     await page.waitForURL("**/dashboard");
     await expect(
-      page.getByText("Tableau de bord").or(page.getByText("Bienvenue sur Tokō"))
+      page
+        .getByRole("heading", { name: "Tableau de bord" })
+        .or(page.getByRole("heading", { name: "Bienvenue sur Tokō" }))
     ).toBeVisible({ timeout: 10_000 });
   });
 

--- a/e2e/rewards.spec.ts
+++ b/e2e/rewards.spec.ts
@@ -38,7 +38,9 @@ test.describe("Rewards page", () => {
     await page.goto("/rewards");
     await page.waitForLoadState("networkidle");
 
-    const addBtn = page.getByRole("button", { name: "Ajouter" });
+    const addBtn = page
+      .locator("main")
+      .getByRole("button", { name: "Ajouter", exact: true });
 
     if (await addBtn.isVisible().catch(() => false)) {
       await addBtn.click();

--- a/e2e/symptom-crud.spec.ts
+++ b/e2e/symptom-crud.spec.ts
@@ -5,7 +5,9 @@ test.describe("Symptom CRUD operations", () => {
     await page.goto("/symptoms");
     await page.waitForLoadState("networkidle");
 
-    const addBtn = page.getByRole("button", { name: "Ajouter" });
+    const addBtn = page
+      .locator("main")
+      .getByRole("button", { name: "Ajouter", exact: true });
 
     if (!(await addBtn.isVisible().catch(() => false))) {
       // No child selected, skip
@@ -30,7 +32,9 @@ test.describe("Symptom CRUD operations", () => {
     await page.goto("/symptoms");
     await page.waitForLoadState("networkidle");
 
-    const addBtn = page.getByRole("button", { name: "Ajouter" });
+    const addBtn = page
+      .locator("main")
+      .getByRole("button", { name: "Ajouter", exact: true });
 
     if (!(await addBtn.isVisible().catch(() => false))) {
       return;
@@ -54,7 +58,9 @@ test.describe("Symptom CRUD operations", () => {
     await page.goto("/symptoms");
     await page.waitForLoadState("networkidle");
 
-    const addBtn = page.getByRole("button", { name: "Ajouter" });
+    const addBtn = page
+      .locator("main")
+      .getByRole("button", { name: "Ajouter", exact: true });
 
     if (!(await addBtn.isVisible().catch(() => false))) {
       return;
@@ -76,7 +82,9 @@ test.describe("Symptom CRUD operations", () => {
     await page.goto("/symptoms");
     await page.waitForLoadState("networkidle");
 
-    const addBtn = page.getByRole("button", { name: "Ajouter" });
+    const addBtn = page
+      .locator("main")
+      .getByRole("button", { name: "Ajouter", exact: true });
 
     if (!(await addBtn.isVisible().catch(() => false))) {
       return;

--- a/e2e/symptoms.spec.ts
+++ b/e2e/symptoms.spec.ts
@@ -10,8 +10,12 @@ test.describe("Symptoms page", () => {
 
   test("add symptom button opens dialog", async ({ page }) => {
     await page.goto("/symptoms");
+    await page.waitForLoadState("networkidle");
 
-    await page.getByRole("button", { name: "Ajouter" }).click();
+    await page
+      .locator("main")
+      .getByRole("button", { name: "Ajouter", exact: true })
+      .click();
 
     const dialog = page.getByRole("dialog");
     await expect(dialog.getByText("Nouveau relevé")).toBeVisible();


### PR DESCRIPTION
## Summary

E2E has been red since #88 relocated the `ChildSelector` (with a `+ Ajouter un enfant` button) from the top `<header>` into the sidebar. Every authenticated page now exposes two buttons whose accessible names contain **"Ajouter"**, and Playwright's `getByRole({ name })` defaults to substring matching. The result:

- `symptoms.spec.ts:14` threw a strict-mode violation on the first click — the most likely hard failure in the pipeline.
- `symptom-crud`, `crisis-list`, `rewards` all used `addBtn.isVisible().catch(() => false)`, so the strict-mode error was caught and the test body silently skipped — vacuous passes that weren't exercising anything.
- `children.spec.ts` targeted `locator("header")` for the add-child flow, but the add-child button now lives in the sidebar.

## Fix

- Scope all page-level "Ajouter" lookups to `<main>` with `exact: true`.
- Point the children spec at the sidebar's `+ Ajouter un enfant` affordance and the sidebar combobox.

## Test plan

- [ ] CI `E2E Tests` job turns green.
- [ ] No new flakes in symptoms / symptom-crud / crisis-list / rewards / children.

https://claude.ai/code/session_01VobDuZufKVRTDQpsHu2NjG