### PR TITLE
feat(timer): visual time-timer for tasks and transitions

### DIFF
--- a/apps/web/src/components/timer/visual-timer.tsx
+++ b/apps/web/src/components/timer/visual-timer.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Play, Pause, RotateCcw, Maximize2, Minimize2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+const PRESET_MINUTES = [1, 5, 10, 15, 20, 30, 45, 60] as const;
+
+const DIAL_SIZE = 280; // px
+const STROKE = 22;
+const CENTER = DIAL_SIZE / 2;
+const RADIUS = CENTER - STROKE;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+function formatMMSS(totalSec: number): string {
+  const safe = Math.max(0, Math.floor(totalSec));
+  const m = Math.floor(safe / 60);
+  const s = safe % 60;
+  return `${m.toString().padStart(2, "0")}:${s.toString().padStart(2, "0")}`;
+}
+
+export function VisualTimer({ defaultMinutes = 10 }: { defaultMinutes?: number }) {
+  const { t } = useTranslation();
+  const [durationSec, setDurationSec] = useState(defaultMinutes * 60);
+  const [remainingSec, setRemainingSec] = useState(defaultMinutes * 60);
+  const [running, setRunning] = useState(false);
+  const [fullscreen, setFullscreen] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (!running) return;
+    intervalRef.current = setInterval(() => {
+      setRemainingSec((r) => {
+        if (r <= 1) {
+          setRunning(false);
+          return 0;
+        }
+        return r - 1;
+      });
+    }, 1000);
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [running]);
+
+  // Try to vibrate when the timer hits zero. The Web Vibration API is
+  // best-effort: ignored on iOS Safari and many desktops, no-op on
+  // unsupported browsers, no permission prompt.
+  useEffect(() => {
+    if (remainingSec === 0 && durationSec > 0 && navigator.vibrate) {
+      navigator.vibrate([200, 100, 200, 100, 400]);
+    }
+  }, [remainingSec, durationSec]);
+
+  // Escape exits fullscreen so it never traps the user.
+  useEffect(() => {
+    if (!fullscreen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setFullscreen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [fullscreen]);
+
+  const setMinutes = (m: number) => {
+    const sec = m * 60;
+    setDurationSec(sec);
+    setRemainingSec(sec);
+    setRunning(false);
+  };
+
+  const reset = () => {
+    setRemainingSec(durationSec);
+    setRunning(false);
+  };
+
+  const fraction = durationSec > 0 ? remainingSec / durationSec : 0;
+  const dashOffset = CIRCUMFERENCE * (1 - fraction);
+  const finished = remainingSec === 0 && durationSec > 0;
+
+  const wrapperClass = fullscreen
+    ? "fixed inset-0 z-50 flex flex-col items-center justify-center gap-8 bg-background pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)]"
+    : "flex flex-col items-center gap-6";
+
+  return (
+    <div className={wrapperClass}>
+      <div
+        className={cn(
+          "relative flex items-center justify-center transition-transform",
+          finished && "animate-pulse"
+        )}
+        style={{ width: DIAL_SIZE, height: DIAL_SIZE }}
+        aria-live="polite"
+      >
+        <svg
+          width={DIAL_SIZE}
+          height={DIAL_SIZE}
+          viewBox={`0 0 ${DIAL_SIZE} ${DIAL_SIZE}`}
+          aria-hidden="true"
+        >
+          <circle
+            cx={CENTER}
+            cy={CENTER}
+            r={RADIUS}
+            fill="none"
+            stroke="var(--muted)"
+            strokeWidth={STROKE}
+          />
+          <circle
+            cx={CENTER}
+            cy={CENTER}
+            r={RADIUS}
+            fill="none"
+            stroke="var(--primary)"
+            strokeWidth={STROKE}
+            strokeLinecap="round"
+            strokeDasharray={CIRCUMFERENCE}
+            strokeDashoffset={dashOffset}
+            transform={`rotate(-90 ${CENTER} ${CENTER})`}
+            style={{ transition: "stroke-dashoffset 0.95s linear" }}
+          />
+        </svg>
+        <div className="absolute inset-0 flex flex-col items-center justify-center">
+          <span
+            className="font-heading text-5xl font-semibold tabular-nums tracking-tight text-foreground sm:text-6xl"
+            aria-label={t("timer.remaining", {
+              time: formatMMSS(remainingSec),
+            })}
+          >
+            {formatMMSS(remainingSec)}
+          </span>
+          {finished && (
+            <span className="mt-1 text-sm font-medium text-primary">
+              {t("timer.finished")}
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center justify-center gap-2">
+        {PRESET_MINUTES.map((m) => {
+          const active = durationSec === m * 60;
+          return (
+            <button
+              key={m}
+              type="button"
+              onClick={() => setMinutes(m)}
+              className={cn(
+                "rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
+                active
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "border-border/60 bg-background hover:bg-accent"
+              )}
+            >
+              {t("timer.minutes", { count: m })}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-3">
+        <Button
+          size="lg"
+          onClick={() => {
+            if (finished) reset();
+            setRunning((r) => !r);
+          }}
+          className="gap-2 px-6"
+          disabled={durationSec === 0}
+        >
+          {running ? (
+            <>
+              <Pause className="h-4 w-4" /> {t("timer.pause")}
+            </>
+          ) : (
+            <>
+              <Play className="h-4 w-4" /> {t("timer.start")}
+            </>
+          )}
+        </Button>
+        <Button
+          size="lg"
+          variant="outline"
+          onClick={reset}
+          aria-label={t("timer.reset")}
+        >
+          <RotateCcw className="h-4 w-4" />
+        </Button>
+        <Button
+          size="lg"
+          variant="ghost"
+          onClick={() => setFullscreen((f) => !f)}
+          aria-label={
+            fullscreen ? t("timer.exitFullscreen") : t("timer.fullscreen")
+          }
+        >
+          {fullscreen ? (
+            <Minimize2 className="h-4 w-4" />
+          ) : (
+            <Maximize2 className="h-4 w-4" />
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -9,11 +9,12 @@ import {
   ListChecks,
   Newspaper,
   Sparkles,
+  Timer,
   UserCog,
 } from "lucide-react";
 
 export type NavItem = {
-  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/actualites" | "/account";
+  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/timer" | "/actualites" | "/account";
   labelKey: string;
   shortLabelKey?: string;
   icon: React.ComponentType<{ className?: string }>;
@@ -32,6 +33,7 @@ export const navItems: readonly NavItem[] = [
   { to: "/rewards", labelKey: "nav.rewards", shortLabelKey: "nav.rewardsShort", icon: Trophy, group: "tracking" },
   { to: "/crisis-list", labelKey: "nav.crisisList", shortLabelKey: "nav.crisis", icon: HandHeart, primary: true, group: "care" },
   { to: "/medications", labelKey: "nav.medications", icon: Pill, group: "care" },
+  { to: "/timer", labelKey: "nav.timer", icon: Timer, group: "care" },
   { to: "/barkley", labelKey: "nav.barkley", shortLabelKey: "nav.barkleyShort", icon: ClipboardList, primary: true, group: "care" },
   { to: "/actualites", labelKey: "nav.news", icon: Newspaper, group: "account" },
   { to: "/account", labelKey: "nav.account", icon: UserCog, group: "account" },

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -218,6 +218,7 @@
     "journal": "Journal",
     "strengths": "Strengths",
     "medications": "Medications",
+    "timer": "Timer",
     "barkley": "Barkley program",
     "barkleyShort": "Barkley",
     "routines": "Routines",
@@ -614,6 +615,19 @@
     "nextReward": "Next reward",
     "starsToEarn": "⭐ to earn",
     "locked": "Locked"
+  },
+  "timer": {
+    "title": "Visual timer",
+    "subtitle": "A dial that visibly empties helps your child — and you — feel how much time is left for a task: homework, brushing teeth, gaming, transitions.",
+    "start": "Start",
+    "pause": "Pause",
+    "reset": "Reset",
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+    "finished": "Done!",
+    "remaining": "Time remaining: {{time}}",
+    "minutes_one": "{{count}} min",
+    "minutes_other": "{{count}} min"
   },
   "strengths": {
     "title": "Strengths",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -218,6 +218,7 @@
     "journal": "Journal",
     "strengths": "Points forts",
     "medications": "Médicaments",
+    "timer": "Minuteur",
     "barkley": "Programme Barkley",
     "barkleyShort": "Barkley",
     "routines": "Routines",
@@ -614,6 +615,19 @@
     "nextReward": "Prochaine récompense",
     "starsToEarn": "⭐ à gagner",
     "locked": "Verrouillée"
+  },
+  "timer": {
+    "title": "Minuteur visuel",
+    "subtitle": "Un cadran qui se vide aide votre enfant — et vous — à percevoir le temps qui reste pour une tâche : devoirs, brossage de dents, jeu vidéo, transition.",
+    "start": "Démarrer",
+    "pause": "Pause",
+    "reset": "Réinitialiser",
+    "fullscreen": "Plein écran",
+    "exitFullscreen": "Quitter le plein écran",
+    "finished": "Terminé !",
+    "remaining": "Temps restant : {{time}}",
+    "minutes_one": "{{count}} min",
+    "minutes_other": "{{count}} min"
   },
   "strengths": {
     "title": "Points forts",

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -19,6 +19,7 @@ import { Route as RessourcesIndexRouteImport } from './routes/ressources/index'
 import { Route as RessourcesPlanDeCriseRouteImport } from './routes/ressources/plan-de-crise'
 import { Route as RessourcesSlugRouteImport } from './routes/ressources/$slug'
 import { Route as InviteTokenRouteImport } from './routes/invite/$token'
+import { Route as AuthenticatedTimerIndexRouteImport } from './routes/_authenticated/timer/index'
 import { Route as AuthenticatedSymptomsIndexRouteImport } from './routes/_authenticated/symptoms/index'
 import { Route as AuthenticatedStrengthsIndexRouteImport } from './routes/_authenticated/strengths/index'
 import { Route as AuthenticatedRoutinesIndexRouteImport } from './routes/_authenticated/routines/index'
@@ -82,6 +83,11 @@ const InviteTokenRoute = InviteTokenRouteImport.update({
   id: '/invite/$token',
   path: '/invite/$token',
   getParentRoute: () => rootRouteImport,
+} as any)
+const AuthenticatedTimerIndexRoute = AuthenticatedTimerIndexRouteImport.update({
+  id: '/timer/',
+  path: '/timer/',
+  getParentRoute: () => AuthenticatedRoute,
 } as any)
 const AuthenticatedSymptomsIndexRoute =
   AuthenticatedSymptomsIndexRouteImport.update({
@@ -191,6 +197,7 @@ export interface FileRoutesByFullPath {
   '/routines/': typeof AuthenticatedRoutinesIndexRoute
   '/strengths/': typeof AuthenticatedStrengthsIndexRoute
   '/symptoms/': typeof AuthenticatedSymptomsIndexRoute
+  '/timer/': typeof AuthenticatedTimerIndexRoute
   '/barkley/formation/$stepNumber': typeof AuthenticatedBarkleyFormationStepNumberRoute
 }
 export interface FileRoutesByTo {
@@ -216,6 +223,7 @@ export interface FileRoutesByTo {
   '/routines': typeof AuthenticatedRoutinesIndexRoute
   '/strengths': typeof AuthenticatedStrengthsIndexRoute
   '/symptoms': typeof AuthenticatedSymptomsIndexRoute
+  '/timer': typeof AuthenticatedTimerIndexRoute
   '/barkley/formation/$stepNumber': typeof AuthenticatedBarkleyFormationStepNumberRoute
 }
 export interface FileRoutesById {
@@ -243,6 +251,7 @@ export interface FileRoutesById {
   '/_authenticated/routines/': typeof AuthenticatedRoutinesIndexRoute
   '/_authenticated/strengths/': typeof AuthenticatedStrengthsIndexRoute
   '/_authenticated/symptoms/': typeof AuthenticatedSymptomsIndexRoute
+  '/_authenticated/timer/': typeof AuthenticatedTimerIndexRoute
   '/_authenticated/barkley/formation/$stepNumber': typeof AuthenticatedBarkleyFormationStepNumberRoute
 }
 export interface FileRouteTypes {
@@ -270,6 +279,7 @@ export interface FileRouteTypes {
     | '/routines/'
     | '/strengths/'
     | '/symptoms/'
+    | '/timer/'
     | '/barkley/formation/$stepNumber'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -295,6 +305,7 @@ export interface FileRouteTypes {
     | '/routines'
     | '/strengths'
     | '/symptoms'
+    | '/timer'
     | '/barkley/formation/$stepNumber'
   id:
     | '__root__'
@@ -321,6 +332,7 @@ export interface FileRouteTypes {
     | '/_authenticated/routines/'
     | '/_authenticated/strengths/'
     | '/_authenticated/symptoms/'
+    | '/_authenticated/timer/'
     | '/_authenticated/barkley/formation/$stepNumber'
   fileRoutesById: FileRoutesById
 }
@@ -408,6 +420,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/invite/$token'
       preLoaderRoute: typeof InviteTokenRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/_authenticated/timer/': {
+      id: '/_authenticated/timer/'
+      path: '/timer'
+      fullPath: '/timer/'
+      preLoaderRoute: typeof AuthenticatedTimerIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/symptoms/': {
       id: '/_authenticated/symptoms/'
@@ -524,6 +543,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedRoutinesIndexRoute: typeof AuthenticatedRoutinesIndexRoute
   AuthenticatedStrengthsIndexRoute: typeof AuthenticatedStrengthsIndexRoute
   AuthenticatedSymptomsIndexRoute: typeof AuthenticatedSymptomsIndexRoute
+  AuthenticatedTimerIndexRoute: typeof AuthenticatedTimerIndexRoute
   AuthenticatedBarkleyFormationStepNumberRoute: typeof AuthenticatedBarkleyFormationStepNumberRoute
 }
 
@@ -541,6 +561,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedRoutinesIndexRoute: AuthenticatedRoutinesIndexRoute,
   AuthenticatedStrengthsIndexRoute: AuthenticatedStrengthsIndexRoute,
   AuthenticatedSymptomsIndexRoute: AuthenticatedSymptomsIndexRoute,
+  AuthenticatedTimerIndexRoute: AuthenticatedTimerIndexRoute,
   AuthenticatedBarkleyFormationStepNumberRoute:
     AuthenticatedBarkleyFormationStepNumberRoute,
 }

--- a/apps/web/src/routes/_authenticated/timer/index.tsx
+++ b/apps/web/src/routes/_authenticated/timer/index.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { PageHeader } from "@/components/layout/page-header";
+import { VisualTimer } from "@/components/timer/visual-timer";
+
+export const Route = createFileRoute("/_authenticated/timer/")({
+  component: TimerPage,
+  staticData: { crumb: "nav.timer" },
+});
+
+function TimerPage() {
+  const { t } = useTranslation();
+  return (
+    <div className="space-y-8">
+      <PageHeader
+        title={t("timer.title")}
+        description={t("timer.subtitle")}
+      />
+      <div className="flex justify-center pt-4">
+        <VisualTimer />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a Time Timer-style visual countdown — a colored dial that visibly depletes as time passes. Helps both the ADHD child and the parent feel "how much time is left" concretely (homework, brushing teeth, screen time, transitions).

* SVG dial driven by `stroke-dashoffset`; remaining `MM:SS` in the centre
* Presets at 1 / 5 / 10 / 15 / 20 / 30 / 45 / 60 min, plus start / pause / reset
* Fullscreen toggle to use it next to the kid; Escape exits
* Best-effort vibration on completion via the Web Vibration API (silent no-op when unsupported)
* New `/timer` route under the **Soins** sidebar group, French + English

Frontend only — no DB / API changes.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 23/23 web tests pass
- [ ] Manual: select a preset, hit Start, dial depletes smoothly, MM:SS counts down
- [ ] Manual: pause + resume, reset behaviour
- [ ] Manual: fullscreen toggle (and Escape exits)
- [ ] Manual mobile: vibration on completion (Android Chrome)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYpTtTB9vgtiA3dsVdH2LT)_