### PR TITLE
feat(nav): add Mon compte entry to user dropdown menu

### DIFF
--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -6,7 +6,7 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { Heart, LogOut, LifeBuoy, ChevronDown, Menu, Lock } from "lucide-react";
+import { Heart, LogOut, LifeBuoy, ChevronDown, Menu, Lock, UserCog } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -276,6 +276,10 @@ function UserMenu() {
           )}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
+        <DropdownMenuItem render={<Link to="/account" />}>
+          <UserCog className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          {t("nav.account")}
+        </DropdownMenuItem>
         {koeAvailable && (
           <DropdownMenuItem onClick={openKoe}>
             <LifeBuoy className="h-4 w-4 text-muted-foreground" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- Adds a "Mon compte" entry to the sidebar user dropdown (next to Aide & support / Verrouiller / Déconnexion), linking to `/account`.
- Uses the `UserCog` icon and the existing `nav.account` i18n key for consistency with the sidebar nav.

## Test plan
- [ ] Open the user popover at the bottom of the sidebar; verify "Mon compte" appears above the support/lock/logout items.
- [ ] Click it and confirm navigation to `/account`.

https://claude.ai/code/session_01JV3ck4VTq9tTzWNWEKRAwB

---
_Generated by [Claude Code](https://claude.ai/code/session_01JV3ck4VTq9tTzWNWEKRAwB)_