### PR TITLE
feat(crisis): add SOS de-escalation button with 3 techniques

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -307,6 +307,19 @@
   98% { transform: rotate(4deg); }
 }
 
+/*
+ * SOS Crisis breathing circle: 4-4-4-4 box breathing.
+ * Each phase lasts 4s (25% of the 16s cycle); inhale grows, hold stays large,
+ * exhale shrinks, pause stays small.
+ */
+@keyframes sos-breathe {
+  0%   { transform: scale(0.55); }
+  25%  { transform: scale(1); }
+  50%  { transform: scale(1); }
+  75%  { transform: scale(0.55); }
+  100% { transform: scale(0.55); }
+}
+
 @utility animate-slide-in-right {
   animation: slide-in-right 0.3s ease-out;
 }
@@ -337,6 +350,10 @@
 
 @utility animate-tip-wiggle {
   animation: tip-wiggle 6s ease-in-out infinite;
+}
+
+@utility animate-sos-breathe {
+  animation: sos-breathe 16s ease-in-out infinite;
 }
 
 /* ─── Article body (ressources) ─── */

--- a/apps/web/src/components/shared/sos-crisis-button.tsx
+++ b/apps/web/src/components/shared/sos-crisis-button.tsx
@@ -1,0 +1,304 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "@tanstack/react-router";
+import {
+  HeartPulse,
+  Wind,
+  VolumeX,
+  Sparkles,
+  ArrowLeft,
+  X,
+  ChevronRight,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+type Technique = "breathing" | "sensory" | "diversion";
+
+const BREATH_PHASES = ["inhale", "hold", "exhale", "pause"] as const;
+type BreathPhase = (typeof BREATH_PHASES)[number];
+const PHASE_DURATION_MS = 4000;
+
+export function SOSCrisisButton() {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const [technique, setTechnique] = useState<Technique | null>(null);
+
+  // Reset to chooser when overlay closes so reopening starts fresh.
+  useEffect(() => {
+    if (!open) {
+      const id = setTimeout(() => setTechnique(null), 250);
+      return () => clearTimeout(id);
+    }
+  }, [open]);
+
+  // Escape closes the overlay (or backs out of an active technique).
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      if (technique) setTechnique(null);
+      else setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, technique]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        aria-label={t("sos.openLabel")}
+        className="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] left-[max(1rem,env(safe-area-inset-left))] z-40 flex h-14 items-center gap-2 rounded-full bg-destructive px-4 text-sm font-semibold text-white shadow-lg ring-2 ring-destructive/20 transition-transform duration-200 hover:scale-105 focus-visible:scale-105 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring active:scale-95 lg:bottom-6 lg:left-6"
+      >
+        <span
+          aria-hidden="true"
+          className="absolute inset-0 -z-10 rounded-full bg-destructive/40 animate-tip-halo"
+        />
+        <HeartPulse className="h-5 w-5" aria-hidden="true" />
+        <span>{t("sos.buttonLabel")}</span>
+      </button>
+
+      {open && (
+        <SOSOverlay
+          technique={technique}
+          onSelectTechnique={setTechnique}
+          onBack={() => setTechnique(null)}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+function SOSOverlay({
+  technique,
+  onSelectTechnique,
+  onBack,
+  onClose,
+}: {
+  technique: Technique | null;
+  onSelectTechnique: (t: Technique) => void;
+  onBack: () => void;
+  onClose: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("sos.dialogLabel")}
+      className="fixed inset-0 z-50 flex flex-col bg-gradient-to-b from-sage-50 via-background to-accent-50 pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)] dark:from-sage-900/30 dark:via-background dark:to-accent-900/30"
+    >
+      <div className="flex items-center justify-between px-4 pt-4 sm:px-6">
+        {technique ? (
+          <Button
+            variant="ghost"
+            onClick={onBack}
+            className="gap-2 text-muted-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" />
+            {t("sos.back")}
+          </Button>
+        ) : (
+          <span aria-hidden="true" className="h-9 w-9" />
+        )}
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label={t("sos.close")}
+          className="flex h-11 w-11 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <div className="flex flex-1 flex-col items-center justify-center px-4 sm:px-6">
+        {technique === null && (
+          <TechniqueChooser onSelect={onSelectTechnique} />
+        )}
+        {technique === "breathing" && <BreathingView />}
+        {technique === "sensory" && <SensoryView />}
+        {technique === "diversion" && <DiversionView onClose={onClose} />}
+      </div>
+    </div>
+  );
+}
+
+const TECHNIQUES: Array<{
+  key: Technique;
+  icon: typeof Wind;
+  toneClass: string;
+}> = [
+  {
+    key: "breathing",
+    icon: Wind,
+    toneClass:
+      "bg-info-surface text-info-foreground ring-info-border hover:bg-info-surface/70",
+  },
+  {
+    key: "sensory",
+    icon: VolumeX,
+    toneClass:
+      "bg-sage-100 text-sage-800 ring-sage-200 hover:bg-sage-100/70 dark:bg-sage-900/40 dark:text-sage-100 dark:ring-sage-800",
+  },
+  {
+    key: "diversion",
+    icon: Sparkles,
+    toneClass:
+      "bg-accent-100 text-accent-900 ring-accent-200 hover:bg-accent-100/70 dark:bg-accent-900/40 dark:text-accent-100 dark:ring-accent-800",
+  },
+];
+
+function TechniqueChooser({
+  onSelect,
+}: {
+  onSelect: (t: Technique) => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="w-full max-w-2xl space-y-8 text-center">
+      <div className="space-y-2">
+        <h2 className="font-heading text-3xl font-semibold tracking-tight sm:text-4xl">
+          {t("sos.title")}
+        </h2>
+        <p className="mx-auto max-w-md text-base text-muted-foreground sm:text-lg">
+          {t("sos.subtitle")}
+        </p>
+      </div>
+      <div className="grid gap-3 sm:gap-4">
+        {TECHNIQUES.map(({ key, icon: Icon, toneClass }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => onSelect(key)}
+            className={`flex w-full items-center gap-4 rounded-2xl px-5 py-5 text-left ring-1 transition-all hover:scale-[1.01] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring ${toneClass}`}
+          >
+            <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-background/60">
+              <Icon className="h-6 w-6" aria-hidden="true" />
+            </span>
+            <span className="flex-1 space-y-1">
+              <span className="block font-heading text-lg font-semibold">
+                {t(`sos.techniques.${key}.title`)}
+              </span>
+              <span className="block text-sm opacity-80">
+                {t(`sos.techniques.${key}.description`)}
+              </span>
+            </span>
+            <ChevronRight className="h-5 w-5 shrink-0 opacity-60" aria-hidden="true" />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BreathingView() {
+  const { t } = useTranslation();
+  const [phase, setPhase] = useState<BreathPhase>("inhale");
+  const phaseRef = useRef(phase);
+  phaseRef.current = phase;
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      const i = BREATH_PHASES.indexOf(phaseRef.current);
+      const next = BREATH_PHASES[(i + 1) % BREATH_PHASES.length]!;
+      setPhase(next);
+    }, PHASE_DURATION_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className="flex flex-col items-center gap-10 text-center">
+      <h2 className="font-heading text-2xl font-semibold sm:text-3xl">
+        {t("sos.breathing.title")}
+      </h2>
+      <div
+        className="relative flex h-56 w-56 items-center justify-center sm:h-72 sm:w-72"
+        aria-live="polite"
+      >
+        <span
+          aria-hidden="true"
+          className="absolute inset-0 rounded-full bg-info-surface/40 ring-2 ring-info-border animate-sos-breathe"
+        />
+        <span className="relative text-2xl font-semibold text-foreground sm:text-3xl">
+          {t(`sos.breathing.phases.${phase}`)}
+        </span>
+      </div>
+      <p className="max-w-md text-sm leading-relaxed text-muted-foreground">
+        {t("sos.breathing.intro")}
+      </p>
+    </div>
+  );
+}
+
+function SensoryView() {
+  const { t } = useTranslation();
+  const steps = t("sos.sensory.steps", { returnObjects: true }) as string[];
+  return (
+    <div className="w-full max-w-xl space-y-8 text-center">
+      <div className="space-y-2">
+        <h2 className="font-heading text-2xl font-semibold sm:text-3xl">
+          {t("sos.sensory.title")}
+        </h2>
+        <p className="text-base text-muted-foreground">
+          {t("sos.sensory.intro")}
+        </p>
+      </div>
+      <ol className="space-y-3 text-left">
+        {steps.map((step, i) => (
+          <li
+            key={i}
+            className="flex items-start gap-4 rounded-2xl bg-sage-100/60 p-4 ring-1 ring-sage-200 dark:bg-sage-900/30 dark:ring-sage-800"
+          >
+            <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-background font-heading text-sm font-semibold text-sage-700 dark:text-sage-200">
+              {i + 1}
+            </span>
+            <p className="text-base leading-relaxed text-foreground">{step}</p>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+}
+
+function DiversionView({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation();
+  const ideas = t("sos.diversion.ideas", { returnObjects: true }) as Array<{
+    emoji: string;
+    label: string;
+  }>;
+  return (
+    <div className="w-full max-w-xl space-y-8 text-center">
+      <div className="space-y-2">
+        <h2 className="font-heading text-2xl font-semibold sm:text-3xl">
+          {t("sos.diversion.title")}
+        </h2>
+        <p className="text-base text-muted-foreground">
+          {t("sos.diversion.intro")}
+        </p>
+      </div>
+      <ul className="grid gap-3 sm:grid-cols-2">
+        {ideas.map((idea) => (
+          <li
+            key={idea.label}
+            className="flex items-center gap-3 rounded-2xl bg-accent-100/60 p-4 text-left ring-1 ring-accent-200 dark:bg-accent-900/30 dark:ring-accent-800"
+          >
+            <span className="text-2xl" aria-hidden="true">
+              {idea.emoji}
+            </span>
+            <span className="text-base font-medium text-foreground">
+              {idea.label}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <Link to="/crisis-list" onClick={onClose}>
+        <Button variant="outline" className="gap-2">
+          <Sparkles className="h-4 w-4" />
+          {t("sos.diversion.viewMyList")}
+        </Button>
+      </Link>
+    </div>
+  );
+}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -630,6 +630,62 @@
     "savedToast": "Strength updated",
     "deletedToast": "Strength removed"
   },
+  "sos": {
+    "openLabel": "Open SOS crisis mode",
+    "buttonLabel": "SOS",
+    "dialogLabel": "Crisis de-escalation techniques",
+    "title": "Take a breath. You're in the right place.",
+    "subtitle": "Pick one technique to bring things down. No judgement — you're already carrying a lot.",
+    "back": "Back",
+    "close": "Close",
+    "techniques": {
+      "breathing": {
+        "title": "Guided breathing",
+        "description": "Calm your nervous system in 1 minute before turning back to your child."
+      },
+      "sensory": {
+        "title": "Sensory reset",
+        "description": "Lower the input so your child can come back down."
+      },
+      "diversion": {
+        "title": "Redirect",
+        "description": "A few ideas to shift attention to something soothing."
+      }
+    },
+    "breathing": {
+      "title": "Breathe with me",
+      "intro": "Follow the circle. Breathe in as it grows, breathe out as it shrinks. Stay with it for 1 to 2 minutes.",
+      "phases": {
+        "inhale": "Breathe in",
+        "hold": "Hold",
+        "exhale": "Breathe out",
+        "pause": "Pause"
+      }
+    },
+    "sensory": {
+      "title": "Lower the input",
+      "intro": "A meltdown is often overload. Reduce what's coming into their brain first.",
+      "steps": [
+        "Dim the lights or move to a quiet room.",
+        "Turn off music, TV and notifications.",
+        "Talk less, lower, slower — your words are input too.",
+        "Offer a comfort item: stuffed toy, weighted blanket, noise-cancelling headphones."
+      ]
+    },
+    "diversion": {
+      "title": "Shift their focus",
+      "intro": "Once the peak has passed, offer one simple, concrete option. No negotiation — just an invitation.",
+      "ideas": [
+        { "emoji": "🫧", "label": "Blow soap bubbles" },
+        { "emoji": "💧", "label": "Share a big glass of water" },
+        { "emoji": "🧊", "label": "Hold an ice cube" },
+        { "emoji": "🎵", "label": "Play a calm song" },
+        { "emoji": "🖍️", "label": "Bring out paper and crayons" },
+        { "emoji": "🚶", "label": "Take a 5-minute walk outside" }
+      ],
+      "viewMyList": "Open my custom calm-down list"
+    }
+  },
   "crisis": {
     "title": "Crisis list",
     "subtitle": "The things that help me when I'm not okay",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -630,6 +630,62 @@
     "savedToast": "Point fort modifié",
     "deletedToast": "Point fort supprimé"
   },
+  "sos": {
+    "openLabel": "Ouvrir le mode SOS Crise",
+    "buttonLabel": "SOS Crise",
+    "dialogLabel": "Techniques de désamorçage de crise",
+    "title": "Respirez. Vous êtes au bon endroit.",
+    "subtitle": "Choisissez une technique pour désamorcer la crise. Personne ne juge — vous gérez déjà beaucoup.",
+    "back": "Retour",
+    "close": "Fermer",
+    "techniques": {
+      "breathing": {
+        "title": "Respiration guidée",
+        "description": "Calmez votre système nerveux en 1 minute, avant de revenir à votre enfant."
+      },
+      "sensory": {
+        "title": "Isolation sensorielle",
+        "description": "Réduisez les stimuli pour aider votre enfant à redescendre."
+      },
+      "diversion": {
+        "title": "Diversion",
+        "description": "Quelques idées pour rediriger l'attention vers quelque chose d'apaisant."
+      }
+    },
+    "breathing": {
+      "title": "Respirez avec moi",
+      "intro": "Suivez le cercle. Inspirez quand il grandit, expirez quand il rétrécit. Restez 1 à 2 minutes.",
+      "phases": {
+        "inhale": "Inspirez",
+        "hold": "Retenez",
+        "exhale": "Expirez",
+        "pause": "Pause"
+      }
+    },
+    "sensory": {
+      "title": "Réduisez les stimuli",
+      "intro": "Une crise est souvent une surcharge. Diminuez d'abord ce qui entre dans son cerveau.",
+      "steps": [
+        "Baissez la lumière ou allez dans une pièce calme.",
+        "Coupez la musique, la télé, les notifications.",
+        "Parlez moins, plus bas, plus lentement — vos mots sont des stimuli.",
+        "Proposez un objet réconfortant : doudou, couverture lourde, casque anti-bruit."
+      ]
+    },
+    "diversion": {
+      "title": "Rediriger l'attention",
+      "intro": "Quand le pic est passé, proposez une activité simple et concrète. Pas de négociation, juste une option.",
+      "ideas": [
+        { "emoji": "🫧", "label": "Faire des bulles de savon" },
+        { "emoji": "💧", "label": "Boire un grand verre d'eau ensemble" },
+        { "emoji": "🧊", "label": "Tenir un glaçon dans la main" },
+        { "emoji": "🎵", "label": "Mettre une chanson douce" },
+        { "emoji": "🖍️", "label": "Sortir feuille et crayons" },
+        { "emoji": "🚶", "label": "Marcher 5 minutes dehors" }
+      ],
+      "viewMyList": "Voir ma liste anti-crise personnalisée"
+    }
+  },
   "crisis": {
     "title": "Liste de la crise",
     "subtitle": "Les choses qui me font du bien quand ça ne va pas",

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -39,6 +39,7 @@ import { ChildSelector } from "@/components/shared/child-selector";
 import { KoeWidget, useKoeTrigger } from "@/components/koe-widget";
 import { FloatingTipButton } from "@/components/shared/floating-tip-button";
 import { InstallPrompt } from "@/components/shared/install-prompt";
+import { SOSCrisisButton } from "@/components/shared/sos-crisis-button";
 import { LockOverlay } from "@/components/shared/lock-overlay";
 import { useIdleLock } from "@/hooks/use-idle-lock";
 import { useUiStore } from "@/stores/ui-store";
@@ -122,6 +123,7 @@ function AuthenticatedShell() {
         {isMobile && <MobileTabBar />}
       </SidebarInset>
 
+      <SOSCrisisButton />
       <FloatingTipButton />
       <KoeWidget />
       <LockOverlay />


### PR DESCRIPTION
## Summary

Floating red FAB on every authenticated page that opens a fullscreen overlay offering three immediate de-escalation techniques for parents in the middle of a meltdown.

* **Guided breathing** — animated 4-4-4-4 box-breathing circle with phase labels (Inspirez / Retenez / Expirez / Pause)
* **Sensory reset** — checklist to lower stimulation (lights, sounds, voice, comfort item)
* **Redirect** — 6 default soothing ideas + shortcut to the parent's custom anti-crisis list

Targets parents under stress: large hit targets, calm gradient background, escape closes, FR + EN translations.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 23/23 web tests pass
- [x] Vite dev server compiles and serves the new module
- [ ] Manual: click the red SOS FAB (bottom-left) on any authenticated page, cycle through all three techniques, verify breathing animation timing matches phase labels, escape closes overlay
- [ ] Manual: dark mode legibility on the red FAB

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYpTtTB9vgtiA3dsVdH2LT)_