### PR TITLE
fix(api): harden ownership checks, pagination bounds, and date ordering

### DIFF
--- a/apps/api/src/routes/ai.ts
+++ b/apps/api/src/routes/ai.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { and, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import type { AppEnv } from "../types";
 import { authMiddleware } from "../middleware/auth";
 import { db, aiRecommendations } from "@focusflow/db";
@@ -19,7 +19,7 @@ aiRoutes.get("/recommendations", async (c) => {
     .select()
     .from(aiRecommendations)
     .where(eq(aiRecommendations.userId, currentUser.id))
-    .orderBy(aiRecommendations.createdAt)
+    .orderBy(desc(aiRecommendations.createdAt))
     .limit(100);
   return c.json(rows);
 });

--- a/apps/api/src/routes/children.ts
+++ b/apps/api/src/routes/children.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { AppEnv } from "../types";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { db, children, subscription } from "@focusflow/db";
 import { createChildSchema, updateChildSchema } from "@focusflow/validators";
 import { authMiddleware } from "../middleware/auth";
@@ -100,20 +100,15 @@ childrenRoutes.patch("/:id", async (c) => {
     );
   }
 
-  const [existing] = await db
-    .select()
-    .from(children)
-    .where(eq(children.id, id));
-
-  if (!existing || existing.parentId !== user.id) {
-    throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
-  }
-
   const [updated] = await db
     .update(children)
     .set({ ...parsed.data, updatedAt: new Date() })
-    .where(eq(children.id, id))
+    .where(and(eq(children.id, id), eq(children.parentId, user.id)))
     .returning();
+
+  if (!updated) {
+    throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
+  }
 
   return c.json(updated);
 });
@@ -122,15 +117,14 @@ childrenRoutes.delete("/:id", async (c) => {
   const user = c.get("user");
   const id = c.req.param("id");
 
-  const [existing] = await db
-    .select()
-    .from(children)
-    .where(eq(children.id, id));
+  const deleted = await db
+    .delete(children)
+    .where(and(eq(children.id, id), eq(children.parentId, user.id)))
+    .returning({ id: children.id });
 
-  if (!existing || existing.parentId !== user.id) {
+  if (deleted.length === 0) {
     throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
   }
 
-  await db.delete(children).where(eq(children.id, id));
   return c.json({ ok: true });
 });

--- a/apps/api/src/routes/journal.ts
+++ b/apps/api/src/routes/journal.ts
@@ -26,8 +26,8 @@ journalRoutes.get("/:childId", async (c) => {
     throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
   }
 
-  const limit = Math.min(Number(c.req.query("limit")) || 100, 500);
-  const offset = Number(c.req.query("offset")) || 0;
+  const limit = Math.min(Math.max(Number(c.req.query("limit")) || 100, 1), 500);
+  const offset = Math.max(Number(c.req.query("offset")) || 0, 0);
 
   const result = await db
     .select()

--- a/apps/api/src/routes/report.ts
+++ b/apps/api/src/routes/report.ts
@@ -79,6 +79,12 @@ reportRoutes.post("/send-email", async (c) => {
     if (from) {
         sinceDate = from;
         untilDate = to ?? new Date().toISOString().split("T")[0]!;
+        if (sinceDate > untilDate) {
+            return c.json(
+                { error: "La date de début doit précéder la date de fin." },
+                422
+            );
+        }
     } else {
         const days = PERIOD_DAYS[period ?? "quarter"] ?? 90;
         sinceDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000)

--- a/apps/api/src/routes/symptoms.ts
+++ b/apps/api/src/routes/symptoms.ts
@@ -26,8 +26,8 @@ symptomsRoutes.get("/:childId", async (c) => {
     throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
   }
 
-  const limit = Math.min(Number(c.req.query("limit")) || 100, 500);
-  const offset = Number(c.req.query("offset")) || 0;
+  const limit = Math.min(Math.max(Number(c.req.query("limit")) || 100, 1), 500);
+  const offset = Math.max(Number(c.req.query("offset")) || 0, 0);
 
   const result = await db
     .select()


### PR DESCRIPTION
- ai: return recommendations latest-first to match the documented contract
- children: fold parentId into UPDATE/DELETE WHERE clauses so ownership is
  enforced atomically (no check-then-act race window)
- symptoms, journal: clamp limit and offset to non-negative values so a
  crafted query cannot trigger a Postgres LIMIT/OFFSET error
- report: reject send-email when from > to instead of silently returning
  an empty range

https://claude.ai/code/session_01R84cwhci1L3Ayjbsx5J7dc