### PR TITLE
fix(web): sync HTML title, meta description, and PWA manifest with new positioning

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="description" content="Application de suivi pour les parents d'enfants avec TDAH : symptômes, journal, programme Barkley, récompenses." />
+    <meta name="description" content="Toko est une app installable qui aide les parents à gérer le quotidien avec leurs enfants — routines, humeurs, rendez-vous, rappels, récompenses. Conçue pour tous les parents, avec un accompagnement renforcé TDAH." />
     <meta name="theme-color" content="#d4663a" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Tokō" />
-    <title>Toko — Guider votre enfant TDAH</title>
+    <title>Toko — L'app qui vous rend du temps en famille</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/icon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/apps/web/public/manifest.webmanifest
+++ b/apps/web/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
-  "name": "Tokō — Guider votre enfant TDAH",
+  "name": "Tokō — L'app qui vous rend du temps en famille",
   "short_name": "Tokō",
-  "description": "Application de suivi pour les parents d'enfants avec TDAH : symptômes, journal, programme Barkley, récompenses.",
+  "description": "App installable qui aide les parents à gérer le quotidien avec leurs enfants — routines, humeurs, rendez-vous, rappels, récompenses. Conçue pour tous les parents, avec un accompagnement renforcé TDAH.",
   "start_url": "/dashboard",
   "scope": "/",
   "display": "standalone",
@@ -9,7 +9,7 @@
   "background_color": "#fdf5f0",
   "theme_color": "#d4663a",
   "lang": "fr",
-  "categories": ["health", "medical", "lifestyle"],
+  "categories": ["lifestyle", "health", "productivity"],
   "icons": [
     {
       "src": "/icon.svg",


### PR DESCRIPTION
## Summary

Follow-up to #95. After the landing repositioning, the browser tab title, SEO meta description, and PWA manifest still carried the ADHD-only framing (`"Guider votre enfant TDAH"` / `"pour les parents d'enfants avec TDAH"`).

- `apps/web/index.html`: title → `"Toko — L'app qui vous rend du temps en famille"`; description aligned with the landing hero copy.
- `apps/web/public/manifest.webmanifest`: same `name` / `description` update; dropped the `medical` category (kept `lifestyle` + `health`, added `productivity`).

## Test plan

- [x] `manifest.webmanifest` parses as JSON
- [x] `pnpm lint:copy` (guilt-lexicon rule B7) passes
- [x] `pnpm lint:trackers` passes
- [ ] On merge, Release workflow bumps to a patch version and redeploys

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkVcRfDDBfxJZMG8ndyTCC)_