### PR TITLE
Update GitHub Actions to latest versions and pin pnpm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "pnpm"
@@ -87,13 +89,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "pnpm"
@@ -115,7 +119,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: playwright-report
           path: playwright-report/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,13 +80,15 @@ jobs:
     if: needs.detect-release.outputs.should_release == 'true'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "pnpm"
@@ -114,16 +116,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "pnpm"


### PR DESCRIPTION
## Summary
This PR updates GitHub Actions to their latest versions and adds explicit pnpm version pinning across CI/CD workflows for improved consistency and reproducibility.

## Key Changes
- **actions/checkout**: Updated from v4 to v5 in both `ci.yml` and `release.yml`
- **actions/setup-node**: Updated from v4 to v5 in both `ci.yml` and `release.yml`
- **actions/upload-artifact**: Updated from v4 to v5 in `ci.yml`
- **pnpm version pinning**: Added explicit `version: 9.15.4` configuration to all `pnpm/action-setup@v4` steps across both workflows

## Implementation Details
The pnpm version is now explicitly specified in the action configuration rather than relying on the default version bundled with the action. This ensures consistent package manager behavior across all CI/CD runs and prevents unexpected behavior changes from automatic pnpm updates.

All changes are applied consistently across both the main CI workflow and the release workflow to maintain uniformity in the build environment.

https://claude.ai/code/session_014u6sMZ48KoMQWYvQJK5VFK