### PR TITLE
feat(dashboard): personalized greeting + daily tip card

### DIFF
--- a/apps/web/src/components/dashboard/daily-greeting.tsx
+++ b/apps/web/src/components/dashboard/daily-greeting.tsx
@@ -1,0 +1,30 @@
+import { useTranslation } from "react-i18next";
+import { useSession } from "@/lib/auth-client";
+
+function firstName(fullName: string | null | undefined): string | null {
+  if (!fullName) return null;
+  const trimmed = fullName.trim();
+  if (!trimmed) return null;
+  const parts = trimmed.split(/\s+/);
+  return parts[0] ?? null;
+}
+
+function timeOfDayKey(now = new Date()): "morning" | "afternoon" | "evening" {
+  const h = now.getHours();
+  if (h < 12) return "morning";
+  if (h < 18) return "afternoon";
+  return "evening";
+}
+
+export function DailyGreeting() {
+  const { t } = useTranslation();
+  const session = useSession();
+  const name = firstName(session.data?.user?.name);
+  const period = timeOfDayKey();
+
+  const greeting = name
+    ? t(`dashboard.greeting.${period}WithName`, { name })
+    : t(`dashboard.greeting.${period}`);
+
+  return <>{greeting}</>;
+}

--- a/apps/web/src/components/dashboard/daily-tip-card.tsx
+++ b/apps/web/src/components/dashboard/daily-tip-card.tsx
@@ -1,0 +1,103 @@
+import { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Link } from "@tanstack/react-router";
+import { Lightbulb, BookOpen, ArrowRight } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { articles } from "@/lib/resources-data";
+
+type DailyEntry =
+  | { kind: "tip"; key: string }
+  | { kind: "article"; slug: string };
+
+// Mix of short evergreen tips (i18n keys under dashboard.dailyTip.tips.*)
+// and rotating article suggestions. Rotation is deterministic by day of
+// year so the value is stable within the day and predictable across visits.
+const ENTRIES: DailyEntry[] = [
+  { kind: "tip", key: "selfCompassion" },
+  { kind: "tip", key: "smallWins" },
+  { kind: "article", slug: "crise-tdah-enfant-guide-complet" },
+  { kind: "tip", key: "coRegulation" },
+  { kind: "tip", key: "predictableRoutine" },
+  { kind: "article", slug: "apres-le-diagnostic-tdah-parcours-de-soins" },
+  { kind: "tip", key: "namingEmotions" },
+  { kind: "tip", key: "shortInstructions" },
+  { kind: "tip", key: "celebrate" },
+  { kind: "article", slug: "co-regulation-parent-enfant-tdah" },
+  { kind: "tip", key: "yourSleep" },
+  { kind: "tip", key: "askForHelp" },
+  { kind: "tip", key: "transitionWarning" },
+  { kind: "article", slug: "dysregulation-emotionnelle-tdah" },
+  { kind: "tip", key: "physicalRelease" },
+];
+
+function dayOfYear(date = new Date()): number {
+  const start = new Date(date.getFullYear(), 0, 0);
+  const diff = date.getTime() - start.getTime();
+  return Math.floor(diff / (24 * 60 * 60 * 1000));
+}
+
+export function DailyTipCard() {
+  const { t } = useTranslation();
+
+  const entry = useMemo(() => {
+    const idx = dayOfYear() % ENTRIES.length;
+    return ENTRIES[idx]!;
+  }, []);
+
+  if (entry.kind === "article") {
+    const article = articles.find((a) => a.slug === entry.slug);
+    if (!article) return <TipBody tipKey="selfCompassion" />;
+    return (
+      <Card className="border-info-border bg-info-surface">
+        <CardContent className="flex flex-col gap-3 p-5 sm:flex-row sm:items-center sm:gap-4">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-background/70 text-info-foreground">
+            <BookOpen className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <div className="min-w-0 flex-1 space-y-1">
+            <p className="text-xs font-semibold uppercase tracking-wide text-info-foreground/80">
+              {t("dashboard.dailyTip.articleEyebrow")}
+            </p>
+            <p className="font-heading text-base font-semibold leading-snug text-foreground">
+              {article.title}
+            </p>
+            <p className="text-xs text-muted-foreground">{article.readTime}</p>
+          </div>
+          <Link
+            to="/ressources/$slug"
+            params={{ slug: article.slug }}
+            className="shrink-0"
+          >
+            <Button size="sm" variant="outline" className="gap-1.5">
+              {t("dashboard.dailyTip.read")}
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Button>
+          </Link>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return <TipBody tipKey={entry.key} />;
+}
+
+function TipBody({ tipKey }: { tipKey: string }) {
+  const { t } = useTranslation();
+  return (
+    <Card className="border-accent-200 bg-accent-50/60 dark:bg-accent-900/20 dark:border-accent-800">
+      <CardContent className="flex items-start gap-3 p-5">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-background/70 text-accent-700 dark:text-accent-200">
+          <Lightbulb className="h-5 w-5" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1 space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-wide text-accent-700/80 dark:text-accent-300/80">
+            {t("dashboard.dailyTip.tipEyebrow")}
+          </p>
+          <p className="text-sm leading-relaxed text-foreground/90">
+            {t(`dashboard.dailyTip.tips.${tipKey}`)}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -318,6 +318,32 @@
     "addChildTitle": "Add your child",
     "title": "Dashboard",
     "subtitle": "Daily tracking overview",
+    "greeting": {
+      "morning": "Good morning ☀️",
+      "morningWithName": "Good morning {{name}} ☀️",
+      "afternoon": "Good afternoon",
+      "afternoonWithName": "Good afternoon {{name}}",
+      "evening": "Good evening 🌙",
+      "eveningWithName": "Good evening {{name}} 🌙"
+    },
+    "dailyTip": {
+      "tipEyebrow": "Tip of the day",
+      "articleEyebrow": "Article of the day",
+      "read": "Read",
+      "tips": {
+        "selfCompassion": "You are doing your best with a situation that few parents truly understand. Be as gentle with yourself as you are with your child.",
+        "smallWins": "Today, note one small win — yours or your child's. ADHD progress is measured in weeks, not hours.",
+        "coRegulation": "Before asking your child to calm down, lower your own voice by a notch. Their brain mirrors yours, not the other way around.",
+        "predictableRoutine": "A routine repeated at the same time every day frees up mental load — yours and theirs.",
+        "namingEmotions": "Naming what they feel (\"you're frustrated\") lowers the intensity. You don't need to fix it, just name it.",
+        "shortInstructions": "One instruction at a time, eye contact. Long sentences get lost in an ADHD brain.",
+        "celebrate": "Celebrate effort, not outcome. \"You tried even when it was hard\" is more powerful than \"you succeeded.\"",
+        "yourSleep": "Your sleep matters as much as theirs. Go to bed 30 minutes earlier tonight if you can — it's the foundation of your patience tomorrow.",
+        "askForHelp": "Asking for help isn't failure, it's strategy. Co-parent, grandparent, friend: who can you call today?",
+        "transitionWarning": "Before any transition (leaving, mealtime, bedtime), give a 5-minute warning. The ADHD brain needs that buffer.",
+        "physicalRelease": "When tension rises, step outside with them for 10 minutes. Movement releases what words can't."
+      }
+    },
     "billingSuccess": "Subscription activated successfully!",
     "streak": "Streak",
     "streakSubtitle": "consecutive days",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -318,6 +318,32 @@
     "addChildTitle": "Ajouter votre enfant",
     "title": "Tableau de bord",
     "subtitle": "Vue d'ensemble du suivi quotidien",
+    "greeting": {
+      "morning": "Bonjour ☀️",
+      "morningWithName": "Bonjour {{name}} ☀️",
+      "afternoon": "Bel après-midi",
+      "afternoonWithName": "Bel après-midi {{name}}",
+      "evening": "Bonsoir 🌙",
+      "eveningWithName": "Bonsoir {{name}} 🌙"
+    },
+    "dailyTip": {
+      "tipEyebrow": "Conseil du jour",
+      "articleEyebrow": "Article du jour",
+      "read": "Lire",
+      "tips": {
+        "selfCompassion": "Vous faites de votre mieux avec une situation que peu de parents comprennent vraiment. Soyez aussi doux avec vous qu'avec votre enfant.",
+        "smallWins": "Aujourd'hui, notez une petite victoire — la vôtre ou celle de votre enfant. Les progrès TDAH se mesurent en semaines, pas en heures.",
+        "coRegulation": "Avant de demander à votre enfant de se calmer, baissez votre propre voix d'un cran. Son cerveau s'aligne sur le vôtre, pas l'inverse.",
+        "predictableRoutine": "Un rituel répété chaque jour à la même heure libère de la charge mentale — pour vous et pour lui.",
+        "namingEmotions": "Mettre un mot sur ce qu'il ressent (« tu es frustré ») diminue l'intensité de l'émotion. Pas besoin de la résoudre, juste de la nommer.",
+        "shortInstructions": "Une consigne à la fois, regard dans les yeux. Les longues phrases se perdent dans un cerveau TDAH.",
+        "celebrate": "Célébrez l'effort, pas le résultat. « Tu as essayé même quand c'était difficile » est plus puissant que « tu as réussi ».",
+        "yourSleep": "Votre sommeil compte autant que le sien. Couchez-vous 30 minutes plus tôt ce soir si possible — c'est la base de votre patience demain.",
+        "askForHelp": "Demander de l'aide n'est pas un échec, c'est une stratégie. Co-parent, grand-parent, ami : qui pouvez-vous appeler aujourd'hui ?",
+        "transitionWarning": "Avant chaque transition (sortie, repas, dodo), prévenez 5 minutes à l'avance. Le cerveau TDAH a besoin de ce sas.",
+        "physicalRelease": "Si la tension monte, sortez 10 minutes dehors avec lui. Le mouvement décharge ce que les mots ne peuvent pas."
+      }
+    },
     "billingSuccess": "Abonnement activé avec succès !",
     "streak": "Série",
     "streakSubtitle": "jours consécutifs",

--- a/apps/web/src/routes/_authenticated/dashboard/dashboard-page.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard/dashboard-page.tsx
@@ -28,6 +28,8 @@ import {
 import { PageLoader } from "@/components/ui/page-loader";
 import { PageHeader } from "@/components/layout/page-header";
 import { DailyChecklist } from "@/components/dashboard/daily-checklist";
+import { DailyGreeting } from "@/components/dashboard/daily-greeting";
+import { DailyTipCard } from "@/components/dashboard/daily-tip-card";
 import { QuickActions } from "@/components/dashboard/quick-actions";
 import { MoodLogger } from "@/components/dashboard/mood-logger";
 const WeeklyChart = lazy(() =>
@@ -146,9 +148,13 @@ export default function DashboardPage() {
       {/* ── Zone A: Aujourd'hui ────────────────────────────── */}
       <motion.section {...sectionAnim(0)} aria-label={t("dashboard.todaySection")}>
         <PageHeader
-          title={t("dashboard.title")}
+          title={<DailyGreeting />}
           description={t("dashboard.subtitle")}
         />
+
+        <div className="mt-4">
+          <DailyTipCard />
+        </div>
 
         {showInactiveAlert && (
           <div className="mt-4">


### PR DESCRIPTION
## Summary

Closes the third feedback item — make the dashboard warm and dynamic so parents feel like coming back daily instead of seeing a metric grid.

* **Personalized greeting** — replaces "Tableau de bord" with "Bonjour [Prénom] ☀️" / "Bel après-midi" / "Bonsoir 🌙" based on local time. Falls back gracefully to a generic greeting if the user has no name set.
* **Conseil du jour card** — rotates daily between 11 short ADHD-parent tips (self-compassion, co-regulation, transition warnings, your-own-sleep…) and 4 featured articles from the existing resources. Selection is deterministic by day of year so the value is stable within the day.

Frontend only — no DB / API changes. Tips are i18n strings (FR + EN).

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 23/23 web tests pass
- [ ] Manual: dashboard shows greeting with your first name on /dashboard
- [ ] Manual: tip card rotates content on different days (or by editing system clock)
- [ ] Manual: article-of-the-day variant links to the correct resource page

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYpTtTB9vgtiA3dsVdH2LT)_