### PR TITLE
fix(ci): release detector now matches [scope] titles too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,13 @@ jobs:
           elif echo "$FIRST_LINE" | grep -qE "^(fix|perf)(\(.+\))?:"; then
             echo "should_release=true" >> $GITHUB_OUTPUT
             echo "bump_type=patch" >> $GITHUB_OUTPUT
+          elif echo "$FIRST_LINE" | grep -qE "^\[[a-z][a-z0-9-]+\] "; then
+            # Bracketed-scope titles like "[billing] ..." or "[mobile] ..."
+            # don't carry semver intent the way conventional commits do, so
+            # we ship them as a patch by default. To force minor / major,
+            # use workflow_dispatch with version_type=minor|major.
+            echo "should_release=true" >> $GITHUB_OUTPUT
+            echo "bump_type=patch" >> $GITHUB_OUTPUT
           else
             echo "should_release=false" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Why

Today's batch of 7 PRs (#109–#115) all merged to main and **none of them triggered a release**. The bump-type detector at `.github/workflows/release.yml:63-74` only matched conventional-commit prefixes (`feat:`, `fix:`, etc.) and the squash-merge titles all used the `[scope] subject` form (`[billing]`, `[mobile]`, `[push]`, …) which doesn't match.

**Symptom:** `ghcr.io/wifsimster/toko:latest` is still `v0.58.4` (May 1) while `main` is at `c6b918f` (May 8) carrying five unreleased migrations and a Web Push feature. Every merge silently set `should_release=false`.

## Fix

Add a fourth branch to the regex chain that recognises `^\[[a-z][a-z0-9-]+\] ` and ships as `patch`. Bracketed scopes don't carry semver intent — a `[billing]` PR can be either a fix or a feature — so default to the safest bump. Use `workflow_dispatch` with `version_type: minor|major` for the cases where a stronger bump is warranted.

The new branch is **a fallback** — the existing conventional-commit detection still takes precedence and remains the recommended convention. This just means a stray `[scope]` title never silently skips the release again.

## Catch-up release

The 7 already-merged PRs need to ship as a single catch-up. After this PR merges (which itself triggers a `patch` bump → `v0.58.5` via the `fix(ci):` prefix), I'd recommend a manual `workflow_dispatch` of Release with `version_type: minor` to land the cumulative work as `v0.59.0` — five new features + one RGPD compliance fix is a minor at minimum.

Or, if you'd rather not wait, dispatch `version_type: minor` **right now** and merge this PR after — the order doesn't matter, both produce the same end state.

## Test plan

- [ ] Workflow run on this PR is green (lint/typecheck/test).
- [ ] After merge, observe Actions tab → Release workflow fires → version bumps to `v0.58.5` → Docker image published → Deploy workflow runs.
- [ ] Future `[scope]` PR titles trigger releases automatically.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GV6nAnqmbup46xSXFgaPNf)_