### PR TITLE
feat(web): tighten PWA manifest and add install prompt

### DIFF
--- a/apps/web/public/manifest.webmanifest
+++ b/apps/web/public/manifest.webmanifest
@@ -1,21 +1,30 @@
 {
+  "id": "/",
   "name": "Tokō — L'app qui vous rend du temps en famille",
   "short_name": "Tokō",
   "description": "App installable qui aide les parents à gérer le quotidien avec leurs enfants — routines, humeurs, rendez-vous, rappels, récompenses. Conçue pour tous les parents, avec un accompagnement renforcé TDAH.",
   "start_url": "/dashboard",
   "scope": "/",
   "display": "standalone",
+  "display_override": ["standalone", "minimal-ui"],
   "orientation": "portrait",
   "background_color": "#fdf5f0",
   "theme_color": "#d4663a",
   "lang": "fr",
   "categories": ["lifestyle", "health", "productivity"],
+  "prefer_related_applications": false,
   "icons": [
     {
       "src": "/icon.svg",
       "sizes": "any",
       "type": "image/svg+xml",
-      "purpose": "any maskable"
+      "purpose": "any"
+    },
+    {
+      "src": "/icon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
     }
   ]
 }

--- a/apps/web/src/components/shared/install-prompt.tsx
+++ b/apps/web/src/components/shared/install-prompt.tsx
@@ -1,0 +1,70 @@
+import { useTranslation } from "react-i18next";
+import { Download, Share, Plus, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useInstallPrompt } from "@/hooks/use-install-prompt";
+
+export function InstallPrompt() {
+  const { t } = useTranslation();
+  const { canPrompt, mode, install, dismiss } = useInstallPrompt();
+
+  if (!canPrompt) return null;
+
+  return (
+    <div
+      role="region"
+      aria-label={t("install.regionLabel")}
+      className="fixed inset-x-0 bottom-0 z-50 px-4 pb-[calc(env(safe-area-inset-bottom)+5.5rem)] md:bottom-4 md:left-auto md:right-4 md:max-w-sm md:px-0 md:pb-0"
+    >
+      <div className="rounded-xl border border-border/60 bg-background/95 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/85">
+        <div className="flex items-start gap-3">
+          <span
+            aria-hidden="true"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"
+          >
+            <Download className="h-4 w-4" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="font-heading text-sm font-medium">
+              {t("install.title")}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {mode === "ios" ? t("install.iosBody") : t("install.body")}
+            </p>
+
+            {mode === "ios" && (
+              <ol className="mt-2 space-y-1 text-xs text-muted-foreground">
+                <li className="flex items-center gap-1.5">
+                  <Share className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                  <span>{t("install.iosStep1")}</span>
+                </li>
+                <li className="flex items-center gap-1.5">
+                  <Plus className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                  <span>{t("install.iosStep2")}</span>
+                </li>
+              </ol>
+            )}
+
+            <div className="mt-3 flex items-center gap-2">
+              {mode === "native" && (
+                <Button size="sm" onClick={() => void install()}>
+                  {t("install.cta")}
+                </Button>
+              )}
+              <Button size="sm" variant="ghost" onClick={dismiss}>
+                {mode === "ios" ? t("install.gotIt") : t("install.later")}
+              </Button>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={dismiss}
+            aria-label={t("install.close")}
+            className="-m-1.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-install-prompt.ts
+++ b/apps/web/src/hooks/use-install-prompt.ts
@@ -1,0 +1,114 @@
+import { useCallback, useEffect, useState } from "react";
+
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{
+    outcome: "accepted" | "dismissed";
+    platform: string;
+  }>;
+  prompt(): Promise<void>;
+}
+
+const DISMISS_KEY = "toko:install-dismissed-at";
+// Re-prompt at most every 30 days after a dismissal.
+const DISMISS_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+function isStandalone() {
+  if (typeof window === "undefined") return false;
+  // iOS Safari uses a non-standard `standalone` flag.
+  const iosStandalone = (window.navigator as { standalone?: boolean }).standalone;
+  return (
+    iosStandalone === true ||
+    window.matchMedia("(display-mode: standalone)").matches ||
+    window.matchMedia("(display-mode: minimal-ui)").matches
+  );
+}
+
+function isIos() {
+  if (typeof window === "undefined") return false;
+  const ua = window.navigator.userAgent;
+  return /iPhone|iPad|iPod/.test(ua) && !/CriOS|FxiOS|EdgiOS/.test(ua);
+}
+
+function recentlyDismissed() {
+  if (typeof window === "undefined") return false;
+  try {
+    const raw = window.localStorage.getItem(DISMISS_KEY);
+    if (!raw) return false;
+    const ts = Number.parseInt(raw, 10);
+    if (!Number.isFinite(ts)) return false;
+    return Date.now() - ts < DISMISS_TTL_MS;
+  } catch {
+    return false;
+  }
+}
+
+export type InstallMode = "native" | "ios" | "unavailable";
+
+export interface UseInstallPromptResult {
+  canPrompt: boolean;
+  mode: InstallMode;
+  install: () => Promise<"accepted" | "dismissed" | "unsupported">;
+  dismiss: () => void;
+}
+
+export function useInstallPrompt(): UseInstallPromptResult {
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null);
+  const [installed, setInstalled] = useState(() => isStandalone());
+  const [dismissed, setDismissed] = useState(() => recentlyDismissed());
+  const [iosEligible, setIosEligible] = useState(false);
+
+  useEffect(() => {
+    if (installed) return;
+
+    const onBeforeInstall = (e: Event) => {
+      e.preventDefault();
+      setDeferred(e as BeforeInstallPromptEvent);
+    };
+    const onInstalled = () => {
+      setInstalled(true);
+      setDeferred(null);
+    };
+
+    window.addEventListener("beforeinstallprompt", onBeforeInstall);
+    window.addEventListener("appinstalled", onInstalled);
+
+    // iOS Safari never fires beforeinstallprompt — surface manual instructions.
+    if (isIos() && !isStandalone()) {
+      setIosEligible(true);
+    }
+
+    return () => {
+      window.removeEventListener("beforeinstallprompt", onBeforeInstall);
+      window.removeEventListener("appinstalled", onInstalled);
+    };
+  }, [installed]);
+
+  const dismiss = useCallback(() => {
+    try {
+      window.localStorage.setItem(DISMISS_KEY, Date.now().toString());
+    } catch {
+      // Ignore storage errors (private mode, quota, etc.).
+    }
+    setDismissed(true);
+  }, []);
+
+  const install = useCallback(async () => {
+    if (!deferred) return "unsupported" as const;
+    await deferred.prompt();
+    const { outcome } = await deferred.userChoice;
+    setDeferred(null);
+    if (outcome === "dismissed") dismiss();
+    return outcome;
+  }, [deferred, dismiss]);
+
+  const mode: InstallMode = deferred
+    ? "native"
+    : iosEligible
+      ? "ios"
+      : "unavailable";
+
+  const canPrompt = !installed && !dismissed && mode !== "unavailable";
+
+  return { canPrompt, mode, install, dismiss };
+}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -1272,5 +1272,17 @@
     "readMore": "Read more",
     "notFound": "Article not found",
     "backToList": "Back to news"
+  },
+  "install": {
+    "regionLabel": "Install Tokō",
+    "title": "Install Tokō on your device",
+    "body": "Open Tokō in one tap, even offline. Add the app to your home screen — no app store needed.",
+    "iosBody": "On iPhone, add Tokō to your home screen to use it like a native app.",
+    "iosStep1": "Tap the Share button",
+    "iosStep2": "Choose \"Add to Home Screen\"",
+    "cta": "Install the app",
+    "later": "Later",
+    "gotIt": "Got it",
+    "close": "Dismiss prompt"
   }
 }

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -1272,5 +1272,17 @@
     "readMore": "Lire la suite",
     "notFound": "Article introuvable",
     "backToList": "Retour aux actualités"
+  },
+  "install": {
+    "regionLabel": "Installer Tokō",
+    "title": "Installer Tokō sur votre appareil",
+    "body": "Accédez à Tokō en un clic, même hors ligne. L'app s'ajoute à votre écran d'accueil sans passer par un store.",
+    "iosBody": "Sur iPhone, ajoutez Tokō à votre écran d'accueil pour le retrouver comme une vraie app.",
+    "iosStep1": "Touchez le bouton Partager",
+    "iosStep2": "Choisissez « Sur l'écran d'accueil »",
+    "cta": "Installer l'app",
+    "later": "Plus tard",
+    "gotIt": "J'ai compris",
+    "close": "Fermer l'invitation"
   }
 }

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -38,6 +38,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { ChildSelector } from "@/components/shared/child-selector";
 import { KoeWidget, useKoeTrigger } from "@/components/koe-widget";
 import { FloatingTipButton } from "@/components/shared/floating-tip-button";
+import { InstallPrompt } from "@/components/shared/install-prompt";
 import { LockOverlay } from "@/components/shared/lock-overlay";
 import { useIdleLock } from "@/hooks/use-idle-lock";
 import { useUiStore } from "@/stores/ui-store";
@@ -124,6 +125,7 @@ function AuthenticatedShell() {
       <FloatingTipButton />
       <KoeWidget />
       <LockOverlay />
+      <InstallPrompt />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- PWA audit: Tokō was already compliant (vite-plugin-pwa, service worker, manifest, theme color, apple-touch-icon, navigate fallback, runtime caching). Two gaps remained.
- Manifest: add `id`, `display_override`, `prefer_related_applications: false`; split the icon into separate `any` and `maskable` entries (Chrome warns when one icon claims both).
- Add `useInstallPrompt` hook (handles `beforeinstallprompt`, `appinstalled`, iOS detection, 30-day dismissal).
- Add `<InstallPrompt />` UI mounted in the authenticated layout — native CTA on Chromium/Android, Share → Add-to-Home-Screen instructions on iOS Safari.
- French and English copy under `install.*`.

## Test plan

- [x] `pnpm --filter @focusflow/web typecheck`
- [x] `pnpm --filter @focusflow/web test` (3 files / 23 tests pass)
- [x] i18n-fr-reviewer agent confirmed French copy is natural and uses vouvoiement
- [ ] Manual: load app on Android Chrome, confirm `beforeinstallprompt` triggers the card and "Installer l'app" launches the native install dialog
- [ ] Manual: load on iOS Safari, confirm Share → Add to Home Screen instructions appear
- [ ] Manual: dismiss the prompt, reload, confirm it stays hidden for 30 days
- [ ] Manual: install the app and confirm the card disappears via `appinstalled`

---
_Generated by [Claude Code](https://claude.ai/code/session_01AMW59EpQCGmFuh9LmNz4QT)_