### PR TITLE
Reposition SOS crisis button to bottom-right corner

### DIFF
--- a/apps/web/src/components/shared/sos-crisis-button.tsx
+++ b/apps/web/src/components/shared/sos-crisis-button.tsx
@@ -51,7 +51,7 @@ export function SOSCrisisButton() {
         type="button"
         onClick={() => setOpen(true)}
         aria-label={t("sos.openLabel")}
-        className="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] left-[max(1rem,env(safe-area-inset-left))] z-40 flex h-14 items-center gap-2 rounded-full bg-destructive px-4 text-sm font-semibold text-white shadow-lg ring-2 ring-destructive/20 transition-transform duration-200 hover:scale-105 focus-visible:scale-105 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring active:scale-95 lg:bottom-6 lg:left-6"
+        className="fixed bottom-[calc(8.75rem+env(safe-area-inset-bottom))] right-4 z-40 flex h-14 items-center gap-2 rounded-full bg-destructive px-4 text-sm font-semibold text-white shadow-lg ring-2 ring-destructive/20 transition-transform duration-200 hover:scale-105 focus-visible:scale-105 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring active:scale-95 lg:bottom-[5rem] lg:right-6"
       >
         <span
           aria-hidden="true"


### PR DESCRIPTION
## Summary
Repositioned the SOS crisis button from the bottom-left to the bottom-right corner of the screen, with adjusted spacing to accommodate the new layout.

## Key Changes
- Changed button horizontal positioning from `left-[max(1rem,env(safe-area-inset-left))]` to `right-4`
- Updated bottom spacing from `bottom-[calc(5rem+env(safe-area-inset-bottom))]` to `bottom-[calc(8.75rem+env(safe-area-inset-bottom))]` on mobile
- Updated large screen bottom spacing from `lg:bottom-6` to `lg:bottom-[5rem]`
- Updated large screen horizontal positioning from `lg:left-6` to `lg:right-6`

## Implementation Details
The button now appears in the bottom-right corner on both mobile and desktop viewports. The increased bottom offset (8.75rem vs 5rem on mobile) accounts for the new positioning and ensures proper spacing from the bottom of the screen.

https://claude.ai/code/session_01FMdQxpuzt5eg3TQPmENkbo