### PR TITLE
fix(ci): release patch on perf: commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           elif echo "$FIRST_LINE" | grep -qE "^(feat|feature)(\(.+\))?:"; then
             echo "should_release=true" >> $GITHUB_OUTPUT
             echo "bump_type=minor" >> $GITHUB_OUTPUT
-          elif echo "$FIRST_LINE" | grep -qE "^fix(\(.+\))?:"; then
+          elif echo "$FIRST_LINE" | grep -qE "^(fix|perf)(\(.+\))?:"; then
             echo "should_release=true" >> $GITHUB_OUTPUT
             echo "bump_type=patch" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary

`perf:` commits currently produce no release (the conventional-commit detector in `release.yml` only recognizes `feat`/`feature`/`fix`). PR #97 shipped three real perf wins under a `perf:` title and therefore never cut a release or redeployed.

Teach the detector to treat `perf($scope)?:` like `fix($scope)?:` and cut a patch release. As a bonus, merging this `fix(ci):` PR will itself patch-release and redeploy `main`, which now contains the #97 perf work.

## Test plan

- [ ] CI green
- [ ] On merge, Release workflow detects `fix(ci):` → patch bump → v0.57.2 published
- [ ] Release v0.57.2 contains #97 (bounded streak query, `/assets/*` immutable cache, optimistic symptom/journal mutations)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FkVcRfDDBfxJZMG8ndyTCC)_