### PR TITLE
feat(landing): clarify ADHD value proposition

### DIFF
--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "appName": "Toko",
-    "appTagline": "Giving you time back as a family",
+    "appTagline": "Fewer meltdowns, more time together",
     "loading": "Loading...",
     "save": "Save",
     "cancel": "Cancel",
@@ -37,8 +37,8 @@
     },
     "trust": {
       "time": {
-        "title": "Give parents their time back",
-        "description": "Fewer paper checklists, fewer duplicate apps — 2 minutes each evening is enough to keep track of your child's daily life."
+        "title": "Quality time, restored",
+        "description": "Fewer meltdowns, less mental load. 2 minutes each evening is enough to spot what calms your child and set up a quieter day."
       },
       "rgpd": {
         "title": "GDPR · data hosted in the EU",
@@ -70,12 +70,12 @@
       "cta": "Read all guides"
     },
     "hero": {
-      "title1": "Simpler parenting,",
-      "title2": "without burning out.",
-      "description": "Routines, moods, appointments, reminders, rewards: Toko brings your child's daily life into one simple app — to ease your mental load and keep track, even on busy days.",
+      "title1": "Fewer meltdowns,",
+      "title2": "more time together.",
+      "description": "Toko helps parents of children with ADHD bring calm back to daily life. Spot what soothes your child, reduce meltdowns, and free up quality time — to rebuild the bond and feel at home in family life again.",
       "ctaPrimary": "Try Toko for free",
       "ctaSecondary": "See how it works",
-      "noCard": "Basic logbook is free, no credit card required."
+      "noCard": "No credit card. 2 minutes to get started."
     },
     "features": {
       "title": "Your child's daily life, all in one place",
@@ -124,7 +124,7 @@
     },
     "pricing": {
       "title": "Simple, transparent pricing",
-      "subtitle": "Start free with the consultation logbook. Upgrade to Family for 90-day trends, multiple children and email-to-doctor.",
+      "subtitle": "Start free and change daily life at home. The Family plan unlocks long-term tracking, multi-child support and everything that helps bring lasting calm to family life.",
       "recommended": "Recommended",
       "trialBadge": "14 days free · no card",
       "intervalToggleLabel": "Family billing interval",
@@ -181,7 +181,7 @@
       }
     },
     "footer": {
-      "tagline": "Toko — The app that gives you time back",
+      "tagline": "Toko — Fewer meltdowns, more time together",
       "version": "v{{version}} — Built on {{date}}",
       "legal": "Legal notice",
       "privacy": "Privacy",
@@ -189,7 +189,7 @@
     }
   },
   "login": {
-    "tagline": "The app that simplifies daily life for parents — and gives you time back as a family.",
+    "tagline": "The app that helps parents of children with ADHD calm daily life — and find more time together.",
     "or": "or",
     "tabLogin": "Sign in",
     "tabRegister": "Sign up",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "appName": "Toko",
-    "appTagline": "Vous rendre du temps en famille",
+    "appTagline": "Moins de crises, plus de moments en famille",
     "loading": "Chargement...",
     "save": "Enregistrer",
     "cancel": "Annuler",
@@ -36,17 +36,17 @@
       "menu": "Menu"
     },
     "hero": {
-      "title1": "Simplifier la gestion des enfants,",
-      "title2": "sans s'épuiser.",
-      "description": "Routines, humeurs, rendez-vous, rappels, récompenses : Toko réunit le quotidien de votre enfant dans une app simple — pour alléger la charge mentale et garder le fil, même les jours chargés.",
+      "title1": "Moins de crises,",
+      "title2": "plus de moments en famille.",
+      "description": "Toko aide les parents d'enfants TDAH à apaiser le quotidien. Identifiez ce qui calme votre enfant, espacez les crises et libérez du temps de qualité — pour restaurer le lien et retrouver une vie de famille plus sereine.",
       "ctaPrimary": "Essayer Toko gratuitement",
       "ctaSecondary": "Voir comment ça marche",
-      "noCard": "Le carnet de base est gratuit, sans carte bancaire."
+      "noCard": "Sans carte bancaire. 2 minutes pour démarrer."
     },
     "trust": {
       "time": {
-        "title": "Rendre du temps aux parents",
-        "description": "Moins de checklists papier, moins d'apps qui se répètent — 2 minutes le soir suffisent pour garder le fil du quotidien de votre enfant."
+        "title": "Du temps de qualité, retrouvé",
+        "description": "Moins de crises, moins de charge mentale. 2 minutes le soir suffisent pour repérer ce qui apaise votre enfant et préparer une journée plus calme."
       },
       "rgpd": {
         "title": "RGPD · données hébergées en UE",
@@ -124,7 +124,7 @@
     },
     "pricing": {
       "title": "Des tarifs simples et transparents",
-      "subtitle": "Commencez gratuitement avec le carnet de consultation. Passez à Famille pour les tendances 90 jours, le multi-enfants et l'envoi par email au médecin.",
+      "subtitle": "Commencez gratuitement et changez votre quotidien à la maison. L'abonnement Famille débloque le suivi long, le multi-enfants et tout ce qui aide à apaiser durablement la vie de famille.",
       "recommended": "Recommandé",
       "trialBadge": "14 jours offerts · sans CB",
       "intervalToggleLabel": "Choix de la périodicité Famille",
@@ -181,7 +181,7 @@
       }
     },
     "footer": {
-      "tagline": "Toko — L'app qui vous rend du temps en famille",
+      "tagline": "Toko — Moins de crises, plus de moments en famille",
       "version": "v{{version}} — Build du {{date}}",
       "legal": "Mentions légales",
       "privacy": "Confidentialité",
@@ -189,7 +189,7 @@
     }
   },
   "login": {
-    "tagline": "L'application qui simplifie le quotidien des parents — et vous rend du temps en famille.",
+    "tagline": "L'application qui aide les parents d'enfants TDAH à apaiser le quotidien — et à retrouver du temps en famille.",
     "or": "ou",
     "tabLogin": "Connexion",
     "tabRegister": "Inscription",


### PR DESCRIPTION
Reposition headline copy around the central benefit — fewer meltdowns,
restored parent-child bond, calmer family life — instead of generic
"simpler parenting" framing. Pivots the pricing subtitle off the
consultation logbook (a secondary feature) and toward changing daily
life at home, which is what parents actually pay for.