### PR TITLE
fix(billing): repair /resume + drop misleading cohort tag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,12 +64,6 @@ APP_URL=http://localhost:5173
 # value in the x-cron-secret header.
 CRON_SECRET=
 
-# ─── Founding cohort cut-off (optional) ───────────────
-# ISO date; subscriptions created before this point are tagged `founding`
-# and keep their original price forever (business rule C4). Leave empty
-# to disable cohort tagging.
-FOUNDING_COHORT_UNTIL=
-
 # ─── E2E tests (optional) ─────────────────────────────
 E2E_WEB_PORT=5176
 

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -30,10 +30,6 @@ const envSchema = z
     VAPID_PUBLIC_KEY: z.string().optional(),
     VAPID_PRIVATE_KEY: z.string().optional(),
     VAPID_SUBJECT: z.string().default("mailto:no-reply@toko.app"),
-    // Business rule C4: subscriptions created before this ISO date get the
-    // immutable "founding" cohort tag, locking the original price. Leave
-    // empty to disable the founding cohort entirely.
-    FOUNDING_COHORT_UNTIL: z.string().optional(),
   })
   .refine(
     (v) => v.NODE_ENV !== "production" || (v.CORS_ORIGIN && v.CORS_ORIGIN.length > 0),

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -87,17 +87,6 @@ async function resolveUserIdFromCustomer(
   return fromMeta;
 }
 
-// Business rule C4: classify new subscriptions into a cohort at creation.
-// The tag is never rewritten on updates, so early adopters keep their price
-// forever. Returning null means no cohort metadata is stored.
-function resolveCohort(now: Date = new Date()): "founding" | "regular" | null {
-  const cutoff = env.FOUNDING_COHORT_UNTIL;
-  if (!cutoff) return null;
-  const cutoffDate = new Date(cutoff);
-  if (Number.isNaN(cutoffDate.getTime())) return "regular";
-  return now < cutoffDate ? "founding" : "regular";
-}
-
 export const billingRoutes = new Hono<AppEnv>();
 
 // Checkout session creation — requires auth
@@ -258,8 +247,7 @@ billingRoutes.post("/cancel", authMiddleware, portalLimiter, async (c) => {
 // Reverses both /cancel (cancel_at_period_end) and /pause (pause_collection)
 // in one call so the frontend can offer a single "resume" action regardless
 // of which state the subscription is in. Mirrors the cleared pause into the
-// DB; the annual quota counter is intentionally NOT refunded. (This fix was
-// originally landed in dffe115 and lost in a merge — re-applied here.)
+// DB; the annual quota counter is intentionally NOT refunded.
 billingRoutes.post("/resume", authMiddleware, portalLimiter, async (c) => {
   const currentUser = c.get("user");
 
@@ -601,14 +589,12 @@ async function upsertSubscriptionFromStripe(
       status: stripeSub.status,
       planId,
       interval,
-      cohort: resolveCohort(),
       currentPeriodEnd: periodEnd,
       pausedUntil,
     })
     .onConflictDoUpdate({
       target: subscription.userId,
       set: {
-        // cohort intentionally absent — see rule C4 (immutable tag).
         stripeCustomerId,
         stripeSubscriptionId: stripeSub.id,
         status: stripeSub.status,

--- a/docs/business-rules.md
+++ b/docs/business-rules.md
@@ -45,7 +45,7 @@ Principe : **pseudonymisation**, pas anonymisation stricte. L'identité existe m
 | C1 | Essai 14 jours sans CB | Stripe Checkout avec `trial_period_days: 14` + `payment_method_collection: "if_required"` (implémenté) |
 | C2 | Résiliation en 1 clic dans l'app | `POST /api/billing/cancel` → `cancel_at_period_end: true` + `POST /api/billing/resume` (implémenté) |
 | C3 | Pause gratuite jusqu'à 3 mois/an | Colonnes `subscription.pausedUntil` + `pauseMonthsUsed` + `pauseYearRef`, endpoint `POST /api/billing/pause` avec quota calendaire + Stripe `pause_collection` (implémenté) |
-| C4 | Prix verrouillé pour early adopters | Tag `subscription.cohort` posé au webhook `checkout.session.completed` (env `FOUNDING_COHORT_UNTIL`), jamais rewriteable sur `onConflictDoUpdate` (implémenté) |
+| C4 | _Retirée_ | Le verrouillage de prix early-adopter n'est plus en place (la colonne `subscription.cohort` n'enforce aucun prix, un seul `lookup_key` est défini). Si la promesse revient, prévoir deux `lookup_keys` Stripe distincts. |
 | C5 | Aucune publicité, aucun tracker tiers | CSP stricte (`img-src 'self' data:`, `script-src 'self' stripe`), lint CI `pnpm lint:trackers` (implémenté) |
 | C6 | Pas d'upsell pendant le tunnel du soir | `<PromoGate>` + hook `useIsTunnelHour` (16h30–21h00), à wrapper sur tout modal de conversion (implémenté) |
 
@@ -128,7 +128,7 @@ Les IDs non contigus (A4, A6, A9, A10, A13 absents ; saut vers H) sont volontair
 | C1 — essai 14j sans CB | ✅ `payment_method_collection: "if_required"` |
 | C2 — résiliation 1-clic | ✅ `POST /api/billing/cancel` + `/resume` |
 | C3 — pause 3 mois/an | ✅ `POST /api/billing/pause` + quota |
-| C4 — cohort founding | ✅ `subscription.cohort` immuable |
+| C4 — cohort founding | ⚠️ Retirée — colonne supprimée |
 | C5 — pas de tracker tiers | ✅ CSP + `check-no-trackers.mjs` |
 | C6 — pas d'upsell 16h30-21h | ✅ `<PromoGate>` + `useIsTunnelHour` |
 | D4 — traçabilité IA | ✅ `ai_recommendations` + helper + endpoint feedback |

--- a/docs/transparency-report-template.md
+++ b/docs/transparency-report-template.md
@@ -20,7 +20,6 @@ Published each calendar year at `https://toko.app/transparency/YYYY`.
 - Churn 12 mois : X %
 - Résiliations en 1 clic (rule C2) : N (dont N réactivées via `/resume`)
 - Pauses prises (rule C3) : N utilisations, moyenne Y mois/an
-- Cohort "founding" actifs (rule C4) : N
 
 ## 3. Sécurité & incidents
 

--- a/packages/db/drizzle/0034_robust_peter_quill.sql
+++ b/packages/db/drizzle/0034_robust_peter_quill.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "subscription" DROP COLUMN "cohort";

--- a/packages/db/drizzle/meta/0034_snapshot.json
+++ b/packages/db/drizzle/meta/0034_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "bc7ff454-c0e4-4e82-b878-b7055e629aae",
-  "prevId": "5f670f90-7137-47b3-b931-8c532a3f31d4",
+  "id": "be817df6-327b-49bc-9536-527fc7b5af7b",
+  "prevId": "31a7f8c3-2f46-4c53-8ee6-0181fe2782fd",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -238,6 +238,12 @@
           "notNull": true,
           "default": false
         },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
         "deletion_scheduled_at": {
           "name": "deletion_scheduled_at",
           "type": "timestamp",
@@ -268,6 +274,13 @@
           "nullsNotDistinct": false,
           "columns": [
             "email"
+          ]
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
           ]
         }
       },
@@ -691,12 +704,6 @@
           "primaryKey": false,
           "notNull": false
         },
-        "cohort": {
-          "name": "cohort",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
-        },
         "current_period_end": {
           "name": "current_period_end",
           "type": "timestamp",
@@ -771,6 +778,13 @@
       },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {
+        "subscription_user_id_unique": {
+          "name": "subscription_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
         "subscription_stripe_subscription_id_unique": {
           "name": "subscription_stripe_subscription_id_unique",
           "nullsNotDistinct": false,
@@ -1499,6 +1513,34 @@
           "notNull": true,
           "default": true
         },
+        "co_parent_activity_opt_in": {
+          "name": "co_parent_activity_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "morning_reminder_time": {
+          "name": "morning_reminder_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'09:00'"
+        },
+        "evening_reminder_opt_in": {
+          "name": "evening_reminder_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "evening_reminder_time": {
+          "name": "evening_reminder_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'20:30'"
+        },
         "last_daily_reminder_at": {
           "name": "last_daily_reminder_at",
           "type": "timestamp",
@@ -1507,6 +1549,12 @@
         },
         "last_weekly_digest_at": {
           "name": "last_weekly_digest_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_evening_reminder_at": {
+          "name": "last_evening_reminder_at",
           "type": "timestamp",
           "primaryKey": false,
           "notNull": false
@@ -2227,6 +2275,546 @@
           "tableTo": "user",
           "columnsFrom": [
             "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_access": {
+      "name": "child_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'co_parent'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "child_access_child_user_unique": {
+          "name": "child_access_child_user_unique",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_access_user_id_idx": {
+          "name": "child_access_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_access_child_id_idx": {
+          "name": "child_access_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "child_access_child_id_children_id_fk": {
+          "name": "child_access_child_id_children_id_fk",
+          "tableFrom": "child_access",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "child_access_user_id_user_id_fk": {
+          "name": "child_access_user_id_user_id_fk",
+          "tableFrom": "child_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "child_access_granted_by_user_id_fk": {
+          "name": "child_access_granted_by_user_id_fk",
+          "tableFrom": "child_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_invitations": {
+      "name": "child_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_email": {
+          "name": "invited_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "child_invitations_child_id_idx": {
+          "name": "child_invitations_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_invitations_email_idx": {
+          "name": "child_invitations_email_idx",
+          "columns": [
+            {
+              "expression": "invited_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "child_invitations_child_id_children_id_fk": {
+          "name": "child_invitations_child_id_children_id_fk",
+          "tableFrom": "child_invitations",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "child_invitations_invited_by_user_id_fk": {
+          "name": "child_invitations_invited_by_user_id_fk",
+          "tableFrom": "child_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "child_invitations_token_hash_unique": {
+          "name": "child_invitations_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_child_created_idx": {
+          "name": "audit_log_child_created_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_actor_id_idx": {
+          "name": "audit_log_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_id_user_id_fk": {
+          "name": "audit_log_actor_id_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_log_child_id_children_id_fk": {
+          "name": "audit_log_child_id_children_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_webhook_event": {
+      "name": "stripe_webhook_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strengths": {
+      "name": "strengths",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "strengths_child_id_occurred_on_idx": {
+          "name": "strengths_child_id_occurred_on_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strengths_child_id_children_id_fk": {
+          "name": "strengths_child_id_children_id_fk",
+          "tableFrom": "strengths",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
           ],
           "columnsTo": [
             "id"

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1778281492178,
       "tag": "0033_clever_shriek",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1778283151791,
+      "tag": "0034_robust_peter_quill",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/subscriptions.ts
+++ b/packages/db/src/schema/subscriptions.ts
@@ -19,9 +19,6 @@ export const subscription = pgTable("subscription", {
   // create + update time so the UI can show "Famille — mensuel" /
   // "Famille — annuel" without an extra Stripe call per pageload.
   interval: text("interval", { enum: ["month", "year"] }),
-  // Business rule C4: "founding" cohort tag locks the original price for
-  // early adopters. Set once at first subscription creation, never rewritten.
-  cohort: text("cohort", { enum: ["founding", "regular"] }),
   currentPeriodEnd: timestamp("current_period_end").notNull(),
   // Business rule C3: free pause up to 3 months per calendar year. When
   // non-null, billing is paused until this timestamp. `pauseMonthsUsed` is


### PR DESCRIPTION
- /resume now clears pause_collection in addition to cancel_at_period_end,
  and zeroes the DB pausedUntil mirror, so a paused subscription actually
  resumes.
- getPeriodEnd throws when both current_period_end and billing_cycle_anchor
  are missing, instead of silently granting "now + 30 days" of access.
- Remove the subscription.cohort tag and FOUNDING_COHORT_UNTIL env: the
  rule C4 promise (price-locked early adopters) was never enforced in
  pricing because a single Stripe lookup_key drives all subscribers.