### PR TITLE
feat(sos): show parent's custom calm-down list inside Diversion view

### DIFF
--- a/apps/web/src/components/shared/sos-crisis-button.tsx
+++ b/apps/web/src/components/shared/sos-crisis-button.tsx
@@ -11,6 +11,8 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { useCrisisItems } from "@/hooks/use-crisis-list";
+import { useUiStore } from "@/stores/ui-store";
 
 type Technique = "breathing" | "sensory" | "diversion";
 
@@ -264,10 +266,26 @@ function SensoryView() {
 
 function DiversionView({ onClose }: { onClose: () => void }) {
   const { t } = useTranslation();
-  const ideas = t("sos.diversion.ideas", { returnObjects: true }) as Array<{
+  const activeChildId = useUiStore((s) => s.activeChildId);
+  const { data: customItems } = useCrisisItems(activeChildId ?? "");
+  const fallbackIdeas = t("sos.diversion.ideas", { returnObjects: true }) as Array<{
     emoji: string;
     label: string;
   }>;
+
+  // Prefer the parent's curated list — these activities they already
+  // know calm THIS child. Fall back to evergreen defaults when there
+  // isn't one yet (or no active child selected). Fetching is live, so
+  // adding an item in /crisis-list reflects on the next SOS open.
+  const usingCustom = !!customItems && customItems.length > 0;
+  const items = usingCustom
+    ? customItems.map((c) => ({
+        key: c.id,
+        emoji: c.emoji || "💙",
+        label: c.label,
+      }))
+    : fallbackIdeas.map((i) => ({ key: i.label, ...i }));
+
   return (
     <div className="w-full max-w-xl space-y-8 text-center">
       <div className="space-y-2">
@@ -275,20 +293,22 @@ function DiversionView({ onClose }: { onClose: () => void }) {
           {t("sos.diversion.title")}
         </h2>
         <p className="text-base text-muted-foreground">
-          {t("sos.diversion.intro")}
+          {usingCustom
+            ? t("sos.diversion.introCustom")
+            : t("sos.diversion.intro")}
         </p>
       </div>
       <ul className="grid gap-3 sm:grid-cols-2">
-        {ideas.map((idea) => (
+        {items.map((item) => (
           <li
-            key={idea.label}
+            key={item.key}
             className="flex items-center gap-3 rounded-2xl bg-accent-100/60 p-4 text-left ring-1 ring-accent-200 dark:bg-accent-900/30 dark:ring-accent-800"
           >
             <span className="text-2xl" aria-hidden="true">
-              {idea.emoji}
+              {item.emoji}
             </span>
             <span className="text-base font-medium text-foreground">
-              {idea.label}
+              {item.label}
             </span>
           </li>
         ))}
@@ -296,7 +316,9 @@ function DiversionView({ onClose }: { onClose: () => void }) {
       <Link to="/crisis-list" onClick={onClose}>
         <Button variant="outline" className="gap-2">
           <Sparkles className="h-4 w-4" />
-          {t("sos.diversion.viewMyList")}
+          {usingCustom
+            ? t("sos.diversion.editMyList")
+            : t("sos.diversion.viewMyList")}
         </Button>
       </Link>
     </div>

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -930,6 +930,8 @@
     "diversion": {
       "title": "Shift their focus",
       "intro": "Once the peak has passed, offer one simple, concrete option. No negotiation — just an invitation.",
+      "introCustom": "Here are the activities you've listed together with your child. Offer one, no bargaining — just an invitation.",
+      "editMyList": "Edit my calm-down list",
       "ideas": [
         { "emoji": "🫧", "label": "Blow soap bubbles" },
         { "emoji": "💧", "label": "Share a big glass of water" },

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -930,6 +930,8 @@
     "diversion": {
       "title": "Rediriger l'attention",
       "intro": "Quand le pic est passé, proposez une activité simple et concrète. Pas de négociation, juste une option.",
+      "introCustom": "Voici les activités que vous avez listées avec votre enfant. Proposez-en une, sans négocier — juste une invitation.",
+      "editMyList": "Modifier ma liste anti-crise",
       "ideas": [
         { "emoji": "🫧", "label": "Faire des bulles de savon" },
         { "emoji": "💧", "label": "Boire un grand verre d'eau ensemble" },


### PR DESCRIPTION
## Summary

Until now the SOS Diversion technique offered a fixed set of evergreen suggestions and a CTA to navigate away to `/crisis-list`. That breaks flow at the worst moment — the parent is mid-meltdown, not in the mood to navigate.

Now the Diversion view fetches the active child's custom anti-crisis list and renders those items inline. Defaults remain as a fallback when the list is empty (or no active child is selected), and the action button switches between "Voir ma liste" and "Modifier ma liste" accordingly.

## Test plan

- [x] `pnpm typecheck` clean, `pnpm test` 23/23 web pass
- [ ] Manual: with no crisis-list items, Diversion shows the static defaults
- [ ] Manual: add 2-3 items in /crisis-list, open SOS Diversion → custom items appear, intro copy switches

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYpTtTB9vgtiA3dsVdH2LT)_