### PR TITLE
feat(web): refresh landing hero copy and acknowledge solo-built app

### DIFF
--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -112,7 +112,7 @@
       },
       "reminders": {
         "title": "Reminders & evening check",
-        "description": "A 2-minute ritual every evening, with Web Push notifications so you never forget — even on the busiest days."
+        "description": "A 2-minute ritual every evening, with Web Push notifications to keep track of daily life — even on the busiest days."
       }
     },
     "pricing": {

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "appName": "Toko",
-    "appTagline": "Guiding your ADHD child",
+    "appTagline": "Giving you time back as a family",
     "loading": "Loading...",
     "save": "Save",
     "cancel": "Cancel",
@@ -34,9 +34,9 @@
       "getStarted": "Get started"
     },
     "trust": {
-      "barkley": {
-        "title": "Grounded in Barkley's program",
-        "description": "Dr. Russell Barkley's PEHP is the most documented parental training program for ADHD worldwide."
+      "time": {
+        "title": "Give parents their time back",
+        "description": "Fewer paper checklists, fewer duplicate apps — 2 minutes each evening is enough to keep track of your child's daily life."
       },
       "rgpd": {
         "title": "GDPR · data hosted in the EU",
@@ -63,24 +63,24 @@
       }
     },
     "resourcesTeaser": {
-      "title": "Understand your child's ADHD",
-      "description": "Clear guides drawn from public scientific publications and official ADHD resources. They don't replace a healthcare professional's advice.",
+      "title": "Understand and support your child",
+      "description": "Clear guides on everyday parenting and ADHD, drawn from public scientific publications. They don't replace a healthcare professional's advice.",
       "cta": "Read all guides"
     },
     "hero": {
-      "title1": "Track your child's ADHD,",
-      "title2": "one day at a time",
-      "description": "Toko is an installable PWA that helps you track your ADHD child's symptoms, routines, medications and appointments. Encrypted, offline-ready, exportable data to prepare specialist visits with confidence.",
+      "title1": "Take back time",
+      "title2": "with your kids",
+      "description": "Toko is an installable PWA that helps parents handle daily life with their kids — routines, moods, appointments, reminders, rewards. Built for all parents, with extra support for families dealing with ADHD.",
       "ctaPrimary": "Start for free",
       "ctaSecondary": "Discover the features",
       "noCard": "Free to start. No credit card required."
     },
     "features": {
-      "title": "Everything to support your child",
-      "subtitle": "Tools designed by parents, for parents.",
+      "title": "Everything to simplify your daily life as a parent",
+      "subtitle": "Tools designed by parents, for parents — with or without ADHD.",
       "symptoms": {
-        "title": "Symptom tracking",
-        "description": "Assess your child daily on 5 dimensions — restlessness, focus, impulsivity, mood, sleep — and track daily routines."
+        "title": "Daily tracking",
+        "description": "Rate your child's mood, sleep, focus and restlessness each day, and keep track of the routines that work."
       },
       "journal": {
         "title": "Observation journal",
@@ -91,24 +91,24 @@
         "description": "Manage your child's treatments, track daily intake and note any side effects."
       },
       "crisis": {
-        "title": "Crisis list",
-        "description": "Build a list of calming activities with your child, viewable in full-screen mode during crises."
+        "title": "Calm-down list",
+        "description": "Build a list of calming activities with your child, viewable in full-screen mode when tension rises — meltdowns, tantrums, tough moments."
       },
       "rewards": {
         "title": "Reward chart",
         "description": "Track target behaviors week after week and unlock rewards with earned stars."
       },
       "barkley": {
-        "title": "Barkley program (PEHP)",
-        "description": "Follow the 10 steps of the parent training program directly in the app, with full educational content and a validation quiz at each step."
+        "title": "Barkley program · ADHD option",
+        "description": "For families dealing with ADHD: the 10 steps of Dr. Barkley's parent training program (PEHP), with educational content and a quiz at each step. Enable it if you need it."
       },
       "dashboard": {
         "title": "Dashboard",
         "description": "Visualize trends over week, month, or quarter, and identify the patterns that matter."
       },
       "news": {
-        "title": "ADHD News",
-        "description": "A feed of articles about ADHD, parenting strategies and support techniques, drawn from public sources and scientific publications."
+        "title": "News & resources",
+        "description": "A feed of articles about parenting, daily routines and ADHD, drawn from public sources and scientific publications."
       },
       "reminders": {
         "title": "Reminders & evening check",
@@ -117,10 +117,10 @@
     },
     "pricing": {
       "title": "Simple, transparent pricing",
-      "subtitle": "Start for free, upgrade to Family for complete medical tracking.",
+      "subtitle": "Start for free, upgrade to Family for full history and detailed reports.",
       "recommended": "Recommended",
       "trialBadge": "14 days free · no card",
-      "annualEquivalent": "≈ €60/year — the price of one specialist visit",
+      "annualEquivalent": "≈ €60/year — a few coffees a month to get your time back",
       "comparisonTitle": "Detailed comparison",
       "comparisonHead": {
         "feature": "Feature",
@@ -128,7 +128,7 @@
         "family": "Family"
       },
       "comparisonRows": {
-        "pdfReport": "PDF report for the doctor",
+        "pdfReport": "PDF report for your appointments",
         "monthQuarterTrends": "Month & quarter trends",
         "fullHistory": "Complete tracking history",
         "profiles": "Child profiles",
@@ -140,7 +140,7 @@
         "medications": "Medication tracking",
         "rewards": "Rewards board",
         "barkley": "Full Barkley program",
-        "news": "ADHD News",
+        "news": "News & resources",
         "weekTrends": "Weekly trends",
         "rgpdExport": "GDPR data export"
       },
@@ -157,8 +157,8 @@
       "family": {
         "name": "Family",
         "period": "/month",
-        "description": "Prepare your medical appointments",
-        "feature1": "PDF report for the specialist",
+        "description": "Full history and detailed reports",
+        "feature1": "Ready-to-share PDF report",
         "feature2": "Full history and trends",
         "feature3": "Up to 3 child profiles",
         "feature4": "Cancel anytime",
@@ -166,7 +166,7 @@
       }
     },
     "footer": {
-      "tagline": "Toko — Guiding your ADHD child",
+      "tagline": "Toko — The app that gives you time back",
       "version": "v{{version}} — Built on {{date}}",
       "legal": "Legal notice",
       "privacy": "Privacy",
@@ -174,7 +174,7 @@
     }
   },
   "login": {
-    "tagline": "The app that helps parents guide their ADHD child, one day at a time.",
+    "tagline": "The app that simplifies daily life for parents — and gives you time back as a family.",
     "or": "or",
     "tabLogin": "Sign in",
     "tabRegister": "Sign up",

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -43,8 +43,8 @@
         "description": "Your health data stays in Europe, encrypted, and belongs to you. Full GDPR export anytime."
       },
       "parents": {
-        "title": "Built with ADHD parents",
-        "description": "Each feature was born from a real need: the Monday morning meltdown, the pediatrician appointment, the last-minute homework rush."
+        "title": "Built by a parent, not a clinic",
+        "description": "Toko is built solo by a concerned parent — not a lab or a medical team. Health decisions stay between you and your healthcare professional."
       }
     },
     "testimonials": {
@@ -64,13 +64,13 @@
     },
     "resourcesTeaser": {
       "title": "Understand your child's ADHD",
-      "description": "Clear guides, written with professionals, to answer the questions every ADHD parent asks.",
+      "description": "Clear guides drawn from public scientific publications and official ADHD resources. They don't replace a healthcare professional's advice.",
       "cta": "Read all guides"
     },
     "hero": {
       "title1": "Track your child's ADHD,",
       "title2": "one day at a time",
-      "description": "Toko helps parents track the symptoms and daily life of their ADHD child. Clear data for informed decisions with healthcare professionals.",
+      "description": "Toko is an installable PWA that helps you track your ADHD child's symptoms, routines, medications and appointments. Encrypted, offline-ready, exportable data to prepare specialist visits with confidence.",
       "ctaPrimary": "Start for free",
       "ctaSecondary": "Discover the features",
       "noCard": "Free to start. No credit card required."
@@ -108,7 +108,11 @@
       },
       "news": {
         "title": "ADHD News",
-        "description": "Stay informed with articles written by professionals about ADHD, parenting strategies, and support techniques."
+        "description": "A feed of articles about ADHD, parenting strategies and support techniques, drawn from public sources and scientific publications."
+      },
+      "reminders": {
+        "title": "Reminders & evening check",
+        "description": "A 2-minute ritual every evening, with Web Push notifications so you never forget — even on the busiest days."
       }
     },
     "pricing": {

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "appName": "Toko",
-    "appTagline": "Guider votre enfant TDAH",
+    "appTagline": "Vous rendre du temps en famille",
     "loading": "Chargement...",
     "save": "Enregistrer",
     "cancel": "Annuler",
@@ -34,17 +34,17 @@
       "getStarted": "Commencer"
     },
     "hero": {
-      "title1": "Suivez le TDAH de votre enfant,",
-      "title2": "un jour à la fois",
-      "description": "Toko est une app installable (PWA) qui vous aide à suivre les symptômes, les routines, les médicaments et les rendez-vous de votre enfant TDAH. Des données chiffrées, hors-ligne, exportables, pour préparer sereinement vos consultations avec un spécialiste.",
+      "title1": "Reprenez du temps",
+      "title2": "avec vos enfants",
+      "description": "Toko est une app installable (PWA) qui aide les parents à gérer le quotidien avec leurs enfants — routines, humeurs, rendez-vous, rappels, récompenses. Conçue pour tous les parents, avec un accompagnement renforcé pour les familles concernées par le TDAH.",
       "ctaPrimary": "Commencer gratuitement",
       "ctaSecondary": "Découvrir les fonctionnalités",
       "noCard": "Gratuit pour commencer. Aucune carte bancaire requise."
     },
     "trust": {
-      "barkley": {
-        "title": "Fondé sur le programme Barkley",
-        "description": "Le PEHP du Dr Russell Barkley est le protocole d'accompagnement parental le plus documenté au monde pour le TDAH."
+      "time": {
+        "title": "Rendre du temps aux parents",
+        "description": "Moins de checklists papier, moins d'apps qui se répètent — 2 minutes le soir suffisent pour garder le fil du quotidien de votre enfant."
       },
       "rgpd": {
         "title": "RGPD · données hébergées en UE",
@@ -71,16 +71,16 @@
       }
     },
     "resourcesTeaser": {
-      "title": "Comprendre le TDAH de votre enfant",
-      "description": "Des guides clairs, rédigés à partir de publications scientifiques publiques et des ressources officielles sur le TDAH. Ils ne remplacent pas l'avis d'un professionnel de santé.",
+      "title": "Comprendre et accompagner votre enfant",
+      "description": "Des guides clairs sur la parentalité au quotidien et le TDAH, rédigés à partir de publications scientifiques publiques. Ils ne remplacent pas l'avis d'un professionnel de santé.",
       "cta": "Lire tous les guides"
     },
     "features": {
-      "title": "Tout pour accompagner votre enfant",
-      "subtitle": "Des outils conçus par des parents, pour des parents.",
+      "title": "Tout pour simplifier votre quotidien de parent",
+      "subtitle": "Des outils conçus par des parents, pour des parents — avec ou sans TDAH.",
       "symptoms": {
-        "title": "Suivi des symptômes",
-        "description": "Évaluez quotidiennement votre enfant sur 5 dimensions — agitation, concentration, impulsivité, humeur, sommeil — et notez le suivi des routines."
+        "title": "Suivi du quotidien",
+        "description": "Évaluez chaque jour l'humeur, le sommeil, l'attention et l'agitation de votre enfant, et gardez trace des routines qui fonctionnent."
       },
       "journal": {
         "title": "Journal d'observations",
@@ -91,24 +91,24 @@
         "description": "Gérez les traitements de votre enfant, suivez les prises quotidiennes et notez les éventuels effets secondaires."
       },
       "crisis": {
-        "title": "Liste de crise",
-        "description": "Construisez avec votre enfant une liste d'activités apaisantes, consultable en mode plein écran pendant les crises."
+        "title": "Liste anti-crise",
+        "description": "Construisez avec votre enfant une liste d'activités apaisantes, consultable en mode plein écran quand la tension monte — crises, colères, moments difficiles."
       },
       "rewards": {
         "title": "Tableau de récompenses",
         "description": "Suivez les comportements cibles semaine après semaine et débloquez des récompenses avec les étoiles gagnées."
       },
       "barkley": {
-        "title": "Programme Barkley (PEHP)",
-        "description": "Suivez les 10 étapes du programme d'entraînement parental directement dans l'application, avec contenu pédagogique complet et quiz de validation à chaque étape."
+        "title": "Programme Barkley · option TDAH",
+        "description": "Pour les familles concernées par le TDAH : les 10 étapes du programme d'entraînement parental du Dr Barkley (PEHP), avec contenu pédagogique et quiz à chaque étape. Activable si vous en avez besoin."
       },
       "dashboard": {
         "title": "Tableau de bord",
         "description": "Visualisez les tendances sur semaine, mois ou trimestre, et identifiez les patterns qui comptent."
       },
       "news": {
-        "title": "Actualités TDAH",
-        "description": "Un fil d'articles sur le TDAH, la parentalité et les stratégies d'accompagnement, rédigés à partir de sources publiques et de publications scientifiques."
+        "title": "Actualités & ressources",
+        "description": "Un fil d'articles sur la parentalité, les routines du quotidien et le TDAH, rédigés à partir de sources publiques et de publications scientifiques."
       },
       "reminders": {
         "title": "Rappels & check du soir",
@@ -117,10 +117,10 @@
     },
     "pricing": {
       "title": "Des tarifs simples et transparents",
-      "subtitle": "Commencez gratuitement, passez au plan Famille pour le suivi médical complet.",
+      "subtitle": "Commencez gratuitement, passez au plan Famille pour l'historique complet et les rapports détaillés.",
       "recommended": "Recommandé",
       "trialBadge": "14 jours offerts · sans CB",
-      "annualEquivalent": "≈ 60 €/an — soit le prix d'une consultation pédopsy",
+      "annualEquivalent": "≈ 60 €/an — quelques cafés par mois pour vous rendre du temps",
       "comparisonTitle": "Comparatif détaillé",
       "comparisonHead": {
         "feature": "Fonctionnalité",
@@ -128,7 +128,7 @@
         "family": "Famille"
       },
       "comparisonRows": {
-        "pdfReport": "Rapport PDF pour le médecin",
+        "pdfReport": "Rapport PDF pour vos rendez-vous",
         "monthQuarterTrends": "Tendances mois & trimestre",
         "fullHistory": "Historique complet de suivi",
         "profiles": "Profils enfant",
@@ -140,7 +140,7 @@
         "medications": "Suivi médicaments",
         "rewards": "Tableau de récompenses",
         "barkley": "Programme Barkley complet",
-        "news": "Actualités TDAH",
+        "news": "Actualités & ressources",
         "weekTrends": "Tendances semaine",
         "rgpdExport": "Export RGPD de vos données"
       },
@@ -157,8 +157,8 @@
       "family": {
         "name": "Famille",
         "period": "/mois",
-        "description": "Préparez vos rendez-vous médicaux",
-        "feature1": "Rapport PDF pour le spécialiste",
+        "description": "Historique complet et rapports détaillés",
+        "feature1": "Rapport PDF prêt à partager",
         "feature2": "Historique et tendances complètes",
         "feature3": "Jusqu'à 3 profils enfant",
         "feature4": "Annulable à tout moment",
@@ -166,7 +166,7 @@
       }
     },
     "footer": {
-      "tagline": "Toko — Guider votre enfant TDAH",
+      "tagline": "Toko — L'app qui vous rend du temps en famille",
       "version": "v{{version}} — Build du {{date}}",
       "legal": "Mentions légales",
       "privacy": "Confidentialité",
@@ -174,7 +174,7 @@
     }
   },
   "login": {
-    "tagline": "L'application qui aide les parents à guider leur enfant TDAH, un jour à la fois.",
+    "tagline": "L'application qui simplifie le quotidien des parents — et vous rend du temps en famille.",
     "or": "ou",
     "tabLogin": "Connexion",
     "tabRegister": "Inscription",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -112,7 +112,7 @@
       },
       "reminders": {
         "title": "Rappels & check du soir",
-        "description": "Un rituel de 2 minutes chaque soir, avec notifications Web Push pour ne rien oublier — même les jours chargés."
+        "description": "Un rituel de 2 minutes chaque soir, avec notifications Web Push pour garder le fil du quotidien — même les jours chargés."
       }
     },
     "pricing": {

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -36,7 +36,7 @@
     "hero": {
       "title1": "Suivez le TDAH de votre enfant,",
       "title2": "un jour à la fois",
-      "description": "Toko aide les parents à suivre les symptômes et le quotidien de leur enfant TDAH. Des données claires pour des décisions éclairées avec les professionnels de santé.",
+      "description": "Toko est une app installable (PWA) qui vous aide à suivre les symptômes, les routines, les médicaments et les rendez-vous de votre enfant TDAH. Des données chiffrées, hors-ligne, exportables, pour préparer sereinement vos consultations avec un spécialiste.",
       "ctaPrimary": "Commencer gratuitement",
       "ctaSecondary": "Découvrir les fonctionnalités",
       "noCard": "Gratuit pour commencer. Aucune carte bancaire requise."
@@ -51,8 +51,8 @@
         "description": "Vos données santé restent en Europe, chiffrées, et vous appartiennent. Export intégral RGPD à tout moment."
       },
       "parents": {
-        "title": "Conçu avec des parents TDAH",
-        "description": "Chaque fonctionnalité est née d'un besoin concret : la crise du lundi matin, le RDV pédopsy, le devoir à boucler au dernier moment."
+        "title": "Construit par un parent, pas un cabinet médical",
+        "description": "Toko est développé en solo par un parent concerné — pas un laboratoire ni une équipe médicale. Les décisions de santé restent entre vous et votre professionnel de santé."
       }
     },
     "testimonials": {
@@ -72,7 +72,7 @@
     },
     "resourcesTeaser": {
       "title": "Comprendre le TDAH de votre enfant",
-      "description": "Des guides clairs, rédigés avec des professionnels, pour répondre aux questions que se posent tous les parents TDAH.",
+      "description": "Des guides clairs, rédigés à partir de publications scientifiques publiques et des ressources officielles sur le TDAH. Ils ne remplacent pas l'avis d'un professionnel de santé.",
       "cta": "Lire tous les guides"
     },
     "features": {
@@ -108,7 +108,11 @@
       },
       "news": {
         "title": "Actualités TDAH",
-        "description": "Restez informé avec des articles rédigés par des professionnels sur le TDAH, la parentalité et les stratégies d'accompagnement."
+        "description": "Un fil d'articles sur le TDAH, la parentalité et les stratégies d'accompagnement, rédigés à partir de sources publiques et de publications scientifiques."
+      },
+      "reminders": {
+        "title": "Rappels & check du soir",
+        "description": "Un rituel de 2 minutes chaque soir, avec notifications Web Push pour ne rien oublier — même les jours chargés."
       }
     },
     "pricing": {

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -16,7 +16,6 @@ import {
   Heart,
   ShieldCheck,
   Sparkles,
-  Stethoscope,
   Quote,
   Clock,
 } from "lucide-react";
@@ -57,7 +56,7 @@ const featureKeys = [
 ] as const;
 
 const trustKeys = [
-  { icon: Stethoscope, key: "barkley" },
+  { icon: Clock, key: "time" },
   { icon: ShieldCheck, key: "rgpd" },
   { icon: Sparkles, key: "parents" },
 ] as const;

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -9,6 +9,7 @@ import {
   ClipboardList,
   Newspaper,
   Pill,
+  Bell,
   Check,
   X,
   ArrowRight,
@@ -50,6 +51,7 @@ const featureKeys = [
   { icon: HandHeart, key: "crisis" },
   { icon: Trophy, key: "rewards" },
   { icon: ClipboardList, key: "barkley" },
+  { icon: Bell, key: "reminders" },
   { icon: BarChart3, key: "dashboard" },
   { icon: Newspaper, key: "news" },
 ] as const;


### PR DESCRIPTION
- Hero: mention installable PWA, offline, encryption, export — reflects recent shipped features (Web Push, offline, privacy hardening)
- Trust bar: rewrite "parents" card to state Toko is built solo by a parent, not a clinic or medical team
- Resources teaser & news feature: drop "written by/with professionals" claims and clarify guides are drawn from public scientific publications
- Add new "Rappels & check du soir" feature card (Bell icon) covering Web Push + evening check ritual

FR + EN locales kept in sync.