### PR TITLE
[mobile] Mobile-first audit follow-ups (closes #77)

### DIFF
--- a/apps/web/src/components/account/notifications-card.tsx
+++ b/apps/web/src/components/account/notifications-card.tsx
@@ -7,6 +7,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
 import { usePreferences, useUpdatePreferences } from "@/hooks/use-preferences";
 
 export function NotificationsCard() {
@@ -36,15 +37,14 @@ export function NotificationsCard() {
               {t("notifications.dailyReminderBody")}
             </p>
           </div>
-          <input
+          <Checkbox
             id="daily-reminder"
-            type="checkbox"
+            className="h-5 w-5"
             checked={data.dailyReminderOptIn}
             disabled={update.isPending}
-            onChange={(e) =>
-              update.mutate({ dailyReminderOptIn: e.target.checked })
+            onCheckedChange={(checked) =>
+              update.mutate({ dailyReminderOptIn: checked === true })
             }
-            className="h-5 w-5 shrink-0 cursor-pointer accent-primary"
           />
         </label>
         <label
@@ -57,15 +57,14 @@ export function NotificationsCard() {
               {t("notifications.weeklyDigestBody")}
             </p>
           </div>
-          <input
+          <Checkbox
             id="weekly-digest"
-            type="checkbox"
+            className="h-5 w-5"
             checked={data.weeklyDigestOptIn}
             disabled={update.isPending}
-            onChange={(e) =>
-              update.mutate({ weeklyDigestOptIn: e.target.checked })
+            onCheckedChange={(checked) =>
+              update.mutate({ weeklyDigestOptIn: checked === true })
             }
-            className="h-5 w-5 shrink-0 cursor-pointer accent-primary"
           />
         </label>
       </CardContent>

--- a/apps/web/src/components/barkley/behavior-tracking.tsx
+++ b/apps/web/src/components/barkley/behavior-tracking.tsx
@@ -459,7 +459,7 @@ function SortableBehaviorRow({
               className={`flex h-8 w-8 items-center justify-center rounded-full transition-all ${
                 checked
                   ? "scale-110"
-                  : "hover:bg-muted/50 hover:scale-105"
+                  : "hover:bg-muted/50 hover:scale-105 active:bg-muted/50 active:scale-105"
               }`}
               disabled={togglePending}
               title={checked ? t("behaviorTracking.removeStar") : t("behaviorTracking.addStar")}
@@ -563,7 +563,7 @@ function SortableBehaviorCard({
                   className={`flex min-w-0 flex-1 flex-col items-center gap-0.5 rounded-lg px-1.5 py-1.5 transition-all ${
                     checked
                       ? "bg-warning-surface"
-                      : "hover:bg-muted/50"
+                      : "hover:bg-muted/50 active:bg-muted/50"
                   }`}
                   disabled={togglePending}
                 >

--- a/apps/web/src/components/barkley/quiz-state-classes.ts
+++ b/apps/web/src/components/barkley/quiz-state-classes.ts
@@ -5,7 +5,7 @@ export const quizAnswerClasses = cva(
   {
     variants: {
       state: {
-        idle: "border-border hover:border-primary/40 hover:bg-muted/50 cursor-pointer",
+        idle: "border-border hover:border-primary/40 hover:bg-muted/50 active:border-primary/40 active:bg-muted/50 cursor-pointer",
         selected: "border-primary bg-primary/5 cursor-pointer",
         correct: "border-success-border bg-success-surface text-success-foreground cursor-default",
         wrong: "border-danger-border bg-danger-surface text-danger-foreground cursor-default",

--- a/apps/web/src/components/dashboard/barkley-progress-card.tsx
+++ b/apps/web/src/components/dashboard/barkley-progress-card.tsx
@@ -26,7 +26,7 @@ export function BarkleyProgressCard() {
       to="/barkley"
       className="block rounded-xl"
     >
-      <Card className="group cursor-pointer transition-all hover:shadow-md hover:border-primary/30">
+      <Card className="group cursor-pointer transition-all hover:shadow-md hover:border-primary/30 active:border-primary/30 active:shadow-md">
         <CardHeader className="flex flex-row items-center justify-between pb-2">
           <CardTitle className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
             <ClipboardList className="h-4 w-4" />

--- a/apps/web/src/components/dashboard/daily-checklist.tsx
+++ b/apps/web/src/components/dashboard/daily-checklist.tsx
@@ -100,7 +100,7 @@ export function DailyChecklist() {
           <Link
             key={item.key}
             to={item.to}
-            className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors hover:bg-accent group"
+            className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm transition-colors hover:bg-accent active:bg-accent group"
           >
             {item.done ? (
               <CheckCircle2 className="h-4.5 w-4.5 shrink-0 text-status-success" />

--- a/apps/web/src/components/emoji-picker.tsx
+++ b/apps/web/src/components/emoji-picker.tsx
@@ -132,7 +132,7 @@ function CatalogPicker({
   };
 
   return (
-    <div className="flex w-72 flex-col gap-2">
+    <div className="flex w-[min(18rem,90vw)] flex-col gap-2">
       {/* Recherche */}
       <input
         type="text"

--- a/apps/web/src/components/shared/share-dialog.tsx
+++ b/apps/web/src/components/shared/share-dialog.tsx
@@ -127,7 +127,7 @@ export function ShareDialog({
                   "rounded-lg border px-3 py-2 text-left text-xs transition-colors " +
                   (tone === t
                     ? "border-primary/40 bg-primary/5 text-foreground"
-                    : "border-border/60 bg-background text-muted-foreground hover:border-primary/20 hover:text-foreground")
+                    : "border-border/60 bg-background text-muted-foreground hover:border-primary/20 hover:text-foreground active:border-primary/20 active:text-foreground")
                 }
               >
                 <span

--- a/apps/web/src/components/symptoms/symptom-form.tsx
+++ b/apps/web/src/components/symptoms/symptom-form.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { AlertTriangle } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
@@ -291,14 +292,13 @@ export function SymptomForm({
         className="flex min-h-12 cursor-pointer items-center justify-between gap-4 rounded-lg border border-border/60 px-3 py-2.5 text-sm"
       >
         <span>{t("symptoms.routinesLabel")}</span>
-        <input
+        <Checkbox
           id="routines-ok"
-          type="checkbox"
+          className="h-5 w-5"
           checked={values.routinesOk}
-          onChange={(e) =>
-            setValues((prev) => ({ ...prev, routinesOk: e.target.checked }))
+          onCheckedChange={(checked) =>
+            setValues((prev) => ({ ...prev, routinesOk: checked === true }))
           }
-          className="h-5 w-5 shrink-0 cursor-pointer accent-primary"
         />
       </label>
 

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox";
+import { Check } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+// shadcn-style wrapper around base-ui's Checkbox. Replaces the bare native
+// <input type="checkbox" className="accent-primary" /> sprinkled around
+// the app — gives us consistent styling, dark-mode parity, and a proper
+// focus ring matching button/input/radio. Issue #77 item 3.
+
+function Checkbox({
+  className,
+  ...props
+}: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer inline-flex h-4 w-4 shrink-0 items-center justify-center rounded border border-input bg-background shadow-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[checked]:border-primary data-[checked]:bg-primary data-[checked]:text-primary-foreground",
+        className,
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="flex items-center justify-center text-current"
+      >
+        <Check className="h-3 w-3" strokeWidth={3} />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  );
+}
+
+export { Checkbox };

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -32,7 +32,8 @@
       "resources": "Resources",
       "pricing": "Pricing",
       "login": "Sign in",
-      "getStarted": "Get started"
+      "getStarted": "Get started",
+      "menu": "Menu"
     },
     "trust": {
       "time": {

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -32,7 +32,8 @@
       "resources": "Ressources",
       "pricing": "Tarifs",
       "login": "Connexion",
-      "getStarted": "Commencer"
+      "getStarted": "Commencer",
+      "menu": "Menu"
     },
     "hero": {
       "title1": "Le carnet TDAH",

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -108,7 +108,8 @@ function AuthenticatedShell() {
         aria-labelledby="page-title"
         className={cn(
           "min-w-0 focus:outline-none",
-          isMobile && "pb-[calc(4.5rem+env(safe-area-inset-bottom))]"
+          isMobile &&
+            "pb-[calc(4.5rem+env(safe-area-inset-bottom))] landscape:max-md:pb-[calc(3.5rem+env(safe-area-inset-bottom))]"
         )}
       >
         <AppHeader />
@@ -298,7 +299,7 @@ function AppHeader() {
   const { t } = useTranslation();
   const hasBreadcrumbs = useBreadcrumbs().length > 0;
   return (
-    <header className="sticky top-0 z-40 flex h-14 shrink-0 items-center gap-3 border-b border-border/60 bg-background/90 px-4 backdrop-blur-lg supports-[backdrop-filter]:bg-background/70 md:px-6 lg:px-8">
+    <header className="sticky top-0 z-40 flex h-14 shrink-0 items-center gap-3 border-b border-border/60 bg-background/90 px-4 backdrop-blur-lg supports-[backdrop-filter]:bg-background/70 md:px-6 lg:px-8 landscape:max-md:h-10">
       <SidebarTrigger
         aria-label={t("nav.toggleSidebar")}
         className="-ml-1"
@@ -341,7 +342,7 @@ function MobileTabBar() {
                 aria-current={isActive ? "page" : undefined}
                 aria-label={t(item.labelKey)}
                 className={cn(
-                  "flex h-full min-h-14 flex-col items-center justify-center gap-1 px-1 py-1.5 text-xs font-medium transition-colors",
+                  "flex h-full min-h-14 flex-col items-center justify-center gap-1 px-1 py-1.5 text-xs font-medium transition-colors landscape:max-md:min-h-10 landscape:max-md:gap-0",
                   isActive
                     ? "text-primary"
                     : "text-muted-foreground hover:text-foreground"
@@ -358,7 +359,7 @@ function MobileTabBar() {
             type="button"
             onClick={() => setOpenMobile(true)}
             aria-label={t("nav.moreOptions")}
-            className="flex h-full min-h-14 w-full flex-col items-center justify-center gap-1 px-1 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+            className="flex h-full min-h-14 w-full flex-col items-center justify-center gap-1 px-1 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground active:text-foreground landscape:max-md:min-h-10 landscape:max-md:gap-0"
           >
             <Menu className="h-5 w-5" aria-hidden="true" />
             <span className="line-clamp-1 leading-tight">{t("nav.more")}</span>

--- a/apps/web/src/routes/_authenticated/medications/index.tsx
+++ b/apps/web/src/routes/_authenticated/medications/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { Plus, Pencil, Trash2, Pill } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -287,12 +288,11 @@ function MedicationForm({
           className="flex min-h-12 cursor-pointer items-center justify-between gap-4 rounded-lg border border-border/60 px-3 py-2.5 text-sm"
         >
           <span>{t("medications.activeLabel")}</span>
-          <input
+          <Checkbox
             id="med-active"
-            type="checkbox"
+            className="h-5 w-5"
             checked={active}
-            onChange={(e) => setActive(e.target.checked)}
-            className="h-5 w-5 shrink-0 cursor-pointer accent-primary"
+            onCheckedChange={(checked) => setActive(checked === true)}
           />
         </label>
       )}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -15,6 +15,7 @@ import {
   Sparkles,
   Quote,
   Clock,
+  Menu,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -27,6 +28,14 @@ import {
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+  SheetClose,
+} from "@/components/ui/sheet";
 import { authClient } from "@/lib/auth-client";
 import { articles } from "@/lib/resources-data";
 
@@ -134,9 +143,83 @@ function Nav() {
               <ArrowRight className="h-3.5 w-3.5" />
             </Button>
           </Link>
+          <MobileNavSheet />
         </div>
       </div>
     </header>
+  );
+}
+
+// Mobile-only nav drawer. The desktop nav at <sm hides the
+// Features/Resources/Pricing links so the primary "Commencer" CTA gets
+// breathing room — without this drawer, mobile visitors had no way to
+// reach those anchors short of footer-diving.
+function MobileNavSheet() {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  return (
+    <Sheet open={open} onOpenChange={setOpen}>
+      <SheetTrigger
+        render={
+          <Button
+            variant="ghost"
+            size="icon"
+            className="sm:hidden"
+            aria-label={t("landing.nav.menu")}
+          />
+        }
+      >
+        <Menu className="h-5 w-5" />
+      </SheetTrigger>
+      <SheetContent side="right" className="w-[80%] max-w-xs">
+        <SheetHeader>
+          <SheetTitle>{t("landing.nav.menu")}</SheetTitle>
+        </SheetHeader>
+        <nav className="flex flex-col gap-1 px-2 pb-4 text-sm">
+          <SheetClose
+            render={
+              <a
+                href="#fonctionnalites"
+                className="rounded-md px-3 py-2 text-foreground hover:bg-muted"
+              />
+            }
+          >
+            {t("landing.nav.features")}
+          </SheetClose>
+          <SheetClose
+            render={
+              <Link
+                to="/ressources"
+                className="rounded-md px-3 py-2 text-foreground hover:bg-muted"
+              />
+            }
+          >
+            {t("landing.nav.resources")}
+          </SheetClose>
+          <SheetClose
+            render={
+              <a
+                href="#tarifs"
+                className="rounded-md px-3 py-2 text-foreground hover:bg-muted"
+              />
+            }
+          >
+            {t("landing.nav.pricing")}
+          </SheetClose>
+          <Separator className="my-2" />
+          <SheetClose
+            render={
+              <Link
+                to="/login"
+                className="rounded-md px-3 py-2 font-medium text-foreground hover:bg-muted"
+              />
+            }
+          >
+            {t("landing.nav.login")}
+          </SheetClose>
+        </nav>
+      </SheetContent>
+    </Sheet>
   );
 }
 


### PR DESCRIPTION
Closes the five deferred items from the mobile-first audit (#77). None are correctness bugs, but they're paper cuts that compound on every interaction on a real touch device.

## Item 2 — Landing nav hamburger
- New `MobileNavSheet` (Sheet primitive, `sm:hidden`) on the landing nav exposes Features / Resources / Pricing / Connexion. Without it, mobile visitors had no path to those anchors short of footer-diving (the desktop nav hides them at `<sm` to give the primary "Commencer" CTA breathing room).

## Item 3 — Checkbox primitive
- New `components/ui/checkbox.tsx` wraps `@base-ui/react/checkbox` in the shadcn pattern (focus ring matching button/input/radio, dark-mode parity, Lucide check indicator).
- Migrates the three native `<input type="checkbox" className="accent-primary">` callsites:
  - `components/account/notifications-card.tsx` (2 boxes)
  - `components/symptoms/symptom-form.tsx` (1)
  - `routes/_authenticated/medications/index.tsx` (1)
- The `<label>` click-target wrappers stay (still gives the row-wide tap area noted in the audit).

## Item 4 — Landscape chrome
- Header gets `landscape:max-md:h-10`, tab bar items get `landscape:max-md:min-h-10`. Recovers ~32px on iPhone SE in landscape (h-14 → h-10). Outlet's bottom-padding offset shrinks to match (`4.5rem` → `3.5rem`).

## Item 5 — Emoji picker grid cap
- Container width: `w-72` → `w-[min(18rem,90vw)]`. The 8-column grid no longer overflows on screens <288px.

## Item 1 — Targeted hover/focus parity sweep
Adds `active:` twins to the highest-traffic interactive surfaces — the daily-interaction touchpoints flagged in the audit:
- `components/barkley/quiz-state-classes.ts:8` — quiz answer idle state (daily check-in)
- `components/barkley/behavior-tracking.tsx:462,566` — behavior toggle stars (kid-side daily interaction)
- `components/dashboard/barkley-progress-card.tsx:29` — `Card` cursor-pointer
- `components/dashboard/daily-checklist.tsx:103` — list row
- `components/shared/share-dialog.tsx:130` — tone-radio choice

A broader sweep across all 129 `hover:` usages (or wrapping decorative-only hover in a `@media (hover: hover)` Tailwind variant) remains as a future audit pass — this PR covers the highest-value daily-interaction surfaces, where real touch users feel the lack of feedback most.

## i18n
- Adds `landing.nav.menu` in fr + en for the hamburger button label.

## Test plan

- [x] `pnpm typecheck && pnpm test` clean
- [ ] Manual: open `/` on mobile (<sm) → tap hamburger → drawer opens with Features/Resources/Pricing/Connexion. Tap a link → drawer closes, anchor scrolls.
- [ ] Manual: rotate iPhone SE simulator to landscape → header + tab bar shrink to `h-10` / `min-h-10`, content area gains ~32px.
- [ ] Manual: open emoji picker on a 280px-wide simulated viewport → no horizontal scroll, picker fits within `90vw`.
- [ ] Manual: tap (don't hover) the dashboard's Barkley card / a daily-checklist row → see the active-state visual feedback during the tap.
- [ ] Manual: notification toggles on `/account` toggle correctly, symptom-form routines checkbox persists, medications "actif" toggle saves.

Closes #77.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GV6nAnqmbup46xSXFgaPNf)_