### PR TITLE
Reposition floating tip button to right side of screen

### DIFF
--- a/apps/web/src/components/shared/floating-tip-button.tsx
+++ b/apps/web/src/components/shared/floating-tip-button.tsx
@@ -54,7 +54,7 @@ export function FloatingTipButton() {
   const showNext = available.length > 1;
 
   return (
-    <div className="pointer-events-none fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] left-4 z-40 lg:bottom-6 lg:left-6">
+    <div className="pointer-events-none fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 z-40 lg:bottom-6 lg:right-6">
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger
           render={
@@ -79,7 +79,7 @@ export function FloatingTipButton() {
         />
         <PopoverContent
           side="top"
-          align="start"
+          align="end"
           sideOffset={8}
           className="pointer-events-auto w-[min(20rem,calc(100vw-2rem))] border border-info-border bg-[color-mix(in_oklab,#3b82f6_14%,var(--color-popover))] text-info-foreground shadow-md dark:bg-[color-mix(in_oklab,#3b82f6_22%,var(--color-popover))]"
         >


### PR DESCRIPTION
## Summary
Repositioned the floating tip button from the left side to the right side of the screen, with corresponding alignment adjustments for the popover content.

## Key Changes
- Changed button positioning from `left-4 lg:left-6` to `right-4 lg:right-6`
- Updated popover content alignment from `align="start"` to `align="end"` to properly align with the right-positioned button

## Implementation Details
The changes maintain the same responsive behavior (mobile: 1rem, desktop: 1.5rem spacing) while mirroring the layout to the right side of the viewport. The popover alignment adjustment ensures the content displays correctly relative to the button's new position.

https://claude.ai/code/session_01VyRSBdvojCYLqhoiqLRo5o