### PR TITLE
feat(achievements): parent badge system for engagement

### DIFF
--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -12,11 +12,12 @@ import {
   Timer,
   Stethoscope,
   Vault,
+  Award,
   UserCog,
 } from "lucide-react";
 
 export type NavItem = {
-  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/timer" | "/care-pathway" | "/admin-vault" | "/actualites" | "/account";
+  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/timer" | "/care-pathway" | "/admin-vault" | "/achievements" | "/actualites" | "/account";
   labelKey: string;
   shortLabelKey?: string;
   icon: React.ComponentType<{ className?: string }>;
@@ -39,6 +40,7 @@ export const navItems: readonly NavItem[] = [
   { to: "/care-pathway", labelKey: "nav.carePathway", icon: Stethoscope, group: "care" },
   { to: "/admin-vault", labelKey: "nav.adminVault", icon: Vault, group: "care" },
   { to: "/barkley", labelKey: "nav.barkley", shortLabelKey: "nav.barkleyShort", icon: ClipboardList, primary: true, group: "care" },
+  { to: "/achievements", labelKey: "nav.achievements", icon: Award, group: "account" },
   { to: "/actualites", labelKey: "nav.news", icon: Newspaper, group: "account" },
   { to: "/account", labelKey: "nav.account", icon: UserCog, group: "account" },
 ] as const;

--- a/apps/web/src/hooks/use-achievements.ts
+++ b/apps/web/src/hooks/use-achievements.ts
@@ -1,0 +1,56 @@
+import { useChildren } from "./use-children";
+import { useStats } from "./use-stats";
+import { useJournal } from "./use-journal";
+import { useStrengths } from "./use-strengths";
+import { useCrisisItems } from "./use-crisis-list";
+import { useRoutines } from "./use-routines";
+import { useAdminDocuments } from "./use-admin-vault";
+import { useCarePathwayProgress } from "./use-care-pathway";
+import { useUiStore } from "@/stores/ui-store";
+import {
+  computeAchievements,
+  type AchievementSignals,
+} from "@/lib/achievements-data";
+import { CARE_PATHWAY_STEPS } from "@/lib/care-pathway-data";
+
+// Aggregates the signals the achievement engine needs from the active
+// child's data. "Active child" is a deliberate scope choice: the rewards
+// are felt in the context of one child you're tracking, not pooled
+// across siblings. Empty/loading states resolve to 0 so badges only
+// light up when the data is actually present.
+export function useAchievements() {
+  const activeChildId = useUiStore((s) => s.activeChildId);
+  const id = activeChildId ?? "";
+
+  const { data: children } = useChildren();
+  const { data: stats } = useStats(id, "week");
+  const { data: journal } = useJournal(id);
+  const { data: strengths } = useStrengths(id);
+  const { data: crisis } = useCrisisItems(id);
+  const { data: routines } = useRoutines(id);
+  const { data: docs } = useAdminDocuments(id);
+  const { data: carePathway } = useCarePathwayProgress(id);
+
+  const screeningStepIds = CARE_PATHWAY_STEPS.filter(
+    (s) => s.phase === "screening",
+  ).map((s) => s.id);
+
+  const signals: AchievementSignals = {
+    childCount: children?.length ?? 0,
+    journalCount: journal?.length ?? 0,
+    strengthCount: strengths?.length ?? 0,
+    crisisItemCount: crisis?.length ?? 0,
+    routineCount: routines?.length ?? 0,
+    docCount: docs?.length ?? 0,
+    streakDays: stats?.streak ?? 0,
+    carePathwayDoneCount:
+      carePathway?.filter((p) => p.status === "done").length ?? 0,
+    carePathwayScreeningDoneCount:
+      carePathway?.filter(
+        (p) => p.status === "done" && screeningStepIds.includes(p.stepId),
+      ).length ?? 0,
+    carePathwayScreeningTotal: screeningStepIds.length,
+  };
+
+  return computeAchievements(signals);
+}

--- a/apps/web/src/lib/achievements-data.ts
+++ b/apps/web/src/lib/achievements-data.ts
@@ -1,0 +1,141 @@
+// Parent-side gamification: badges that celebrate the parent's engagement
+// with Tokō. Computation is fully client-side and stateless — we look at
+// data already cached by React Query and check predicates. No DB writes,
+// no unlock dates persisted (the visible "unlocked" state IS the reward).
+//
+// Order matters: cards render in this order. Group early/easy wins first
+// so the empty grid feels achievable, then ramp up.
+
+export type AchievementId =
+  | "first_child"
+  | "first_journal"
+  | "first_strength"
+  | "five_strengths"
+  | "first_crisis_list"
+  | "first_routine"
+  | "streak_7"
+  | "streak_30"
+  | "first_care_step_done"
+  | "screening_phase_done"
+  | "first_doc_vault"
+  | "explorer";
+
+export interface AchievementSignals {
+  childCount: number;
+  journalCount: number;
+  strengthCount: number;
+  crisisItemCount: number;
+  routineCount: number;
+  docCount: number;
+  streakDays: number;
+  carePathwayDoneCount: number;
+  carePathwayScreeningDoneCount: number;
+  carePathwayScreeningTotal: number;
+}
+
+export interface Achievement {
+  id: AchievementId;
+  emoji: string;
+  /** Subtle dimming of the unlocked card vs prominent ones. */
+  tone: "warmth" | "growth" | "trust";
+  isUnlocked: (s: AchievementSignals) => boolean;
+}
+
+export const ACHIEVEMENTS: Achievement[] = [
+  {
+    id: "first_child",
+    emoji: "👶",
+    tone: "warmth",
+    isUnlocked: (s) => s.childCount >= 1,
+  },
+  {
+    id: "first_journal",
+    emoji: "📖",
+    tone: "warmth",
+    isUnlocked: (s) => s.journalCount >= 1,
+  },
+  {
+    id: "first_strength",
+    emoji: "🌟",
+    tone: "warmth",
+    isUnlocked: (s) => s.strengthCount >= 1,
+  },
+  {
+    id: "first_crisis_list",
+    emoji: "💙",
+    tone: "warmth",
+    isUnlocked: (s) => s.crisisItemCount >= 1,
+  },
+  {
+    id: "first_routine",
+    emoji: "📋",
+    tone: "warmth",
+    isUnlocked: (s) => s.routineCount >= 1,
+  },
+  {
+    id: "streak_7",
+    emoji: "🔥",
+    tone: "growth",
+    isUnlocked: (s) => s.streakDays >= 7,
+  },
+  {
+    id: "five_strengths",
+    emoji: "🌳",
+    tone: "growth",
+    isUnlocked: (s) => s.strengthCount >= 5,
+  },
+  {
+    id: "first_care_step_done",
+    emoji: "🩺",
+    tone: "growth",
+    isUnlocked: (s) => s.carePathwayDoneCount >= 1,
+  },
+  {
+    id: "first_doc_vault",
+    emoji: "🗃️",
+    tone: "growth",
+    isUnlocked: (s) => s.docCount >= 1,
+  },
+  {
+    id: "streak_30",
+    emoji: "🏔️",
+    tone: "trust",
+    isUnlocked: (s) => s.streakDays >= 30,
+  },
+  {
+    id: "screening_phase_done",
+    emoji: "🔎",
+    tone: "trust",
+    isUnlocked: (s) =>
+      s.carePathwayScreeningTotal > 0 &&
+      s.carePathwayScreeningDoneCount >= s.carePathwayScreeningTotal,
+  },
+  {
+    id: "explorer",
+    emoji: "🧭",
+    tone: "trust",
+    isUnlocked: (s) => {
+      // 5+ distinct features touched: child, journal, strength, crisis,
+      // routine, doc-vault, care-pathway. Each contributes 1 point.
+      let score = 0;
+      if (s.childCount >= 1) score++;
+      if (s.journalCount >= 1) score++;
+      if (s.strengthCount >= 1) score++;
+      if (s.crisisItemCount >= 1) score++;
+      if (s.routineCount >= 1) score++;
+      if (s.docCount >= 1) score++;
+      if (s.carePathwayDoneCount >= 1) score++;
+      return score >= 5;
+    },
+  },
+];
+
+export function computeAchievements(
+  signals: AchievementSignals,
+): { unlocked: Set<AchievementId>; total: number } {
+  const unlocked = new Set<AchievementId>();
+  for (const a of ACHIEVEMENTS) {
+    if (a.isUnlocked(signals)) unlocked.add(a.id);
+  }
+  return { unlocked, total: ACHIEVEMENTS.length };
+}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -221,6 +221,7 @@
     "timer": "Timer",
     "carePathway": "Care pathway",
     "adminVault": "Vault",
+    "achievements": "My badges",
     "barkley": "Barkley program",
     "barkleyShort": "Barkley",
     "routines": "Routines",
@@ -630,6 +631,65 @@
     "remaining": "Time remaining: {{time}}",
     "minutes_one": "{{count}} min",
     "minutes_other": "{{count}} min"
+  },
+  "achievements": {
+    "title": "My parent badges",
+    "subtitle": "Every action counts. Here are the milestones you've crossed with Tokō — for you, not your child. No one else celebrates your consistency.",
+    "progressLabel": "{{done}} badge of {{total}} unlocked",
+    "progressLabel_other": "{{done}} badges of {{total}} unlocked",
+    "disclaimer": "Badges update live based on the active child's data. No leaderboard, no pressure — just a mirror of what you've built.",
+    "unlocked": "Unlocked",
+    "locked": "Coming",
+    "badges": {
+      "first_child": {
+        "title": "First step",
+        "description": "You added your first child. Tracking starts here."
+      },
+      "first_journal": {
+        "title": "First observation",
+        "description": "First journal entry. Your notes are gold for the specialist."
+      },
+      "first_strength": {
+        "title": "Kind eye",
+        "description": "You logged a strength of your child. Keep going — this is what rebalances everything."
+      },
+      "five_strengths": {
+        "title": "Pride catalogue",
+        "description": "5 strengths recorded. You're seeing your child from a different angle."
+      },
+      "first_crisis_list": {
+        "title": "Calm-down kit",
+        "description": "First soothing activity listed. You have a Plan B when tension rises."
+      },
+      "first_routine": {
+        "title": "Routine on board",
+        "description": "First routine created. Daily life takes shape."
+      },
+      "streak_7": {
+        "title": "A full week",
+        "description": "7 consecutive days of tracking. Consistency pays off."
+      },
+      "streak_30": {
+        "title": "A month standing",
+        "description": "30 consecutive days of tracking. You stuck with it — that's rare."
+      },
+      "first_care_step_done": {
+        "title": "First step crossed",
+        "description": "One care-pathway step ticked off. Real progress, keep going."
+      },
+      "screening_phase_done": {
+        "title": "Screening complete",
+        "description": "All screening-phase steps done. Diagnosis is in sight."
+      },
+      "first_doc_vault": {
+        "title": "Archives in order",
+        "description": "First document in the vault. Never again panic the night before an appointment."
+      },
+      "explorer": {
+        "title": "Explorer",
+        "description": "You've used 5 different features. Tokō has become your toolbox."
+      }
+    }
   },
   "adminVault": {
     "title": "Document vault",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -221,6 +221,7 @@
     "timer": "Minuteur",
     "carePathway": "Parcours de soins",
     "adminVault": "Coffre-fort",
+    "achievements": "Mes badges",
     "barkley": "Programme Barkley",
     "barkleyShort": "Barkley",
     "routines": "Routines",
@@ -630,6 +631,65 @@
     "remaining": "Temps restant : {{time}}",
     "minutes_one": "{{count}} min",
     "minutes_other": "{{count}} min"
+  },
+  "achievements": {
+    "title": "Mes badges parent",
+    "subtitle": "Chaque action compte. Voici les jalons que vous avez franchis avec Tokō — pour vous, pas pour vos enfants. Personne d'autre ne célèbre votre constance.",
+    "progressLabel": "{{done}} badge sur {{total}} débloqué",
+    "progressLabel_other": "{{done}} badges sur {{total}} débloqués",
+    "disclaimer": "Les badges se mettent à jour en temps réel selon les données de l'enfant actif. Pas de classement, pas de pression — juste un miroir de ce que vous avez construit.",
+    "unlocked": "Débloqué",
+    "locked": "À venir",
+    "badges": {
+      "first_child": {
+        "title": "Premier pas",
+        "description": "Vous avez ajouté votre premier enfant. Le suivi commence ici."
+      },
+      "first_journal": {
+        "title": "Première observation",
+        "description": "Première entrée dans le journal. Vos notes valent de l'or pour le pédopsy."
+      },
+      "first_strength": {
+        "title": "Œil bienveillant",
+        "description": "Vous avez noté un point fort de votre enfant. Continuez : c'est ce qui rééquilibre tout."
+      },
+      "five_strengths": {
+        "title": "Catalogue de fierté",
+        "description": "5 points forts enregistrés. Vous voyez votre enfant sous un autre angle."
+      },
+      "first_crisis_list": {
+        "title": "Trousse anti-crise",
+        "description": "Première activité apaisante listée. Vous avez un plan B quand ça monte."
+      },
+      "first_routine": {
+        "title": "Cap sur la routine",
+        "description": "Première routine créée. Le quotidien prend forme."
+      },
+      "streak_7": {
+        "title": "Une semaine pleine",
+        "description": "7 jours consécutifs de suivi. La régularité paye."
+      },
+      "streak_30": {
+        "title": "Un mois debout",
+        "description": "30 jours consécutifs de suivi. Vous avez tenu, c'est rare."
+      },
+      "first_care_step_done": {
+        "title": "Première étape franchie",
+        "description": "Une étape du parcours de soins cochée. Avancée concrète, on continue."
+      },
+      "screening_phase_done": {
+        "title": "Repérage complet",
+        "description": "Toutes les étapes de la phase de repérage sont faites. Diagnostic en vue."
+      },
+      "first_doc_vault": {
+        "title": "Archives en ordre",
+        "description": "Premier document dans le coffre-fort. Plus jamais paniquer la veille d'un RDV."
+      },
+      "explorer": {
+        "title": "Exploratrice / Explorateur",
+        "description": "Vous avez utilisé 5 fonctionnalités différentes. Tokō est devenu votre boîte à outils."
+      }
+    }
   },
   "adminVault": {
     "title": "Coffre-fort administratif",

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as AuthenticatedCarePathwayIndexRouteImport } from './routes/_aut
 import { Route as AuthenticatedBarkleyIndexRouteImport } from './routes/_authenticated/barkley/index'
 import { Route as AuthenticatedAdminVaultIndexRouteImport } from './routes/_authenticated/admin-vault/index'
 import { Route as AuthenticatedActualitesIndexRouteImport } from './routes/_authenticated/actualites/index'
+import { Route as AuthenticatedAchievementsIndexRouteImport } from './routes/_authenticated/achievements/index'
 import { Route as AuthenticatedAccountIndexRouteImport } from './routes/_authenticated/account/index'
 import { Route as AuthenticatedActualitesSlugRouteImport } from './routes/_authenticated/actualites/$slug'
 import { Route as AuthenticatedBarkleyFormationStepNumberRouteImport } from './routes/_authenticated/barkley/formation/$stepNumber'
@@ -169,6 +170,12 @@ const AuthenticatedActualitesIndexRoute =
     path: '/actualites/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedAchievementsIndexRoute =
+  AuthenticatedAchievementsIndexRouteImport.update({
+    id: '/achievements/',
+    path: '/achievements/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedAccountIndexRoute =
   AuthenticatedAccountIndexRouteImport.update({
     id: '/account/',
@@ -200,6 +207,7 @@ export interface FileRoutesByFullPath {
   '/ressources/': typeof RessourcesIndexRoute
   '/actualites/$slug': typeof AuthenticatedActualitesSlugRoute
   '/account/': typeof AuthenticatedAccountIndexRoute
+  '/achievements/': typeof AuthenticatedAchievementsIndexRoute
   '/actualites/': typeof AuthenticatedActualitesIndexRoute
   '/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley/': typeof AuthenticatedBarkleyIndexRoute
@@ -228,6 +236,7 @@ export interface FileRoutesByTo {
   '/ressources': typeof RessourcesIndexRoute
   '/actualites/$slug': typeof AuthenticatedActualitesSlugRoute
   '/account': typeof AuthenticatedAccountIndexRoute
+  '/achievements': typeof AuthenticatedAchievementsIndexRoute
   '/actualites': typeof AuthenticatedActualitesIndexRoute
   '/admin-vault': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley': typeof AuthenticatedBarkleyIndexRoute
@@ -258,6 +267,7 @@ export interface FileRoutesById {
   '/ressources/': typeof RessourcesIndexRoute
   '/_authenticated/actualites/$slug': typeof AuthenticatedActualitesSlugRoute
   '/_authenticated/account/': typeof AuthenticatedAccountIndexRoute
+  '/_authenticated/achievements/': typeof AuthenticatedAchievementsIndexRoute
   '/_authenticated/actualites/': typeof AuthenticatedActualitesIndexRoute
   '/_authenticated/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/_authenticated/barkley/': typeof AuthenticatedBarkleyIndexRoute
@@ -288,6 +298,7 @@ export interface FileRouteTypes {
     | '/ressources/'
     | '/actualites/$slug'
     | '/account/'
+    | '/achievements/'
     | '/actualites/'
     | '/admin-vault/'
     | '/barkley/'
@@ -316,6 +327,7 @@ export interface FileRouteTypes {
     | '/ressources'
     | '/actualites/$slug'
     | '/account'
+    | '/achievements'
     | '/actualites'
     | '/admin-vault'
     | '/barkley'
@@ -345,6 +357,7 @@ export interface FileRouteTypes {
     | '/ressources/'
     | '/_authenticated/actualites/$slug'
     | '/_authenticated/account/'
+    | '/_authenticated/achievements/'
     | '/_authenticated/actualites/'
     | '/_authenticated/admin-vault/'
     | '/_authenticated/barkley/'
@@ -545,6 +558,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedActualitesIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/achievements/': {
+      id: '/_authenticated/achievements/'
+      path: '/achievements'
+      fullPath: '/achievements/'
+      preLoaderRoute: typeof AuthenticatedAchievementsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/account/': {
       id: '/_authenticated/account/'
       path: '/account'
@@ -572,6 +592,7 @@ declare module '@tanstack/react-router' {
 interface AuthenticatedRouteChildren {
   AuthenticatedActualitesSlugRoute: typeof AuthenticatedActualitesSlugRoute
   AuthenticatedAccountIndexRoute: typeof AuthenticatedAccountIndexRoute
+  AuthenticatedAchievementsIndexRoute: typeof AuthenticatedAchievementsIndexRoute
   AuthenticatedActualitesIndexRoute: typeof AuthenticatedActualitesIndexRoute
   AuthenticatedAdminVaultIndexRoute: typeof AuthenticatedAdminVaultIndexRoute
   AuthenticatedBarkleyIndexRoute: typeof AuthenticatedBarkleyIndexRoute
@@ -592,6 +613,7 @@ interface AuthenticatedRouteChildren {
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedActualitesSlugRoute: AuthenticatedActualitesSlugRoute,
   AuthenticatedAccountIndexRoute: AuthenticatedAccountIndexRoute,
+  AuthenticatedAchievementsIndexRoute: AuthenticatedAchievementsIndexRoute,
   AuthenticatedActualitesIndexRoute: AuthenticatedActualitesIndexRoute,
   AuthenticatedAdminVaultIndexRoute: AuthenticatedAdminVaultIndexRoute,
   AuthenticatedBarkleyIndexRoute: AuthenticatedBarkleyIndexRoute,

--- a/apps/web/src/routes/_authenticated/achievements/index.tsx
+++ b/apps/web/src/routes/_authenticated/achievements/index.tsx
@@ -1,0 +1,153 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { Lock } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { PageHeader } from "@/components/layout/page-header";
+import { useAchievements } from "@/hooks/use-achievements";
+import {
+  ACHIEVEMENTS,
+  type AchievementId,
+  type Achievement,
+} from "@/lib/achievements-data";
+import { cn } from "@/lib/utils";
+
+export const Route = createFileRoute("/_authenticated/achievements/")({
+  component: AchievementsPage,
+  staticData: { crumb: "nav.achievements" },
+});
+
+const TONE_CLASSES: Record<
+  Achievement["tone"],
+  { unlockedSurface: string; badgeClass: string }
+> = {
+  warmth: {
+    unlockedSurface:
+      "bg-accent-50 ring-2 ring-accent-300 dark:bg-accent-900/30 dark:ring-accent-700",
+    badgeClass:
+      "bg-accent-100 text-accent-900 dark:bg-accent-900/60 dark:text-accent-100",
+  },
+  growth: {
+    unlockedSurface:
+      "bg-sage-50 ring-2 ring-sage-300 dark:bg-sage-900/30 dark:ring-sage-700",
+    badgeClass:
+      "bg-sage-100 text-sage-800 dark:bg-sage-900/60 dark:text-sage-100",
+  },
+  trust: {
+    unlockedSurface:
+      "bg-info-surface ring-2 ring-info-border",
+    badgeClass: "bg-background/70 text-info-foreground ring-1 ring-info-border",
+  },
+};
+
+function AchievementsPage() {
+  const { t } = useTranslation();
+  const { unlocked, total } = useAchievements();
+  const unlockedCount = unlocked.size;
+  const pct = Math.round((unlockedCount / total) * 100);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t("achievements.title")}
+        description={t("achievements.subtitle")}
+      />
+
+      <Card className="border-primary/20 bg-primary/5">
+        <CardContent className="space-y-3 p-5">
+          <div className="flex items-center justify-between gap-4">
+            <p className="font-heading text-base font-semibold">
+              {t("achievements.progressLabel", {
+                done: unlockedCount,
+                total,
+              })}
+            </p>
+            <span className="font-heading text-2xl font-semibold tabular-nums text-primary">
+              {pct}%
+            </span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-background ring-1 ring-primary/10">
+            <div
+              className="h-full bg-primary transition-all duration-500"
+              style={{ width: `${pct}%` }}
+              aria-hidden="true"
+            />
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {t("achievements.disclaimer")}
+          </p>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {ACHIEVEMENTS.map((a) => (
+          <BadgeCard key={a.id} badge={a} unlocked={unlocked.has(a.id)} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function BadgeCard({
+  badge,
+  unlocked,
+}: {
+  badge: Achievement;
+  unlocked: boolean;
+}) {
+  const { t } = useTranslation();
+  const tone = TONE_CLASSES[badge.tone];
+
+  return (
+    <Card
+      className={cn(
+        "transition-all duration-300",
+        unlocked
+          ? `${tone.unlockedSurface} border-transparent`
+          : "border-dashed bg-muted/30",
+      )}
+    >
+      <CardContent className="space-y-3 p-5">
+        <div className="flex items-start justify-between gap-2">
+          <span
+            className={cn(
+              "text-4xl leading-none transition-all duration-300",
+              !unlocked && "opacity-40 grayscale",
+            )}
+            aria-hidden="true"
+          >
+            {badge.emoji}
+          </span>
+          {unlocked ? (
+            <Badge className={`${tone.badgeClass} border-transparent`}>
+              {t("achievements.unlocked")}
+            </Badge>
+          ) : (
+            <Badge variant="outline" className="gap-1 text-muted-foreground">
+              <Lock className="h-3 w-3" />
+              {t("achievements.locked")}
+            </Badge>
+          )}
+        </div>
+        <div className="space-y-1">
+          <p
+            className={cn(
+              "font-heading text-base font-semibold leading-snug",
+              !unlocked && "text-muted-foreground",
+            )}
+          >
+            {t(`achievements.badges.${badge.id}.title` satisfies BadgeKey)}
+          </p>
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            {t(`achievements.badges.${badge.id}.description` satisfies BadgeKey)}
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// Hint to make the dynamic key well-typed at the call sites above.
+type BadgeKey =
+  | `achievements.badges.${AchievementId}.title`
+  | `achievements.badges.${AchievementId}.description`;


### PR DESCRIPTION
## Summary

Closes the gamification feedback item — a "Mes badges parent" page that celebrates the parent's engagement with Tokō. The original framing: **parents of ADHD kids rarely get recognition from anyone — the app should mirror back what they've already built.**

* 12 badges across three tones — **warmth** (first-time wins), **growth** (multi-step momentum), **trust** (long-haul markers)
* Conditions: first child / journal entry / strength / crisis-list / routine / care-step / vault doc; 7-day & 30-day streaks; 5+ strengths; full screening phase; explorer (5 features used)
* Pure client-side computation aggregating data already cached by React Query — no DB writes, no unlock dates persisted (the visible state IS the reward)
* New `/achievements` route under the **Compte** sidebar group, FR + EN copy, locked cards greyscaled, unlocked cards with tone-coloured ring

Frontend only — no schema or API changes.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 4/4 packages pass
- [ ] Manual: empty account shows all 12 cards locked + greyscaled
- [ ] Manual: add a child → "Premier pas" unlocks
- [ ] Manual: add a journal entry → "Première observation" unlocks
- [ ] Manual: 7-day streak (or seed mock data) → "Une semaine pleine" unlocks

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYpTtTB9vgtiA3dsVdH2LT)_