### PR TITLE
Remove demo credentials and hint from login form

### DIFF
--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -204,7 +204,6 @@
     "submittingLogin": "Signing in...",
     "submitRegister": "Create my account",
     "submittingRegister": "Signing up...",
-    "demoHint": "Demo account pre-filled — Premium access included",
     "googleContinue": "Continue with Google",
     "googleLoading": "Signing in...",
     "errorInvalid": "Invalid credentials",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -204,7 +204,6 @@
     "submittingLogin": "Connexion...",
     "submitRegister": "Créer mon compte",
     "submittingRegister": "Inscription...",
-    "demoHint": "Compte démo pré-rempli — accès Premium inclus",
     "googleContinue": "Continuer avec Google",
     "googleLoading": "Connexion...",
     "errorInvalid": "Identifiants incorrects",

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -67,15 +67,10 @@ function LoginPage() {
   );
 }
 
-const DEMO_CREDENTIALS = {
-  email: "demo@toko.app",
-  password: "demo1234",
-};
-
 function LoginForm() {
   const { t } = useTranslation();
-  const [email, setEmail] = useState(DEMO_CREDENTIALS.email);
-  const [password, setPassword] = useState(DEMO_CREDENTIALS.password);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -140,9 +135,6 @@ function LoginForm() {
           >
             {loading ? t("login.submittingLogin") : t("login.submitLogin")}
           </Button>
-          <p className="text-center text-xs text-muted-foreground">
-            {t("login.demoHint")}
-          </p>
         </form>
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary
Removed the demo account functionality from the login page, including pre-filled credentials and the associated UI hint.

## Key Changes
- Removed `DEMO_CREDENTIALS` constant that contained demo account email and password
- Changed initial state for email and password fields from pre-filled demo values to empty strings
- Removed the demo hint text that was displayed below the login button
- Removed corresponding translation strings (`demoHint`) from English and French locale files

## Implementation Details
Users will now see a blank login form instead of one pre-populated with demo credentials. The hint text indicating "Demo account pre-filled — Premium access included" has been removed from both the UI and translation files.

https://claude.ai/code/session_01YTe1zrMZDEijNQSKHNk2m8