### PR TITLE
feat(landing): reposition Toko around simplifying child management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tokō
 
-Application web qui aide les parents à suivre et accompagner leur enfant TDAH (Trouble du Déficit de l'Attention avec ou sans Hyperactivité) au quotidien.
+Application web qui simplifie la gestion du quotidien avec ses enfants — pour réduire la charge mentale des parents — avec un accompagnement renforcé pour les familles concernées par le TDAH (Trouble du Déficit de l'Attention avec ou sans Hyperactivité).
 
 ## Table des matières
 
@@ -27,11 +27,12 @@ Application web qui aide les parents à suivre et accompagner leur enfant TDAH (
 
 ## À quoi sert ce produit ?
 
-- Suivre les symptômes TDAH de votre enfant au quotidien sur 7 dimensions
+- Garder le fil du quotidien de votre enfant en quelques minutes par soir
 - Tenir un journal d'observations avec humeur et étiquettes
+- Suivre les symptômes au quotidien sur 7 dimensions
 - Construire une liste de crise pour aider l'enfant à s'apaiser
-- Mettre en place le programme Barkley (PEHP) avec tableau de récompenses
 - Visualiser les tendances sur semaine, mois et trimestre
+- Pour les familles concernées par le TDAH : programme Barkley (PEHP) avec tableau de récompenses
 
 ## Fonctionnalités principales
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -3,12 +3,12 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-    <meta name="description" content="Toko est une app installable qui aide les parents à gérer le quotidien avec leurs enfants — routines, humeurs, rendez-vous, rappels, récompenses. Conçue pour tous les parents, avec un accompagnement renforcé TDAH." />
+    <meta name="description" content="Toko est une app installable qui simplifie la gestion du quotidien avec vos enfants — routines, humeurs, rendez-vous, rappels, récompenses — pour réduire la charge mentale des parents. Accompagnement renforcé disponible pour les familles concernées par le TDAH." />
     <meta name="theme-color" content="#d4663a" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Tokō" />
-    <title>Toko — L'app qui vous rend du temps en famille</title>
+    <title>Toko — Simplifier la gestion des enfants, sans s'épuiser</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/icon.svg" />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -66,20 +66,20 @@
     },
     "resourcesTeaser": {
       "title": "Understand and support your child",
-      "description": "Clear guides on everyday parenting and ADHD, drawn from public scientific publications. They don't replace a healthcare professional's advice.",
+      "description": "Clear guides on everyday parenting — routines, sleep, emotions — with an ADHD section for families who need it. Drawn from public scientific publications, they don't replace a healthcare professional's advice.",
       "cta": "Read all guides"
     },
     "hero": {
-      "title1": "The ADHD logbook",
-      "title2": "your child psychiatrist will actually read.",
-      "description": "Get ready for every appointment in minutes: symptoms, journal, medication and your questions for the doctor — all in one clear PDF, ready to print or send.",
-      "ctaPrimary": "Prepare my next appointment",
+      "title1": "Simpler parenting,",
+      "title2": "without burning out.",
+      "description": "Routines, moods, appointments, reminders, rewards: Toko brings your child's daily life into one simple app — to ease your mental load and keep track, even on busy days.",
+      "ctaPrimary": "Try Toko for free",
       "ctaSecondary": "See how it works",
       "noCard": "Basic logbook is free, no credit card required."
     },
     "features": {
-      "title": "Three tools, one goal: a useful appointment",
-      "subtitle": "Built with and for parents dealing with ADHD.",
+      "title": "Your child's daily life, all in one place",
+      "subtitle": "Built by a parent, for parents — with extra support for families dealing with ADHD.",
       "andMore": "Also included: daily journal, symptom tracking, medication tracking, dashboard, evening reminders, resources & news.",
       "carnet": {
         "title": "ADHD consultation logbook",
@@ -479,7 +479,7 @@
   },
   "symptoms": {
     "title": "Symptoms",
-    "subtitle": "Daily ADHD symptom tracking",
+    "subtitle": "Daily symptom tracking",
     "addButton": "Add",
     "filterAll": "All",
     "filterHighAgitation": "High restlessness",
@@ -1263,7 +1263,7 @@
   ],
   "news": {
     "title": "News",
-    "subtitle": "Guides, tips and resources to support your ADHD child daily.",
+    "subtitle": "Guides, tips and resources to support your child daily — with an ADHD section for families who need it.",
     "empty": "No news yet",
     "emptyHint": "Check back soon for the latest updates.",
     "readMore": "Read more",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -36,10 +36,10 @@
       "menu": "Menu"
     },
     "hero": {
-      "title1": "Le carnet TDAH",
-      "title2": "que votre pédopsy va enfin lire.",
-      "description": "Préparez chaque rendez-vous médical en quelques minutes : symptômes, journal, traitement et vos questions au médecin — tout dans un PDF clair, à imprimer ou à envoyer en un clic.",
-      "ctaPrimary": "Préparer ma prochaine consultation",
+      "title1": "Simplifier la gestion des enfants,",
+      "title2": "sans s'épuiser.",
+      "description": "Routines, humeurs, rendez-vous, rappels, récompenses : Toko réunit le quotidien de votre enfant dans une app simple — pour alléger la charge mentale et garder le fil, même les jours chargés.",
+      "ctaPrimary": "Essayer Toko gratuitement",
       "ctaSecondary": "Voir comment ça marche",
       "noCard": "Le carnet de base est gratuit, sans carte bancaire."
     },
@@ -74,12 +74,12 @@
     },
     "resourcesTeaser": {
       "title": "Comprendre et accompagner votre enfant",
-      "description": "Des guides clairs sur la parentalité au quotidien et le TDAH, rédigés à partir de publications scientifiques publiques. Ils ne remplacent pas l'avis d'un professionnel de santé.",
+      "description": "Des guides clairs sur la parentalité au quotidien — routines, sommeil, émotions — avec un volet TDAH pour les familles concernées. Rédigés à partir de publications scientifiques publiques, ils ne remplacent pas l'avis d'un professionnel de santé.",
       "cta": "Lire tous les guides"
     },
     "features": {
-      "title": "Trois outils, un seul objectif : la consultation utile",
-      "subtitle": "Conçus avec et pour des parents concernés par le TDAH.",
+      "title": "Tout le quotidien de votre enfant, au même endroit",
+      "subtitle": "Conçue par un parent, pour les parents — avec un accompagnement renforcé pour les familles concernées par le TDAH.",
       "andMore": "Et aussi : journal quotidien, suivi des symptômes, suivi des médicaments, tableau de bord, rappels du soir, ressources & actualités.",
       "carnet": {
         "title": "Carnet de consultation TDAH",
@@ -479,7 +479,7 @@
   },
   "symptoms": {
     "title": "Symptômes",
-    "subtitle": "Suivi quotidien des symptômes TDAH",
+    "subtitle": "Suivi quotidien des symptômes",
     "addButton": "Ajouter",
     "filterAll": "Toutes",
     "filterHighAgitation": "Agitation élevée",
@@ -1263,7 +1263,7 @@
   ],
   "news": {
     "title": "Actualités",
-    "subtitle": "Guides, conseils et ressources pour accompagner votre enfant TDAH au quotidien.",
+    "subtitle": "Guides, conseils et ressources pour accompagner votre enfant au quotidien — avec un volet TDAH pour les familles concernées.",
     "empty": "Aucune actualité pour le moment",
     "emptyHint": "Revenez bientôt pour découvrir les dernières nouvelles.",
     "readMore": "Lire la suite",


### PR DESCRIPTION
## Summary

Move the main framing of Toko away from "ADHD logbook" toward a broader "simplify child management, without burning out" positioning. ADHD-specific features (Barkley program, knowledge base) are kept but referenced as an option for families who need it rather than the core identity.

- Hero, page title and meta description lead with the parent fatigue / charge mentale benefit
- Features and resources sections frame ADHD as an extra layer for concerned families
- README headline and "À quoi sert" list reflect the new positioning
- Symptoms and news subtitles no longer prefix everything with TDAH

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` passes (23 web + 57 API)
- [x] JSON locale files validate
- [ ] Visual check of landing hero, features section, stats subtitle and news header

https://claude.ai/code/session_014c5SQ9K9bvPTjPZLSmZYYt

---
_Generated by [Claude Code](https://claude.ai/code/session_014c5SQ9K9bvPTjPZLSmZYYt)_