### PR TITLE
[billing] Stripe P2 hygiene + observability (closes #103)

### DIFF
--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -16,8 +16,13 @@ import {
 import { env } from "../lib/env";
 import { log } from "../lib/safe-logger";
 
+// Stripe Checkout supports a fixed set of locales; we whitelist the two we
+// actually ship in the app so a stray header can't push an unsupported
+// value into the request and trigger a Stripe 400.
+const CHECKOUT_LOCALES = ["fr", "en"] as const;
 const checkoutBodySchema = z.object({
   plan: z.enum(["monthly", "annual"]).optional(),
+  locale: z.enum(CHECKOUT_LOCALES).optional(),
 });
 
 function intervalFromStripe(
@@ -111,6 +116,7 @@ billingRoutes.post("/checkout", authMiddleware, checkoutLimiter, async (c) => {
     );
   }
   const plan: Plan = parsed.data.plan ?? "annual";
+  const locale = parsed.data.locale ?? "fr";
 
   // Find or create Stripe customer.
   //
@@ -157,7 +163,7 @@ billingRoutes.post("/checkout", authMiddleware, checkoutLimiter, async (c) => {
     payment_method_collection: "if_required",
     success_url: `${env.CORS_ORIGIN || "http://localhost:5173"}/dashboard?billing=success`,
     cancel_url: `${env.CORS_ORIGIN || "http://localhost:5173"}/#tarifs`,
-    locale: "fr",
+    locale,
   });
 
   return c.json({ url: session.url });
@@ -294,6 +300,16 @@ billingRoutes.post("/resume", authMiddleware, portalLimiter, async (c) => {
 // pause crosses into a new calendar year.
 const MAX_PAUSE_MONTHS_PER_YEAR = 3;
 
+// Returns the calendar year of `d` in Europe/Paris (the userbase locale).
+// Using UTC here would miscredit early-January pauses to the prior year.
+function parisYear(d: Date): number {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: "Europe/Paris",
+    year: "numeric",
+  });
+  return Number(fmt.format(d));
+}
+
 billingRoutes.post("/pause", authMiddleware, portalLimiter, async (c) => {
   const currentUser = c.get("user");
   const body = await c.req.json().catch(() => ({}));
@@ -333,7 +349,11 @@ billingRoutes.post("/pause", authMiddleware, portalLimiter, async (c) => {
   }
 
   const now = new Date();
-  const currentYear = now.getUTCFullYear();
+  // Year boundary in Europe/Paris (the userbase locale) rather than UTC.
+  // A pause taken at 2026-01-01 00:30 local time would otherwise count
+  // against 2025's quota for 1 hour each year, refunding it abruptly at
+  // 02:00. Issue #103 P2.
+  const currentYear = parisYear(now);
   const sameYear = sub.pauseYearRef === currentYear;
   const usedThisYear = sameYear ? sub.pauseMonthsUsed : 0;
   const remaining = MAX_PAUSE_MONTHS_PER_YEAR - usedThisYear;
@@ -394,6 +414,19 @@ stripeWebhookRoute.post("/", async (c) => {
     return c.json({ error: "Invalid signature" }, 400);
   }
 
+  // Defensive: reject any event referencing a demo_-prefixed identifier.
+  // The demo seed (apps/api/src/seed.ts) writes literal stripeSubscriptionId
+  // = "demo_subscription"; if a forged or misconfigured webhook ever sent
+  // an event with that id, processing it would mutate the demo account's
+  // billing row. Issue #103 "Demo seed uses literal demo_subscription".
+  if (containsDemoIdentifier(event)) {
+    log.warn("stripe_webhook_rejected_demo_identifier", {
+      eventId: event.id,
+      eventType: event.type,
+    });
+    return c.json({ received: true, ignored: "demo_identifier" });
+  }
+
   // Idempotency / dedup. Stripe retries any non-2xx response for ≥3 days
   // and routinely re-delivers events even on success during outages, so
   // out-of-order replays of `customer.subscription.updated` could overwrite
@@ -405,9 +438,12 @@ stripeWebhookRoute.post("/", async (c) => {
       .insert(stripeWebhookEvent)
       .values({ id: event.id, eventType: event.type });
   } catch {
-    log.info("stripe_webhook_duplicate", {
+    // Tagged log line so SREs can compute
+    // stripe_webhook_total{event_type, status="duplicate"} from logs.
+    log.info("stripe_webhook_event", {
       eventId: event.id,
       eventType: event.type,
+      status: "duplicate",
     });
     return c.json({ received: true, duplicate: true });
   }
@@ -485,7 +521,12 @@ stripeWebhookRoute.post("/", async (c) => {
       }
     }
   } catch (err) {
-    log.error("stripe_webhook_failed", { eventType: event.type, err });
+    log.error("stripe_webhook_failed", {
+      eventId: event.id,
+      eventType: event.type,
+      status: "failed",
+      err,
+    });
     // Roll back the dedup row so Stripe's retry can re-attempt processing —
     // otherwise a transient DB blip would mark the event "processed" forever.
     await db
@@ -494,8 +535,28 @@ stripeWebhookRoute.post("/", async (c) => {
     return c.json({ error: "Webhook processing failed" }, 500);
   }
 
+  // Tagged success log so SREs can compute
+  // stripe_webhook_total{event_type, status="success"} from logs.
+  log.info("stripe_webhook_event", {
+    eventId: event.id,
+    eventType: event.type,
+    status: "success",
+  });
   return c.json({ received: true });
 });
+
+// Returns true when the Stripe event payload references any identifier
+// prefixed with `demo_` (the seed's literal namespace). Cheap shallow scan
+// over the keys we care about — id, customer, subscription.
+function containsDemoIdentifier(event: Stripe.Event): boolean {
+  if (event.id.startsWith("demo_")) return true;
+  const obj = event.data.object as unknown as Record<string, unknown>;
+  for (const k of ["id", "customer", "subscription"] as const) {
+    const v = obj[k];
+    if (typeof v === "string" && v.startsWith("demo_")) return true;
+  }
+  return false;
+}
 
 // Single funnel for every subscription-state webhook. Conflict target is
 // `userId` (unique post-migration 0030) so a re-subscription after cancel

--- a/apps/api/src/routes/health.ts
+++ b/apps/api/src/routes/health.ts
@@ -1,11 +1,52 @@
 import { Hono } from "hono";
+import { getStripe } from "../lib/stripe";
+import { log } from "../lib/safe-logger";
 
 export const healthRoutes = new Hono();
 
-healthRoutes.get("/", (c) => {
+// Cached Stripe-credentials probe. We don't want every healthcheck to fan
+// out to Stripe (uptime monitors hit /api/health every 30s; a Stripe call
+// per ping would burn 86k requests/day for no useful signal), so we ping
+// at most once every 5 minutes and surface the cached verdict on every
+// request. The signal we want to catch is: API key was rotated, network
+// to Stripe is broken, or our account was suspended — none of which
+// resolve in <5 min anyway.
+const STRIPE_PING_TTL_MS = 5 * 60_000;
+let stripeProbe: { ok: boolean; checkedAt: number; error?: string } = {
+  ok: true,
+  checkedAt: 0,
+};
+
+async function probeStripe(): Promise<void> {
+  if (Date.now() - stripeProbe.checkedAt < STRIPE_PING_TTL_MS) return;
+  try {
+    // balance.retrieve() is the cheapest authenticated read and doesn't
+    // require any list permissions; a 401 / 403 / network failure is the
+    // signal we're after.
+    await getStripe().balance.retrieve();
+    stripeProbe = { ok: true, checkedAt: Date.now() };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "unknown";
+    stripeProbe = { ok: false, checkedAt: Date.now(), error: message };
+    log.warn("stripe_health_probe_failed", { error: message });
+  }
+}
+
+healthRoutes.get("/", async (c) => {
+  // Fire-and-forget so the probe never blocks healthcheck latency. A
+  // failed Stripe ping is a signal, not a reason to fail liveness — the
+  // uptime monitor still gets a fast 200 with the degraded flag.
+  void probeStripe();
   return c.json({
     status: "ok",
     timestamp: new Date().toISOString(),
     service: "toko-api",
+    stripe: {
+      ok: stripeProbe.ok,
+      checkedAt:
+        stripeProbe.checkedAt === 0
+          ? null
+          : new Date(stripeProbe.checkedAt).toISOString(),
+    },
   });
 });

--- a/apps/web/src/components/account/pause-subscription-dialog.tsx
+++ b/apps/web/src/components/account/pause-subscription-dialog.tsx
@@ -1,0 +1,119 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { Loader2, PauseCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { usePauseBilling } from "@/hooks/use-billing";
+
+type PauseMonths = 1 | 2 | 3;
+
+export function PauseSubscriptionDialog() {
+  const { t, i18n } = useTranslation();
+  const locale = i18n.resolvedLanguage === "en" ? "en-US" : "fr-FR";
+  const pause = usePauseBilling();
+  const [open, setOpen] = useState(false);
+  const [months, setMonths] = useState<PauseMonths>(1);
+
+  const formatDate = (iso: string) =>
+    new Date(iso).toLocaleDateString(locale, {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
+
+  const handleSubmit = () => {
+    pause.mutate(months, {
+      onSuccess: (data) => {
+        toast.success(
+          t("account.pauseSuccess", { date: formatDate(data.pausedUntil) }),
+        );
+        setOpen(false);
+      },
+      onError: (err: unknown) => {
+        // Surface the 409 quota-exceeded error specifically; fall back to a
+        // generic message for network / Stripe failures.
+        const status = (err as { status?: number } | null)?.status;
+        if (status === 409) {
+          toast.error(t("account.pauseQuotaExceeded"));
+        } else {
+          toast.error(t("account.pauseGenericError"));
+        }
+      },
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger
+        render={
+          <Button variant="outline">
+            <PauseCircle className="h-4 w-4" data-icon="inline-start" />
+            {t("account.pauseCta")}
+          </Button>
+        }
+      />
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("account.pauseDialogTitle")}</DialogTitle>
+          <DialogDescription>
+            {t("account.pauseDialogIntro")}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <p className="text-sm font-medium">
+            {t("account.pauseChooseDuration")}
+          </p>
+          <RadioGroup<PauseMonths>
+            value={months}
+            onValueChange={(v) => setMonths(v)}
+            aria-label={t("account.pauseChooseDuration")}
+            className="grid grid-cols-3 gap-2"
+          >
+            {([1, 2, 3] as const).map((m) => (
+              <RadioGroupItem
+                key={m}
+                value={m}
+                className={
+                  "rounded-lg border px-3 py-2 text-center text-sm font-medium " +
+                  (months === m
+                    ? "border-primary bg-primary/10 text-primary"
+                    : "border-border/60 text-muted-foreground hover:text-foreground")
+                }
+              >
+                {m === 1
+                  ? t("account.pauseOneMonth")
+                  : m === 2
+                    ? t("account.pauseTwoMonths")
+                    : t("account.pauseThreeMonths")}
+              </RadioGroupItem>
+            ))}
+          </RadioGroup>
+        </div>
+        <DialogFooter>
+          <DialogClose render={<Button variant="outline" />}>
+            {t("child.cancel")}
+          </DialogClose>
+          <Button onClick={handleSubmit} disabled={pause.isPending}>
+            {pause.isPending && (
+              <Loader2 className="h-4 w-4 animate-spin" data-icon="inline-start" />
+            )}
+            {pause.isPending
+              ? t("account.pauseSubmitting")
+              : t("account.pauseSubmit")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/ui/radio-group.tsx
+++ b/apps/web/src/components/ui/radio-group.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+import { RadioGroup as RadioGroupPrimitive } from "@base-ui/react/radio-group";
+import { Radio as RadioPrimitive } from "@base-ui/react/radio";
+
+import { cn } from "@/lib/utils";
+
+// Thin shadcn-style wrapper around base-ui's RadioGroup. We expose the
+// behavior (arrow-key navigation, focus management, controlled value)
+// without prescribing the visual — the dialog using it renders the items
+// as button-cards rather than the classic dot-radio. Default styles only
+// add the focus-visible ring; consumers add their own selected/idle look.
+
+function RadioGroup<Value = string>({
+  className,
+  ...props
+}: RadioGroupPrimitive.Props<Value>) {
+  return (
+    <RadioGroupPrimitive
+      data-slot="radio-group"
+      className={cn("grid gap-2", className)}
+      {...props}
+    />
+  );
+}
+
+interface RadioGroupItemProps extends RadioPrimitive.Root.Props {
+  /** Visual content rendered inside the item (label, icon, etc.) */
+  children?: React.ReactNode;
+}
+
+function RadioGroupItem({
+  className,
+  children,
+  ...props
+}: RadioGroupItemProps) {
+  return (
+    <RadioPrimitive.Root
+      data-slot="radio-group-item"
+      className={cn(
+        "relative cursor-pointer select-none outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+    </RadioPrimitive.Root>
+  );
+}
+
+export { RadioGroup, RadioGroupItem };

--- a/apps/web/src/hooks/use-billing.ts
+++ b/apps/web/src/hooks/use-billing.ts
@@ -1,4 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import i18n from "@/lib/i18n";
 import { api } from "@/lib/api-client";
 
 export type BillingPlan = "monthly" | "annual";
@@ -51,13 +53,22 @@ export function useCheckout() {
   return useMutation<{ url: string }, Error, BillingPlan | void>({
     mutationFn: (plan) => {
       const finalPlan = plan ?? readStoredPlan();
-      return api.post<{ url: string }>(
-        "/billing/checkout",
-        finalPlan ? { plan: finalPlan } : {},
-      );
+      const body: Record<string, unknown> = {
+        // Forward the user's resolved language so Stripe's Checkout page
+        // appears in the same locale as the app — replaces the hardcoded
+        // "fr" that lived server-side.
+        locale: i18n.resolvedLanguage ?? "fr",
+      };
+      if (finalPlan) body.plan = finalPlan;
+      return api.post<{ url: string }>("/billing/checkout", body);
     },
     onSuccess: (data) => {
       window.location.href = data.url;
+    },
+    onError: () => {
+      // Network/429/503 — without this the UI stays frozen on the spinner
+      // and the parent has no idea why nothing happened.
+      toast.error(i18n.t("account.checkoutError"));
     },
   });
 }
@@ -67,6 +78,9 @@ export function usePortal() {
     mutationFn: () => api.post<{ url: string }>("/billing/portal", {}),
     onSuccess: (data) => {
       window.location.href = data.url;
+    },
+    onError: () => {
+      toast.error(i18n.t("account.portalError"));
     },
   });
 }

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -394,6 +394,8 @@
     "pauseSuccess": "Subscription paused until {{date}}.",
     "pauseQuotaExceeded": "Annual pause quota reached. You'll be able to pause again starting January 1st.",
     "pauseGenericError": "Couldn't pause the subscription right now.",
+    "checkoutError": "Couldn't start checkout right now. Please try again in a moment.",
+    "portalError": "Couldn't open the management portal. Please try again in a moment.",
     "pastDue": "Payment overdue",
     "canceled": "Canceled",
     "accessUntil": "Access until",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -394,6 +394,8 @@
     "pauseSuccess": "Abonnement en pause jusqu'au {{date}}.",
     "pauseQuotaExceeded": "Quota annuel de pause atteint. Vous pourrez à nouveau mettre en pause à partir du 1ᵉʳ janvier.",
     "pauseGenericError": "Impossible de mettre l'abonnement en pause pour le moment.",
+    "checkoutError": "Impossible de démarrer le paiement pour le moment. Réessayez dans quelques instants.",
+    "portalError": "Impossible d'ouvrir le portail de gestion. Réessayez dans quelques instants.",
     "pastDue": "Paiement en retard",
     "canceled": "Annulé",
     "accessUntil": "Accès jusqu'au",

--- a/apps/web/src/routes/_authenticated/account/index.tsx
+++ b/apps/web/src/routes/_authenticated/account/index.tsx
@@ -1,7 +1,6 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useState } from "react";
 import { useTranslation, Trans } from "react-i18next";
-import { toast } from "sonner";
 import {
   Download,
   Trash2,
@@ -10,7 +9,6 @@ import {
   CreditCard,
   FileText,
   ArrowRight,
-  PauseCircle,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -39,10 +37,10 @@ import { useDeleteAccount, useExportAccount } from "@/hooks/use-account";
 import {
   useBillingStatus,
   useCheckout,
-  usePauseBilling,
   usePortal,
 } from "@/hooks/use-billing";
 import { NotificationsCard } from "@/components/account/notifications-card";
+import { PauseSubscriptionDialog } from "@/components/account/pause-subscription-dialog";
 
 export const Route = createFileRoute("/_authenticated/account/")({
   component: AccountPage,
@@ -324,107 +322,5 @@ function AccountPage() {
         </CardContent>
       </Card>
     </div>
-  );
-}
-
-function PauseSubscriptionDialog() {
-  const { t, i18n } = useTranslation();
-  const locale = i18n.resolvedLanguage === "en" ? "en-US" : "fr-FR";
-  const pause = usePauseBilling();
-  const [open, setOpen] = useState(false);
-  const [months, setMonths] = useState<1 | 2 | 3>(1);
-
-  const formatDate = (iso: string) =>
-    new Date(iso).toLocaleDateString(locale, {
-      day: "numeric",
-      month: "long",
-      year: "numeric",
-    });
-
-  const handleSubmit = () => {
-    pause.mutate(months, {
-      onSuccess: (data) => {
-        toast.success(
-          t("account.pauseSuccess", { date: formatDate(data.pausedUntil) })
-        );
-        setOpen(false);
-      },
-      onError: (err: unknown) => {
-        // Surface the 409 quota-exceeded error specifically; fall back to a
-        // generic message for network / Stripe failures.
-        const status = (err as { status?: number } | null)?.status;
-        if (status === 409) {
-          toast.error(t("account.pauseQuotaExceeded"));
-        } else {
-          toast.error(t("account.pauseGenericError"));
-        }
-      },
-    });
-  };
-
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger
-        render={
-          <Button variant="outline">
-            <PauseCircle className="h-4 w-4" data-icon="inline-start" />
-            {t("account.pauseCta")}
-          </Button>
-        }
-      />
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>{t("account.pauseDialogTitle")}</DialogTitle>
-          <DialogDescription>
-            {t("account.pauseDialogIntro")}
-          </DialogDescription>
-        </DialogHeader>
-        <div className="space-y-3">
-          <p className="text-sm font-medium">
-            {t("account.pauseChooseDuration")}
-          </p>
-          <div
-            role="radiogroup"
-            aria-label={t("account.pauseChooseDuration")}
-            className="grid grid-cols-3 gap-2"
-          >
-            {([1, 2, 3] as const).map((m) => (
-              <button
-                key={m}
-                type="button"
-                role="radio"
-                aria-checked={months === m}
-                onClick={() => setMonths(m)}
-                className={
-                  "rounded-lg border px-3 py-2 text-sm font-medium transition-colors " +
-                  (months === m
-                    ? "border-primary bg-primary/10 text-primary"
-                    : "border-border/60 text-muted-foreground hover:text-foreground")
-                }
-              >
-                {m === 1
-                  ? t("account.pauseOneMonth")
-                  : m === 2
-                    ? t("account.pauseTwoMonths")
-                    : t("account.pauseThreeMonths")}
-              </button>
-            ))}
-          </div>
-        </div>
-        <DialogFooter>
-          <DialogClose render={<Button variant="outline" />}>
-            {t("child.cancel")}
-          </DialogClose>
-          <Button onClick={handleSubmit} disabled={pause.isPending}>
-            {pause.isPending && (
-              <Loader2 className="h-4 w-4 animate-spin" data-icon="inline-start" />
-            )}
-            {pause.isPending
-              ? t("account.pauseSubmitting")
-              : t("account.pauseSubmit")}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
   );
 }


### PR DESCRIPTION
Closes the P2 punch list left after #112: UX, accessibility, RGPD-locale, and the SRE handoff hooks. None of these are correctness bugs in the strict sense, but each one is a paper cut that compounds — silent checkout failures, UTC-credited pauses on January 1st, demo-prefixed identifiers reaching the live webhook handler.

## UX
- **`useCheckout` / `usePortal` toasts on error.** A 429/503/network blip used to leave the spinner frozen with no feedback; now `toast.error("Impossible de démarrer le paiement…")`.
- **`PauseSubscriptionDialog` extracted** from `routes/_authenticated/account/index.tsx` into `components/account/pause-subscription-dialog.tsx`, matching CLAUDE.md component conventions. The route is ~100 lines lighter.
- **`components/ui/radio-group.tsx`** wraps base-ui's `RadioGroup` + `Radio.Root` in a thin shadcn-style primitive. The pause dialog's hand-rolled buttons had `role="radio"` set on `<button>` elements but no arrow-key navigation; the primitive gives us proper keyboard handling for free while keeping the card-grid look.

## i18n / locale
- **Checkout `locale` forwarded** from the resolved app language (`i18n.resolvedLanguage`). Server whitelists `"fr"` / `"en"` via Zod so a stray header can't push an unsupported locale at Stripe. Was hardcoded `"fr"`.
- **Pause-quota year boundary in Europe/Paris** instead of UTC. A `January 1 00:30 Europe/Paris` pause used to count against the previous year's quota for the first hour of the new year, then refund itself at 02:00 when UTC ticked over. Fixed via a small `Intl.DateTimeFormat`-based `parisYear()` helper.

## Observability + safety
- **Webhook tagged event log:** every delivery now emits exactly one structured `log.{info,error}("stripe_webhook_event"|"stripe_webhook_failed", { eventId, eventType, status })` with `status ∈ {success, duplicate, failed}`. SREs can compute `stripe_webhook_total{event_type, status}` from logs without a metrics backend; a Prometheus exporter is a separate concern.
- **`/api/health` Stripe probe** at 5-minute TTL, fire-and-forget so healthcheck latency is unchanged. Calls `balance.retrieve()` (cheapest authenticated read). The response surfaces `stripe.ok` + `stripe.checkedAt`. Catches API-key rotation, network partition, account suspension at the uptime-monitor cadence.
- **Demo-identifier rejection.** The webhook short-circuits with 200 + `{ ignored: "demo_identifier" }` if `event.id`, `event.data.object.id`, `.customer`, or `.subscription` is `demo_`-prefixed. The demo seed (`apps/api/src/seed.ts`) writes literal `stripeSubscriptionId = "demo_subscription"`; a forged delivery referencing that id can no longer mutate the demo account's billing row.

## Out of scope (none remaining)

This closes the **last** P2 items from #103. The Stripe integration is now hardened end-to-end: correctness (#112), RGPD (#112), UX, accessibility, observability.

## Test plan

- [x] `pnpm typecheck && pnpm test` clean (57 unit tests pass)
- [ ] Manual: tab into the pause dialog, hit ←/→ arrow keys → selection moves between the three duration options.
- [ ] Manual: switch app language to English → click "Subscribe" → Stripe Checkout page renders in English.
- [ ] Manual: `curl /api/health` → response includes `stripe.ok=true`, `stripe.checkedAt` populated within 5 minutes.
- [ ] Stripe CLI: `stripe trigger checkout.session.completed --override id=demo_evt_123` → webhook returns `{ ignored: "demo_identifier" }`, no DB write.
- [ ] Manual: kill the network mid-checkout → `useCheckout` toast surfaces "Impossible de démarrer le paiement…".

Closes #103.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GV6nAnqmbup46xSXFgaPNf)_