### PR TITLE
[audit] Per-child activity feed for the co-parent household

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -26,6 +26,7 @@ import { roadmapRoutes } from "./routes/roadmap";
 import { pushRoutes } from "./routes/push";
 import { childInvitationsRoutes } from "./routes/child-invitations";
 import { childAccessRoutes } from "./routes/child-access";
+import { auditLogRoutes } from "./routes/audit-log";
 import { auth } from "./lib/auth";
 
 const app = new Hono();
@@ -99,6 +100,7 @@ app.route("/api/health", healthRoutes);
 app.route("/api/children", childrenRoutes);
 app.route("/api/child-invitations", childInvitationsRoutes);
 app.route("/api/child-access", childAccessRoutes);
+app.route("/api/audit-log", auditLogRoutes);
 app.route("/api/symptoms", symptomsRoutes);
 app.route("/api/journal", journalRoutes);
 app.route("/api/stats", statsRoutes);

--- a/apps/api/src/lib/audit.ts
+++ b/apps/api/src/lib/audit.ts
@@ -1,0 +1,114 @@
+import { and, desc, eq } from "drizzle-orm";
+import { db, auditLog, user as userTable } from "@focusflow/db";
+
+type EntityType =
+  | "child"
+  | "symptom"
+  | "journal"
+  | "medication"
+  | "medication_log"
+  | "crisis_item"
+  | "child_access"
+  | "child_invitation";
+
+type Action = "create" | "update" | "delete" | "accept" | "revoke";
+
+interface LogAuditOptions {
+  actorId: string;
+  actorName?: string | null;
+  childId?: string | null;
+  entityType: EntityType;
+  entityId?: string | null;
+  action: Action;
+  summary?: string | null;
+}
+
+// Best-effort write — we never want a failed audit insert to roll back
+// the user's actual mutation. Most callers use this fire-and-forget
+// after a successful insert/update, inside a try/catch upstream.
+export async function logAudit(opts: LogAuditOptions): Promise<void> {
+  try {
+    await db.insert(auditLog).values({
+      actorId: opts.actorId,
+      actorName: opts.actorName ?? null,
+      childId: opts.childId ?? null,
+      entityType: opts.entityType,
+      entityId: opts.entityId ?? null,
+      action: opts.action,
+      summary: opts.summary ?? null,
+    });
+  } catch (err) {
+    // Swallow — the audit feed is non-critical. A future hardening pass
+    // can wire this into the structured logger.
+    console.error("audit_log_write_failed", err);
+  }
+}
+
+export interface AuditEntry {
+  id: string;
+  actorId: string | null;
+  actorName: string | null;
+  childId: string | null;
+  entityType: EntityType;
+  entityId: string | null;
+  action: Action;
+  summary: string | null;
+  createdAt: Date;
+}
+
+// Recent activity feed for a child. Joins to user so we can refresh the
+// actor's name if it was missing (older rows pre-feature) — but always
+// prefers the snapshot stored at write time (resilient to user deletion).
+export async function listAuditForChild(
+  childId: string,
+  limit = 50,
+): Promise<AuditEntry[]> {
+  const rows = await db
+    .select({
+      id: auditLog.id,
+      actorId: auditLog.actorId,
+      snapshotName: auditLog.actorName,
+      currentName: userTable.name,
+      childId: auditLog.childId,
+      entityType: auditLog.entityType,
+      entityId: auditLog.entityId,
+      action: auditLog.action,
+      summary: auditLog.summary,
+      createdAt: auditLog.createdAt,
+    })
+    .from(auditLog)
+    .leftJoin(userTable, eq(userTable.id, auditLog.actorId))
+    .where(eq(auditLog.childId, childId))
+    .orderBy(desc(auditLog.createdAt))
+    .limit(limit);
+
+  return rows.map((r) => ({
+    id: r.id,
+    actorId: r.actorId,
+    actorName: r.snapshotName ?? r.currentName ?? null,
+    childId: r.childId,
+    entityType: r.entityType as EntityType,
+    entityId: r.entityId,
+    action: r.action as Action,
+    summary: r.summary,
+    createdAt: r.createdAt,
+  }));
+}
+
+// Used when a row is being inserted on a child the actor already has
+// access to, but the route handler hasn't yet re-fetched the actor's
+// display name from the session. Cheap call.
+export async function snapshotActorName(
+  actorId: string,
+): Promise<string | null> {
+  const [row] = await db
+    .select({ name: userTable.name })
+    .from(userTable)
+    .where(eq(userTable.id, actorId))
+    .limit(1);
+  return row?.name ?? null;
+}
+
+// Re-export to keep the unused-import noise low in callers — they
+// don't typically need the helper above directly.
+export { and };

--- a/apps/api/src/routes/audit-log.ts
+++ b/apps/api/src/routes/audit-log.ts
@@ -1,0 +1,27 @@
+import { Hono } from "hono";
+import { authMiddleware } from "../middleware/auth";
+import { assertChildAccess } from "../lib/child-access";
+import { listAuditForChild } from "../lib/audit";
+import type { AppEnv } from "../types";
+
+export const auditLogRoutes = new Hono<AppEnv>();
+
+auditLogRoutes.use("*", authMiddleware);
+
+// Recent activity feed for a child. Any user with access (owner or
+// co-parent) can read — the whole point is that both parents see what
+// the other did.
+auditLogRoutes.get("/child/:childId", async (c) => {
+  const currentUser = c.get("user");
+  const childId = c.req.param("childId");
+
+  await assertChildAccess(currentUser.id, childId);
+
+  const limit = Math.min(
+    Math.max(Number(c.req.query("limit")) || 50, 1),
+    200,
+  );
+
+  const rows = await listAuditForChild(childId, limit);
+  return c.json(rows);
+});

--- a/apps/api/src/routes/child-access.ts
+++ b/apps/api/src/routes/child-access.ts
@@ -11,6 +11,7 @@ import {
   assertChildAccess,
   assertChildOwner,
 } from "../lib/child-access";
+import { logAudit } from "../lib/audit";
 import type { AppEnv } from "../types";
 
 export const childAccessRoutes = new Hono<AppEnv>();
@@ -73,6 +74,16 @@ childAccessRoutes.delete("/child/:childId/user/:userId", async (c) => {
   if (deleted.length === 0) {
     throw new AppError("NOT_FOUND", "Co-parent non trouvé", 404);
   }
+
+  void logAudit({
+    actorId: currentUser.id,
+    actorName: currentUser.name ?? null,
+    childId,
+    entityType: "child_access",
+    entityId: deleted[0]?.id ?? null,
+    action: "revoke",
+    summary: "Accès retiré pour le co-parent",
+  });
 
   return c.json({ ok: true });
 });

--- a/apps/api/src/routes/child-invitations.ts
+++ b/apps/api/src/routes/child-invitations.ts
@@ -16,6 +16,7 @@ import { authMiddleware } from "../middleware/auth";
 import { rateLimiter } from "../middleware/rate-limiter";
 import { AppError } from "../middleware/error-handler";
 import { assertChildOwner } from "../lib/child-access";
+import { logAudit } from "../lib/audit";
 import { sendEmail } from "../lib/email";
 import { env } from "../lib/env";
 import type { AppEnv } from "../types";
@@ -168,6 +169,16 @@ childInvitationsRoutes.post(
       expiresAt,
     });
 
+    void logAudit({
+      actorId: currentUser.id,
+      actorName: currentUser.name ?? null,
+      childId,
+      entityType: "child_invitation",
+      entityId: null,
+      action: "create",
+      summary: `Invitation envoyée à ${invitedEmail}`,
+    });
+
     const acceptUrl = `${appOrigin()}/invite/${token}`;
     const inviterName = currentUser.name ?? "Un parent";
 
@@ -246,6 +257,16 @@ childInvitationsRoutes.post(
         .update(childInvitations)
         .set({ acceptedAt: new Date() })
         .where(eq(childInvitations.id, invite.id));
+    });
+
+    void logAudit({
+      actorId: currentUser.id,
+      actorName: currentUser.name ?? null,
+      childId: invite.childId,
+      entityType: "child_access",
+      entityId: null,
+      action: "accept",
+      summary: `${currentUser.name ?? "Un parent"} a accepté l'invitation`,
     });
 
     return c.json({ ok: true, childId: invite.childId });

--- a/apps/api/src/routes/children.ts
+++ b/apps/api/src/routes/children.ts
@@ -11,6 +11,7 @@ import {
   assertChildOwner,
   listAccessibleChildIds,
 } from "../lib/child-access";
+import { logAudit } from "../lib/audit";
 
 export const childrenRoutes = new Hono<AppEnv>();
 
@@ -129,6 +130,16 @@ childrenRoutes.patch("/:id", async (c) => {
     throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
   }
 
+  void logAudit({
+    actorId: user.id,
+    actorName: user.name ?? null,
+    childId: updated.id,
+    entityType: "child",
+    entityId: updated.id,
+    action: "update",
+    summary: "Profil de l'enfant mis à jour",
+  });
+
   return c.json(updated);
 });
 
@@ -146,6 +157,16 @@ childrenRoutes.delete("/:id", async (c) => {
   if (deleted.length === 0) {
     throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
   }
+
+  void logAudit({
+    actorId: user.id,
+    actorName: user.name ?? null,
+    childId: id,
+    entityType: "child",
+    entityId: id,
+    action: "delete",
+    summary: "Profil de l'enfant supprimé",
+  });
 
   return c.json({ ok: true });
 });

--- a/apps/api/src/routes/crisis-list.ts
+++ b/apps/api/src/routes/crisis-list.ts
@@ -10,6 +10,7 @@ import {
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess } from "../lib/child-access";
+import { logAudit } from "../lib/audit";
 
 export const crisisListRoutes = new Hono<AppEnv>();
 
@@ -57,6 +58,18 @@ crisisListRoutes.post("/", async (c) => {
     .values({ ...parsed.data, position })
     .returning();
 
+  if (item) {
+    void logAudit({
+      actorId: user.id,
+      actorName: user.name ?? null,
+      childId: item.childId,
+      entityType: "crisis_item",
+      entityId: item.id,
+      action: "create",
+      summary: "Liste de crise modifiée",
+    });
+  }
+
   return c.json(item, 201);
 });
 
@@ -90,6 +103,18 @@ crisisListRoutes.patch("/:id", async (c) => {
     .where(eq(crisisItems.id, id))
     .returning();
 
+  if (updated) {
+    void logAudit({
+      actorId: user.id,
+      actorName: user.name ?? null,
+      childId: updated.childId,
+      entityType: "crisis_item",
+      entityId: updated.id,
+      action: "update",
+      summary: "Liste de crise modifiée",
+    });
+  }
+
   return c.json(updated);
 });
 
@@ -109,6 +134,17 @@ crisisListRoutes.delete("/:id", async (c) => {
   await assertChildAccess(user.id, existing.childId);
 
   await db.delete(crisisItems).where(eq(crisisItems.id, id));
+
+  void logAudit({
+    actorId: user.id,
+    actorName: user.name ?? null,
+    childId: existing.childId,
+    entityType: "crisis_item",
+    entityId: existing.id,
+    action: "delete",
+    summary: "Liste de crise modifiée",
+  });
+
   return c.json({ ok: true });
 });
 

--- a/apps/api/src/routes/journal.ts
+++ b/apps/api/src/routes/journal.ts
@@ -9,6 +9,18 @@ import {
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess } from "../lib/child-access";
+import { logAudit } from "../lib/audit";
+
+function formatFrDate(value: Date | string | null | undefined): string {
+  if (!value) return "";
+  const d = typeof value === "string" ? new Date(value) : value;
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
 
 export const journalRoutes = new Hono<AppEnv>();
 
@@ -53,6 +65,21 @@ journalRoutes.post("/", async (c) => {
     .values(parsed.data)
     .returning();
 
+  if (entry) {
+    const dateStr = formatFrDate(entry.date);
+    void logAudit({
+      actorId: user.id,
+      actorName: user.name ?? null,
+      childId: entry.childId,
+      entityType: "journal",
+      entityId: entry.id,
+      action: "create",
+      summary: dateStr
+        ? `Journal du ${dateStr} ajouté`
+        : "Entrée du journal ajoutée",
+    });
+  }
+
   return c.json(entry, 201);
 });
 
@@ -86,6 +113,18 @@ journalRoutes.patch("/:id", async (c) => {
     .where(eq(journalEntries.id, id))
     .returning();
 
+  if (updated) {
+    void logAudit({
+      actorId: user.id,
+      actorName: user.name ?? null,
+      childId: updated.childId,
+      entityType: "journal",
+      entityId: updated.id,
+      action: "update",
+      summary: "Entrée du journal modifiée",
+    });
+  }
+
   return c.json(updated);
 });
 
@@ -105,5 +144,16 @@ journalRoutes.delete("/:id", async (c) => {
   await assertChildAccess(user.id, existing.childId);
 
   await db.delete(journalEntries).where(eq(journalEntries.id, id));
+
+  void logAudit({
+    actorId: user.id,
+    actorName: user.name ?? null,
+    childId: existing.childId,
+    entityType: "journal",
+    entityId: existing.id,
+    action: "delete",
+    summary: "Entrée du journal supprimée",
+  });
+
   return c.json({ ok: true });
 });

--- a/apps/api/src/routes/medications.ts
+++ b/apps/api/src/routes/medications.ts
@@ -10,6 +10,7 @@ import {
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess } from "../lib/child-access";
+import { logAudit } from "../lib/audit";
 
 export const medicationsRoutes = new Hono<AppEnv>();
 
@@ -58,6 +59,18 @@ medicationsRoutes.post("/", async (c) => {
     .values(parsed.data)
     .returning();
 
+  if (created) {
+    void logAudit({
+      actorId: user.id,
+      actorName: user.name ?? null,
+      childId: created.childId,
+      entityType: "medication",
+      entityId: created.id,
+      action: "create",
+      summary: `Médicament ${created.name} ajouté`,
+    });
+  }
+
   return c.json(created, 201);
 });
 
@@ -82,6 +95,18 @@ medicationsRoutes.patch("/:id", async (c) => {
     .where(eq(medications.id, id))
     .returning();
 
+  if (updated) {
+    void logAudit({
+      actorId: user.id,
+      actorName: user.name ?? null,
+      childId: updated.childId,
+      entityType: "medication",
+      entityId: updated.id,
+      action: "update",
+      summary: `Médicament ${updated.name} mis à jour`,
+    });
+  }
+
   return c.json(updated);
 });
 
@@ -90,7 +115,25 @@ medicationsRoutes.delete("/:id", async (c) => {
   const id = c.req.param("id");
   await assertMedicationOwnership(user.id, id);
 
+  const [existing] = await db
+    .select()
+    .from(medications)
+    .where(eq(medications.id, id));
+
   await db.delete(medications).where(eq(medications.id, id));
+
+  if (existing) {
+    void logAudit({
+      actorId: user.id,
+      actorName: user.name ?? null,
+      childId: existing.childId,
+      entityType: "medication",
+      entityId: existing.id,
+      action: "delete",
+      summary: `Médicament ${existing.name} supprimé`,
+    });
+  }
+
   return c.json({ ok: true });
 });
 
@@ -166,7 +209,10 @@ medicationsRoutes.post("/logs", async (c) => {
     );
   }
 
-  await assertMedicationOwnership(user.id, parsed.data.medicationId);
+  const ownership = await assertMedicationOwnership(
+    user.id,
+    parsed.data.medicationId,
+  );
 
   // Upsert on (medicationId, date) — parent can flip "taken" after the fact.
   const [log] = await db
@@ -180,6 +226,20 @@ medicationsRoutes.post("/logs", async (c) => {
       },
     })
     .returning();
+
+  if (log) {
+    void logAudit({
+      actorId: user.id,
+      actorName: user.name ?? null,
+      childId: ownership.childId,
+      entityType: "medication_log",
+      entityId: log.id,
+      action: log.taken ? "create" : "update",
+      summary: log.taken
+        ? "Prise de médicament enregistrée"
+        : "Prise de médicament mise à jour",
+    });
+  }
 
   return c.json(log, 201);
 });

--- a/apps/api/src/routes/symptoms.ts
+++ b/apps/api/src/routes/symptoms.ts
@@ -9,6 +9,18 @@ import {
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess } from "../lib/child-access";
+import { logAudit } from "../lib/audit";
+
+function formatFrDate(value: Date | string | null | undefined): string {
+  if (!value) return "";
+  const d = typeof value === "string" ? new Date(value) : value;
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
 
 export const symptomsRoutes = new Hono<AppEnv>();
 
@@ -53,6 +65,21 @@ symptomsRoutes.post("/", async (c) => {
     .values(parsed.data)
     .returning();
 
+  if (symptom) {
+    const dateStr = formatFrDate(symptom.date);
+    void logAudit({
+      actorId: user.id,
+      actorName: user.name ?? null,
+      childId: symptom.childId,
+      entityType: "symptom",
+      entityId: symptom.id,
+      action: "create",
+      summary: dateStr
+        ? `Symptômes du ${dateStr} enregistrés`
+        : "Symptômes enregistrés",
+    });
+  }
+
   return c.json(symptom, 201);
 });
 
@@ -90,6 +117,19 @@ symptomsRoutes.patch("/:id", async (c) => {
     throw new AppError("NOT_FOUND", "Relevé non trouvé", 404);
   }
 
+  const dateStr = formatFrDate(updated.date);
+  void logAudit({
+    actorId: user.id,
+    actorName: user.name ?? null,
+    childId: updated.childId,
+    entityType: "symptom",
+    entityId: updated.id,
+    action: "update",
+    summary: dateStr
+      ? `Symptômes du ${dateStr} mis à jour`
+      : "Symptômes mis à jour",
+  });
+
   return c.json(updated);
 });
 
@@ -109,5 +149,19 @@ symptomsRoutes.delete("/:id", async (c) => {
   await assertChildAccess(user.id, existing.childId);
 
   await db.delete(symptoms).where(eq(symptoms.id, id));
+
+  const dateStr = formatFrDate(existing.date);
+  void logAudit({
+    actorId: user.id,
+    actorName: user.name ?? null,
+    childId: existing.childId,
+    entityType: "symptom",
+    entityId: existing.id,
+    action: "delete",
+    summary: dateStr
+      ? `Symptômes du ${dateStr} supprimés`
+      : "Symptômes supprimés",
+  });
+
   return c.json({ ok: true });
 });

--- a/apps/web/src/components/co-parent/co-parent-section.tsx
+++ b/apps/web/src/components/co-parent/co-parent-section.tsx
@@ -6,6 +6,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Tabs,
+  TabsContent,
+  TabsList,
+  TabsTrigger,
+} from "@/components/ui/tabs";
 import { useSession } from "@/lib/auth-client";
 import {
   useChildAccess,
@@ -13,6 +19,7 @@ import {
   useRevokeAccess,
   type ChildAccessRow,
 } from "@/hooks/use-child-access";
+import { RecentActivity } from "@/components/co-parent/recent-activity";
 
 interface Props {
   childId: string;
@@ -52,8 +59,18 @@ export function CoParentSection({ childId }: Props) {
         </p>
       </div>
 
-      {isOwner && (
-        <form onSubmit={handleInvite} className="space-y-2">
+      <Tabs defaultValue="members">
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="members">
+            {t("childAccess.tabMembers")}
+          </TabsTrigger>
+          <TabsTrigger value="activity">
+            {t("childAccess.tabActivity")}
+          </TabsTrigger>
+        </TabsList>
+        <TabsContent value="members" className="space-y-4 pt-3">
+          {isOwner && (
+            <form onSubmit={handleInvite} className="space-y-2">
           <Label htmlFor={`co-parent-email-${childId}`} className="text-sm">
             {t("childAccess.inviteLabel")}
           </Label>
@@ -84,27 +101,32 @@ export function CoParentSection({ childId }: Props) {
         </form>
       )}
 
-      <div className="space-y-2">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-          {t("childAccess.membersTitle")}
-        </p>
-        {access.isLoading ? (
-          <Skeleton className="h-12 w-full" />
-        ) : (
-          <ul className="space-y-2">
-            {access.data?.map((row) => (
-              <MemberRow
-                key={row.id}
-                row={row}
-                isViewerOwner={isOwner}
-                viewerUserId={currentUserId}
-                onRevoke={() => revoke.mutate(row.userId)}
-                revokePending={revoke.isPending}
-              />
-            ))}
-          </ul>
-        )}
-      </div>
+          <div className="space-y-2">
+            <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              {t("childAccess.membersTitle")}
+            </p>
+            {access.isLoading ? (
+              <Skeleton className="h-12 w-full" />
+            ) : (
+              <ul className="space-y-2">
+                {access.data?.map((row) => (
+                  <MemberRow
+                    key={row.id}
+                    row={row}
+                    isViewerOwner={isOwner}
+                    viewerUserId={currentUserId}
+                    onRevoke={() => revoke.mutate(row.userId)}
+                    revokePending={revoke.isPending}
+                  />
+                ))}
+              </ul>
+            )}
+          </div>
+        </TabsContent>
+        <TabsContent value="activity" className="pt-3">
+          <RecentActivity childId={childId} />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/apps/web/src/components/co-parent/recent-activity.tsx
+++ b/apps/web/src/components/co-parent/recent-activity.tsx
@@ -1,0 +1,133 @@
+import { useTranslation } from "react-i18next";
+import {
+  Activity,
+  BookOpen,
+  Crown,
+  HandHeart,
+  History,
+  Pill,
+  User,
+  UserPlus,
+  UserMinus,
+} from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  useAuditLogForChild,
+  type AuditEntry,
+  type AuditEntityType,
+} from "@/hooks/use-audit-log";
+
+interface Props {
+  childId: string;
+}
+
+// Icon picked off entityType so the feed scans visually — symptom rows
+// look different from invitation rows at a glance.
+const ENTITY_ICONS: Record<AuditEntityType, React.ComponentType<{ className?: string }>> = {
+  child: Crown,
+  symptom: Activity,
+  journal: BookOpen,
+  medication: Pill,
+  medication_log: Pill,
+  crisis_item: HandHeart,
+  child_access: UserMinus,
+  child_invitation: UserPlus,
+};
+
+export function RecentActivity({ childId }: Props) {
+  const { t } = useTranslation();
+  const { data, isLoading } = useAuditLogForChild(childId, 50);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-border/60 py-8 text-center text-sm text-muted-foreground">
+        <History className="h-5 w-5" />
+        <p>{t("auditLog.empty")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <ul className="space-y-2">
+      {data.map((entry) => (
+        <ActivityRow key={entry.id} entry={entry} />
+      ))}
+    </ul>
+  );
+}
+
+function ActivityRow({ entry }: { entry: AuditEntry }) {
+  const { t, i18n } = useTranslation();
+  const Icon = ENTITY_ICONS[entry.entityType] ?? User;
+
+  const actor = entry.actorName ?? t("auditLog.deletedActor");
+  const text = entry.summary ?? defaultSummary(t, entry);
+
+  const date = new Date(entry.createdAt);
+  const locale = i18n.resolvedLanguage === "en" ? "en-US" : "fr-FR";
+  const relative = formatRelative(date, locale);
+  const exact = date.toLocaleString(locale, {
+    day: "numeric",
+    month: "short",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  return (
+    <li className="flex items-start gap-3 rounded-lg border border-border/60 bg-background/40 p-3">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <Icon className="h-4 w-4" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm">
+          <span className="font-medium">{actor}</span>{" "}
+          <span className="text-muted-foreground">— {text}</span>
+        </p>
+        <p
+          className="mt-0.5 text-xs text-muted-foreground"
+          title={exact}
+        >
+          {relative}
+        </p>
+      </div>
+    </li>
+  );
+}
+
+// Minimal relative-time formatter so we don't pull in date-fns just for the
+// activity feed. "il y a 3 min", "il y a 2 h", "hier", "il y a 4 j",
+// otherwise the absolute date.
+function formatRelative(date: Date, locale: string): string {
+  const diff = Date.now() - date.getTime();
+  const min = Math.floor(diff / 60_000);
+  if (min < 1) return locale.startsWith("en") ? "just now" : "à l'instant";
+  if (min < 60) return locale.startsWith("en") ? `${min} min ago` : `il y a ${min} min`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return locale.startsWith("en") ? `${hr} h ago` : `il y a ${hr} h`;
+  const d = Math.floor(hr / 24);
+  if (d === 1) return locale.startsWith("en") ? "yesterday" : "hier";
+  if (d < 7) return locale.startsWith("en") ? `${d} d ago` : `il y a ${d} j`;
+  return date.toLocaleDateString(locale, {
+    day: "numeric",
+    month: "short",
+  });
+}
+
+// Fallback when an old row was written without a summary. Cheap and
+// won't block the v1 — we'll be writing summaries for everything new.
+function defaultSummary(
+  t: (key: string) => string,
+  entry: AuditEntry,
+): string {
+  return t(`auditLog.fallback.${entry.entityType}.${entry.action}`);
+}

--- a/apps/web/src/hooks/use-audit-log.ts
+++ b/apps/web/src/hooks/use-audit-log.ts
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+
+export type AuditEntityType =
+  | "child"
+  | "symptom"
+  | "journal"
+  | "medication"
+  | "medication_log"
+  | "crisis_item"
+  | "child_access"
+  | "child_invitation";
+
+export type AuditAction =
+  | "create"
+  | "update"
+  | "delete"
+  | "accept"
+  | "revoke";
+
+export interface AuditEntry {
+  id: string;
+  actorId: string | null;
+  actorName: string | null;
+  childId: string | null;
+  entityType: AuditEntityType;
+  entityId: string | null;
+  action: AuditAction;
+  summary: string | null;
+  createdAt: string;
+}
+
+export const auditLogKeys = {
+  all: ["audit-log"] as const,
+  forChild: (childId: string) => ["audit-log", "child", childId] as const,
+};
+
+export function useAuditLogForChild(childId: string, limit = 50) {
+  return useQuery({
+    queryKey: auditLogKeys.forChild(childId),
+    queryFn: () =>
+      api.get<AuditEntry[]>(
+        `/audit-log/child/${childId}?limit=${limit}`,
+      ),
+    enabled: !!childId,
+  });
+}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -712,6 +712,8 @@
     "invitePlaceholder": "co-parent@family.com",
     "inviteCta": "Send invite",
     "membersTitle": "Members",
+    "tabMembers": "Members",
+    "tabActivity": "Recent activity",
     "roleOwner": "Owner",
     "roleCoParent": "Co-parent",
     "you": "you",
@@ -723,6 +725,49 @@
     "inviteInvalidEmail": "Invalid email address.",
     "inviteForbidden": "Only the owner can invite.",
     "inviteError": "Invite failed to send."
+  },
+  "auditLog": {
+    "empty": "No activity recorded yet.",
+    "deletedActor": "Deleted account",
+    "fallback": {
+      "child": {
+        "create": "Profile created",
+        "update": "Profile updated",
+        "delete": "Profile deleted"
+      },
+      "symptom": {
+        "create": "Symptoms added",
+        "update": "Symptoms updated",
+        "delete": "Symptoms removed"
+      },
+      "journal": {
+        "create": "Journal entry added",
+        "update": "Journal entry updated",
+        "delete": "Journal entry removed"
+      },
+      "medication": {
+        "create": "Medication added",
+        "update": "Medication updated",
+        "delete": "Medication removed"
+      },
+      "medication_log": {
+        "create": "Dose logged",
+        "delete": "Dose removed"
+      },
+      "crisis_item": {
+        "create": "Calm-down strategy added",
+        "update": "Calm-down strategy updated",
+        "delete": "Calm-down strategy removed"
+      },
+      "child_access": {
+        "accept": "Co-parent accepted",
+        "revoke": "Co-parent access revoked"
+      },
+      "child_invitation": {
+        "create": "Invitation sent",
+        "accept": "Invitation accepted"
+      }
+    }
   },
   "featureTip": {
     "label": "Tip",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -712,6 +712,8 @@
     "invitePlaceholder": "co-parent@famille.fr",
     "inviteCta": "Envoyer l'invitation",
     "membersTitle": "Membres",
+    "tabMembers": "Membres",
+    "tabActivity": "Activité récente",
     "roleOwner": "Propriétaire",
     "roleCoParent": "Co-parent",
     "you": "vous",
@@ -723,6 +725,49 @@
     "inviteInvalidEmail": "Adresse email invalide.",
     "inviteForbidden": "Seul le propriétaire peut inviter.",
     "inviteError": "L'invitation n'a pas pu être envoyée."
+  },
+  "auditLog": {
+    "empty": "Aucune activité enregistrée pour le moment.",
+    "deletedActor": "Compte supprimé",
+    "fallback": {
+      "child": {
+        "create": "Profil créé",
+        "update": "Profil mis à jour",
+        "delete": "Profil supprimé"
+      },
+      "symptom": {
+        "create": "Symptômes ajoutés",
+        "update": "Symptômes mis à jour",
+        "delete": "Symptômes supprimés"
+      },
+      "journal": {
+        "create": "Entrée du journal ajoutée",
+        "update": "Entrée du journal modifiée",
+        "delete": "Entrée du journal supprimée"
+      },
+      "medication": {
+        "create": "Médicament ajouté",
+        "update": "Médicament mis à jour",
+        "delete": "Médicament supprimé"
+      },
+      "medication_log": {
+        "create": "Prise de médicament notée",
+        "delete": "Prise de médicament retirée"
+      },
+      "crisis_item": {
+        "create": "Stratégie anti-crise ajoutée",
+        "update": "Stratégie anti-crise modifiée",
+        "delete": "Stratégie anti-crise supprimée"
+      },
+      "child_access": {
+        "accept": "Co-parent accepté",
+        "revoke": "Accès co-parent retiré"
+      },
+      "child_invitation": {
+        "create": "Invitation envoyée",
+        "accept": "Invitation acceptée"
+      }
+    }
   },
   "featureTip": {
     "label": "Conseil",

--- a/packages/db/drizzle/0029_large_iron_monger.sql
+++ b/packages/db/drizzle/0029_large_iron_monger.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "audit_log" (
+	"id" text PRIMARY KEY NOT NULL,
+	"actor_id" text,
+	"actor_name" text,
+	"child_id" text,
+	"entity_type" text NOT NULL,
+	"entity_id" text,
+	"action" text NOT NULL,
+	"summary" text,
+	"created_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "audit_log" ADD CONSTRAINT "audit_log_actor_id_user_id_fk" FOREIGN KEY ("actor_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "audit_log" ADD CONSTRAINT "audit_log_child_id_children_id_fk" FOREIGN KEY ("child_id") REFERENCES "public"."children"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "audit_log_child_created_idx" ON "audit_log" USING btree ("child_id","created_at");--> statement-breakpoint
+CREATE INDEX "audit_log_actor_id_idx" ON "audit_log" USING btree ("actor_id");

--- a/packages/db/drizzle/meta/0029_snapshot.json
+++ b/packages/db/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,2659 @@
+{
+  "id": "0d469c78-8642-4600-a52e-68693399639e",
+  "prevId": "f21965aa-0396-40a5-b9f8-668706096f41",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "deletion_scheduled_at": {
+          "name": "deletion_scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.children": {
+      "name": "children",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age_range": {
+          "name": "age_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_type": {
+          "name": "diagnosis_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undefined'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "children_parent_id_idx": {
+          "name": "children_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "children_parent_id_user_id_fk": {
+          "name": "children_parent_id_user_id_fk",
+          "tableFrom": "children",
+          "tableTo": "user",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.symptoms": {
+      "name": "symptoms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agitation": {
+          "name": "agitation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "focus": {
+          "name": "focus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impulse": {
+          "name": "impulse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood": {
+          "name": "mood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sleep": {
+          "name": "sleep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routines_ok": {
+          "name": "routines_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "symptoms_child_id_date_idx": {
+          "name": "symptoms_child_id_date_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "symptoms_child_id_children_id_fk": {
+          "name": "symptoms_child_id_children_id_fk",
+          "tableFrom": "symptoms",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entries": {
+      "name": "journal_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "journal_entries_child_id_date_idx": {
+          "name": "journal_entries_child_id_date_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_child_id_children_id_fk": {
+          "name": "journal_entries_child_id_children_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cohort": {
+          "name": "cohort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "paused_until": {
+          "name": "paused_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_months_used": {
+          "name": "pause_months_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pause_year_ref": {
+          "name": "pause_year_ref",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscription_user_id_idx": {
+          "name": "subscription_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscription_stripe_subscription_id_unique": {
+          "name": "subscription_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_behavior_logs": {
+      "name": "barkley_behavior_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "behavior_id": {
+          "name": "behavior_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_behavior_logs_behavior_id_idx": {
+          "name": "barkley_behavior_logs_behavior_id_idx",
+          "columns": [
+            {
+              "expression": "behavior_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_behavior_logs_behavior_id_barkley_behaviors_id_fk": {
+          "name": "barkley_behavior_logs_behavior_id_barkley_behaviors_id_fk",
+          "tableFrom": "barkley_behavior_logs",
+          "tableTo": "barkley_behaviors",
+          "columnsFrom": [
+            "behavior_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "barkley_behavior_logs_behavior_id_date_unique": {
+          "name": "barkley_behavior_logs_behavior_id_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "behavior_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_behaviors": {
+      "name": "barkley_behaviors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_behaviors_child_id_idx": {
+          "name": "barkley_behaviors_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_behaviors_child_id_children_id_fk": {
+          "name": "barkley_behaviors_child_id_children_id_fk",
+          "tableFrom": "barkley_behaviors",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_rewards": {
+      "name": "barkley_rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stars_required": {
+          "name": "stars_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "times_claimed": {
+          "name": "times_claimed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_rewards_child_id_idx": {
+          "name": "barkley_rewards_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_rewards_child_id_children_id_fk": {
+          "name": "barkley_rewards_child_id_children_id_fk",
+          "tableFrom": "barkley_rewards",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_steps": {
+      "name": "barkley_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_steps_child_id_idx": {
+          "name": "barkley_steps_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_steps_child_id_children_id_fk": {
+          "name": "barkley_steps_child_id_children_id_fk",
+          "tableFrom": "barkley_steps",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "barkley_steps_child_id_step_number_unique": {
+          "name": "barkley_steps_child_id_step_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "child_id",
+            "step_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crisis_items": {
+      "name": "crisis_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crisis_items_child_id_idx": {
+          "name": "crisis_items_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crisis_items_child_id_children_id_fk": {
+          "name": "crisis_items_child_id_children_id_fk",
+          "tableFrom": "crisis_items",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_logs": {
+      "name": "medication_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "medication_id": {
+          "name": "medication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taken": {
+          "name": "taken",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_effects": {
+          "name": "side_effects",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "medication_logs_medication_id_idx": {
+          "name": "medication_logs_medication_id_idx",
+          "columns": [
+            {
+              "expression": "medication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medication_logs_medication_id_medications_id_fk": {
+          "name": "medication_logs_medication_id_medications_id_fk",
+          "tableFrom": "medication_logs",
+          "tableTo": "medications",
+          "columnsFrom": [
+            "medication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "medication_logs_medication_id_date_unique": {
+          "name": "medication_logs_medication_id_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "medication_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medications": {
+      "name": "medications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose": {
+          "name": "dose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "medications_child_id_idx": {
+          "name": "medications_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medications_child_id_children_id_fk": {
+          "name": "medications_child_id_children_id_fk",
+          "tableFrom": "medications",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Europe/Paris'"
+        },
+        "daily_reminder_opt_in": {
+          "name": "daily_reminder_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weekly_digest_opt_in": {
+          "name": "weekly_digest_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "last_daily_reminder_at": {
+          "name": "last_daily_reminder_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_weekly_digest_at": {
+          "name": "last_weekly_digest_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lock_pin_hash": {
+          "name": "lock_pin_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lock_pin_salt": {
+          "name": "lock_pin_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_user_id_fk": {
+          "name": "user_preferences_user_id_user_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news": {
+      "name": "news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "news_published_at_idx": {
+          "name": "news_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news_slug_idx": {
+          "name": "news_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "news_author_id_user_id_fk": {
+          "name": "news_author_id_user_id_fk",
+          "tableFrom": "news",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "news_slug_unique": {
+          "name": "news_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consents_user_type_idx": {
+          "name": "consents_user_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consents_user_id_user_id_fk": {
+          "name": "consents_user_id_user_id_fk",
+          "tableFrom": "consents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_recommendations": {
+      "name": "ai_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_template": {
+          "name": "prompt_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion": {
+          "name": "suggestion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_note": {
+          "name": "feedback_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_recommendations_user_id_idx": {
+          "name": "ai_recommendations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_recommendations_user_id_user_id_fk": {
+          "name": "ai_recommendations_user_id_user_id_fk",
+          "tableFrom": "ai_recommendations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_recommendations_child_id_children_id_fk": {
+          "name": "ai_recommendations_child_id_children_id_fk",
+          "tableFrom": "ai_recommendations",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nps_responses": {
+      "name": "nps_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort": {
+          "name": "cohort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nps_responses_user_cohort_unique": {
+          "name": "nps_responses_user_cohort_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cohort",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nps_responses_user_id_user_id_fk": {
+          "name": "nps_responses_user_id_user_id_fk",
+          "tableFrom": "nps_responses",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_items": {
+      "name": "roadmap_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roadmap_items_status_idx": {
+          "name": "roadmap_items_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_votes": {
+      "name": "roadmap_votes",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roadmap_votes_item_user_unique": {
+          "name": "roadmap_votes_item_user_unique",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roadmap_votes_item_id_roadmap_items_id_fk": {
+          "name": "roadmap_votes_item_id_roadmap_items_id_fk",
+          "tableFrom": "roadmap_votes",
+          "tableTo": "roadmap_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roadmap_votes_user_id_user_id_fk": {
+          "name": "roadmap_votes_user_id_user_id_fk",
+          "tableFrom": "roadmap_votes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_endpoint_unique": {
+          "name": "push_subscriptions_user_endpoint_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_user_id_fk": {
+          "name": "push_subscriptions_user_id_user_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_access": {
+      "name": "child_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'co_parent'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "child_access_child_user_unique": {
+          "name": "child_access_child_user_unique",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_access_user_id_idx": {
+          "name": "child_access_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_access_child_id_idx": {
+          "name": "child_access_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "child_access_child_id_children_id_fk": {
+          "name": "child_access_child_id_children_id_fk",
+          "tableFrom": "child_access",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "child_access_user_id_user_id_fk": {
+          "name": "child_access_user_id_user_id_fk",
+          "tableFrom": "child_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "child_access_granted_by_user_id_fk": {
+          "name": "child_access_granted_by_user_id_fk",
+          "tableFrom": "child_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_invitations": {
+      "name": "child_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_email": {
+          "name": "invited_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "child_invitations_child_id_idx": {
+          "name": "child_invitations_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_invitations_email_idx": {
+          "name": "child_invitations_email_idx",
+          "columns": [
+            {
+              "expression": "invited_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "child_invitations_child_id_children_id_fk": {
+          "name": "child_invitations_child_id_children_id_fk",
+          "tableFrom": "child_invitations",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "child_invitations_invited_by_user_id_fk": {
+          "name": "child_invitations_invited_by_user_id_fk",
+          "tableFrom": "child_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "child_invitations_token_hash_unique": {
+          "name": "child_invitations_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_child_created_idx": {
+          "name": "audit_log_child_created_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_actor_id_idx": {
+          "name": "audit_log_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_id_user_id_fk": {
+          "name": "audit_log_actor_id_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_log_child_id_children_id_fk": {
+          "name": "audit_log_child_id_children_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1778238845539,
       "tag": "0028_naive_squirrel_girl",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1778239325131,
+      "tag": "0029_large_iron_monger",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/audit-log.ts
+++ b/packages/db/src/schema/audit-log.ts
@@ -1,0 +1,49 @@
+import { pgTable, text, timestamp, index } from "drizzle-orm/pg-core";
+import { user } from "./users";
+import { children } from "./children";
+import { encryptedText } from "../lib/encrypted-text";
+
+// Append-only ledger of who-did-what against a child. Surfaces in the
+// "Activité récente" tab so co-parents stay in the loop on each other's
+// edits — the durable answer to "did Sophie note last night's crisis?".
+//
+// summary is encrypted at rest because it can contain personal details
+// (e.g. "Crise notée le 4 mars" or "Médicament Concerta noté"). actor_id
+// is text (not FK) so deleting a user does not nuke the household's
+// activity record — we want the row to outlive the actor.
+export const auditLog = pgTable("audit_log", {
+  id: text("id")
+    .primaryKey()
+    .$defaultFn(() => crypto.randomUUID()),
+  actorId: text("actor_id").references(() => user.id, {
+    onDelete: "set null",
+  }),
+  // Free-form snapshot of the actor's display name at write time, so the
+  // feed remains readable even if the user record is later deleted.
+  actorName: text("actor_name"),
+  childId: text("child_id").references(() => children.id, {
+    onDelete: "cascade",
+  }),
+  entityType: text("entity_type", {
+    enum: [
+      "child",
+      "symptom",
+      "journal",
+      "medication",
+      "medication_log",
+      "crisis_item",
+      "child_access",
+      "child_invitation",
+    ],
+  }).notNull(),
+  entityId: text("entity_id"),
+  action: text("action", {
+    enum: ["create", "update", "delete", "accept", "revoke"],
+  }).notNull(),
+  summary: encryptedText("summary"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+}, (t) => [
+  // Recent-activity feed query: per-child reverse-chronological.
+  index("audit_log_child_created_idx").on(t.childId, t.createdAt),
+  index("audit_log_actor_id_idx").on(t.actorId),
+]);

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -15,3 +15,4 @@ export * from "./roadmap";
 export * from "./push-subscriptions";
 export * from "./child-access";
 export * from "./child-invitations";
+export * from "./audit-log";


### PR DESCRIPTION
## Why

Now that two adults can share a child's carnet (#107), the natural next question is "who did what?". Today there's no answer. This adds a per-child activity feed surfaced as a tab in the existing share-access dialog, so a co-parent can see at a glance whether the other parent already noted last night's crisis, sent the email to the doctor, or revoked someone's access.

## What ships

**Schema (migration 0029):**
- `audit_log(id, actor_id, actor_name, child_id, entity_type, entity_id, action, summary, created_at)`
- `actor_id` is `ON DELETE SET NULL` so the row outlives the actor. `actor_name` is a snapshot at write-time so the feed stays readable even after deletion (no more orphan "—" rows).
- `summary` uses `encryptedText` (AES-256-GCM, same custom type as `children.name`) — can carry "Crise notée le 4 mars" or a medication name, both health-personal.
- Indexes on `(child_id, created_at)` for the feed query and on `actor_id`.

**API:**
- `logAudit()` helper in `apps/api/src/lib/audit.ts`. Fire-and-forget; swallows its own errors so a failed audit insert can never roll back the user's mutation.
- `GET /api/audit-log/child/:childId` — owner OR co-parent reads. Returns the actor name snapshot, falling back to the user's current name (LEFT JOIN `users`) if the snapshot is null (older rows).
- Wired into the mutating handlers of: `children` (PATCH/DELETE), `symptoms` (POST/PATCH/DELETE), `journal` (POST/PATCH/DELETE), `medications` (POST/PATCH/DELETE + medication_log POST), `crisis-list` (POST/PATCH/DELETE), `child-invitations` (POST `/`, POST `/:token/accept`), `child-access` (DELETE).

**Web:**
- `useAuditLogForChild` hook (React Query).
- `RecentActivity` component with icon-per-entity-type and relative-time ("à l'instant", "il y a 3 min", "hier") + exact timestamp on hover.
- `CoParentSection` now has two tabs — **Membres** (existing) and **Activité récente** (new) — both mount inside the existing Dialog opened from the child kebab menu's "Partager l'accès" entry.
- i18n keys: `auditLog.*` + `childAccess.tabMembers` / `childAccess.tabActivity` in `fr.json` and `en.json`.

## Out of scope (deliberately)

- Row-level field diffs. PATCH summaries are coarse ("Profil mis à jour"). The feed is a UX affordance for the co-parent loop, not a forensic ledger — surfacing every changed-field would drown the relevant signal.
- Tamper-evidence (Merkle, hash chain). Same reasoning: this is not a security audit log. If the threat model later grows, a separate immutable-store can be layered on.
- Retention policy. Rows accumulate forever for now. A pruning job (e.g. drop > 365 days when household size > 1) is a follow-up.
- Read events. Only mutations are logged.

## Test plan

- [x] `pnpm typecheck && pnpm test` clean (api + web)
- [ ] Manual: owner A logs a symptom → A opens share-access → "Activité récente" tab shows the entry attributed to A
- [ ] Manual: A invites B → B accepts → A sees both "Invitation envoyée à B" and "B a accepté l'invitation" rows
- [ ] Manual: B (co-parent) edits a journal entry → A sees the row attributed to B
- [ ] Manual: delete user B → A still sees B's historical rows (with snapshot name preserved)

## Follow-ups (not blocking)

- A "Notify when co-parent acts" toggle (Web Push using existing infra).
- Per-action filtering in the UI (currently a flat list of 50).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GV6nAnqmbup46xSXFgaPNf)_