### PR TITLE
Fix stale child selection after deletion or access revocation

### DIFF
--- a/apps/web/src/components/shared/child-selector.tsx
+++ b/apps/web/src/components/shared/child-selector.tsx
@@ -82,9 +82,19 @@ export function ChildSelector() {
   const showSecondChildUpsell =
     (children?.length ?? 0) >= 1 && !(billing?.active ?? false);
 
-  // Auto-select first child if none is selected
+  // Auto-select first child if none is selected, and reset stale ids
+  // (e.g. a child deleted on another device, access revoked by the
+  // owner). Without this, every child-scoped GET/POST would 404 silently
+  // and the page would show "empty list" with no way to recover.
   useEffect(() => {
-    if (!activeChildId && children?.length) {
+    if (!children) return;
+    if (children.length === 0) {
+      if (activeChildId) setActiveChild(null);
+      return;
+    }
+    const stillExists =
+      activeChildId && children.some((c) => c.id === activeChildId);
+    if (!stillExists) {
       setActiveChild(children[0]!.id);
     }
   }, [activeChildId, children, setActiveChild]);


### PR DESCRIPTION
## Summary
Improved the child selector auto-selection logic to handle cases where the currently selected child no longer exists (e.g., deleted on another device or access revoked by owner). Previously, stale child IDs would cause silent 404 errors on all child-scoped requests, leaving the page in an unrecoverable "empty list" state.

## Key Changes
- Added validation to check if the active child still exists in the children list before using it
- Clear the active child selection when the children list becomes empty
- Auto-select the first available child only when the current selection is invalid or missing
- Enhanced the effect dependency handling to properly reset stale IDs

## Implementation Details
The updated logic now:
1. Returns early if children data hasn't loaded yet
2. Clears selection if the children list is empty
3. Validates that the active child ID still exists in the current children list
4. Only auto-selects the first child if the current selection is invalid

This prevents the silent failures that occurred when requests were made with non-existent child IDs, ensuring users can always recover by having a valid child automatically selected.

https://claude.ai/code/session_01CGbcPoKTsm9L6TRn5n3HNs