### PR TITLE
feat(activity): surface the audit feed as a first-class /activity page

### DIFF
--- a/apps/web/src/components/co-parent/recent-activity.tsx
+++ b/apps/web/src/components/co-parent/recent-activity.tsx
@@ -3,10 +3,12 @@ import {
   Activity,
   BookOpen,
   Crown,
+  FileText,
   HandHeart,
   History,
   ListChecks,
   Pill,
+  Sparkles,
   User,
   UserPlus,
   UserMinus,
@@ -20,6 +22,8 @@ import {
 
 interface Props {
   childId: string;
+  /** Cap the number of entries shown (default 50). Useful for compact previews. */
+  limit?: number;
 }
 
 // Icon picked off entityType so the feed scans visually — symptom rows
@@ -33,13 +37,15 @@ const ENTITY_ICONS: Record<AuditEntityType, React.ComponentType<{ className?: st
   crisis_item: HandHeart,
   child_access: UserMinus,
   child_invitation: UserPlus,
+  strength: Sparkles,
   routine: ListChecks,
   routine_completion: ListChecks,
+  admin_document: FileText,
 };
 
-export function RecentActivity({ childId }: Props) {
+export function RecentActivity({ childId, limit = 50 }: Props) {
   const { t } = useTranslation();
-  const { data, isLoading } = useAuditLogForChild(childId, 50);
+  const { data, isLoading } = useAuditLogForChild(childId, limit);
 
   if (isLoading) {
     return (

--- a/apps/web/src/components/dashboard/activity-preview-card.tsx
+++ b/apps/web/src/components/dashboard/activity-preview-card.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from "react-i18next";
+import { Link } from "@tanstack/react-router";
+import { History, ChevronRight } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { RecentActivity } from "@/components/co-parent/recent-activity";
+import { useUiStore } from "@/stores/ui-store";
+
+// Compact 5-row preview of the activity feed for the dashboard. Renders
+// nothing when no child is selected — the empty-state message belongs
+// to the dedicated /activity page, the dashboard already has plenty
+// going on.
+export function ActivityPreviewCard() {
+  const { t } = useTranslation();
+  const activeChildId = useUiStore((s) => s.activeChildId);
+
+  if (!activeChildId) return null;
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 p-5">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 min-w-0">
+            <History className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <h3 className="font-heading text-sm font-semibold">
+              {t("activityPage.previewTitle")}
+            </h3>
+          </div>
+          <Link to="/activity">
+            <Button variant="ghost" size="sm" className="gap-1 text-xs">
+              {t("activityPage.viewAll")}
+              <ChevronRight className="h-3 w-3" />
+            </Button>
+          </Link>
+        </div>
+        <RecentActivity childId={activeChildId} limit={5} />
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -13,11 +13,12 @@ import {
   Stethoscope,
   Vault,
   Award,
+  History,
   UserCog,
 } from "lucide-react";
 
 export type NavItem = {
-  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/timer" | "/care-pathway" | "/admin-vault" | "/achievements" | "/actualites" | "/account";
+  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/timer" | "/care-pathway" | "/admin-vault" | "/achievements" | "/activity" | "/actualites" | "/account";
   labelKey: string;
   shortLabelKey?: string;
   icon: React.ComponentType<{ className?: string }>;
@@ -40,6 +41,7 @@ export const navItems: readonly NavItem[] = [
   { to: "/care-pathway", labelKey: "nav.carePathway", icon: Stethoscope, group: "care" },
   { to: "/admin-vault", labelKey: "nav.adminVault", icon: Vault, group: "care" },
   { to: "/barkley", labelKey: "nav.barkley", shortLabelKey: "nav.barkleyShort", icon: ClipboardList, primary: true, group: "care" },
+  { to: "/activity", labelKey: "nav.activity", icon: History, group: "account" },
   { to: "/achievements", labelKey: "nav.achievements", icon: Award, group: "account" },
   { to: "/actualites", labelKey: "nav.news", icon: Newspaper, group: "account" },
   { to: "/account", labelKey: "nav.account", icon: UserCog, group: "account" },

--- a/apps/web/src/hooks/use-audit-log.ts
+++ b/apps/web/src/hooks/use-audit-log.ts
@@ -10,8 +10,10 @@ export type AuditEntityType =
   | "crisis_item"
   | "child_access"
   | "child_invitation"
+  | "strength"
   | "routine"
-  | "routine_completion";
+  | "routine_completion"
+  | "admin_document";
 
 export type AuditAction =
   | "create"

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -222,6 +222,7 @@
     "carePathway": "Care pathway",
     "adminVault": "Vault",
     "achievements": "My badges",
+    "activity": "Activity",
     "barkley": "Barkley program",
     "barkleyShort": "Barkley",
     "routines": "Routines",
@@ -1157,6 +1158,13 @@
     "inviteForbidden": "Only the owner can invite.",
     "inviteError": "Invite failed to send."
   },
+  "activityPage": {
+    "title": "Recent activity",
+    "subtitle": "Everything that happened on your child's account — your actions and your co-parent's. Useful to reconstruct a day or spot what changed.",
+    "selectChild": "Select a child to see their activity.",
+    "previewTitle": "Recent activity",
+    "viewAll": "View all"
+  },
   "auditLog": {
     "empty": "No activity recorded yet.",
     "deletedActor": "Deleted account",
@@ -1206,6 +1214,16 @@
       "routine_completion": {
         "create": "Routine step ticked",
         "delete": "Routine step unticked"
+      },
+      "strength": {
+        "create": "Strength added",
+        "update": "Strength updated",
+        "delete": "Strength removed"
+      },
+      "admin_document": {
+        "create": "Document added to the vault",
+        "update": "Document edited",
+        "delete": "Document removed from the vault"
       }
     }
   },

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -222,6 +222,7 @@
     "carePathway": "Parcours de soins",
     "adminVault": "Coffre-fort",
     "achievements": "Mes badges",
+    "activity": "Activité",
     "barkley": "Programme Barkley",
     "barkleyShort": "Barkley",
     "routines": "Routines",
@@ -1157,6 +1158,13 @@
     "inviteForbidden": "Seul le propriétaire peut inviter.",
     "inviteError": "L'invitation n'a pas pu être envoyée."
   },
+  "activityPage": {
+    "title": "Activité récente",
+    "subtitle": "Tout ce qui s'est passé sur le compte de votre enfant — vos actions et celles de votre co-parent. Utile pour reconstituer une journée ou repérer ce qui a changé.",
+    "selectChild": "Sélectionnez un enfant pour voir son activité.",
+    "previewTitle": "Activité récente",
+    "viewAll": "Voir tout"
+  },
   "auditLog": {
     "empty": "Aucune activité enregistrée pour le moment.",
     "deletedActor": "Compte supprimé",
@@ -1206,6 +1214,16 @@
       "routine_completion": {
         "create": "Étape de routine cochée",
         "delete": "Étape de routine décochée"
+      },
+      "strength": {
+        "create": "Point fort ajouté",
+        "update": "Point fort modifié",
+        "delete": "Point fort supprimé"
+      },
+      "admin_document": {
+        "create": "Document ajouté au coffre-fort",
+        "update": "Document modifié",
+        "delete": "Document supprimé du coffre-fort"
       }
     }
   },

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -33,6 +33,7 @@ import { Route as AuthenticatedCarePathwayIndexRouteImport } from './routes/_aut
 import { Route as AuthenticatedBarkleyIndexRouteImport } from './routes/_authenticated/barkley/index'
 import { Route as AuthenticatedAdminVaultIndexRouteImport } from './routes/_authenticated/admin-vault/index'
 import { Route as AuthenticatedActualitesIndexRouteImport } from './routes/_authenticated/actualites/index'
+import { Route as AuthenticatedActivityIndexRouteImport } from './routes/_authenticated/activity/index'
 import { Route as AuthenticatedAchievementsIndexRouteImport } from './routes/_authenticated/achievements/index'
 import { Route as AuthenticatedAccountIndexRouteImport } from './routes/_authenticated/account/index'
 import { Route as AuthenticatedActualitesSlugRouteImport } from './routes/_authenticated/actualites/$slug'
@@ -170,6 +171,12 @@ const AuthenticatedActualitesIndexRoute =
     path: '/actualites/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedActivityIndexRoute =
+  AuthenticatedActivityIndexRouteImport.update({
+    id: '/activity/',
+    path: '/activity/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedAchievementsIndexRoute =
   AuthenticatedAchievementsIndexRouteImport.update({
     id: '/achievements/',
@@ -208,6 +215,7 @@ export interface FileRoutesByFullPath {
   '/actualites/$slug': typeof AuthenticatedActualitesSlugRoute
   '/account/': typeof AuthenticatedAccountIndexRoute
   '/achievements/': typeof AuthenticatedAchievementsIndexRoute
+  '/activity/': typeof AuthenticatedActivityIndexRoute
   '/actualites/': typeof AuthenticatedActualitesIndexRoute
   '/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley/': typeof AuthenticatedBarkleyIndexRoute
@@ -237,6 +245,7 @@ export interface FileRoutesByTo {
   '/actualites/$slug': typeof AuthenticatedActualitesSlugRoute
   '/account': typeof AuthenticatedAccountIndexRoute
   '/achievements': typeof AuthenticatedAchievementsIndexRoute
+  '/activity': typeof AuthenticatedActivityIndexRoute
   '/actualites': typeof AuthenticatedActualitesIndexRoute
   '/admin-vault': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley': typeof AuthenticatedBarkleyIndexRoute
@@ -268,6 +277,7 @@ export interface FileRoutesById {
   '/_authenticated/actualites/$slug': typeof AuthenticatedActualitesSlugRoute
   '/_authenticated/account/': typeof AuthenticatedAccountIndexRoute
   '/_authenticated/achievements/': typeof AuthenticatedAchievementsIndexRoute
+  '/_authenticated/activity/': typeof AuthenticatedActivityIndexRoute
   '/_authenticated/actualites/': typeof AuthenticatedActualitesIndexRoute
   '/_authenticated/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/_authenticated/barkley/': typeof AuthenticatedBarkleyIndexRoute
@@ -299,6 +309,7 @@ export interface FileRouteTypes {
     | '/actualites/$slug'
     | '/account/'
     | '/achievements/'
+    | '/activity/'
     | '/actualites/'
     | '/admin-vault/'
     | '/barkley/'
@@ -328,6 +339,7 @@ export interface FileRouteTypes {
     | '/actualites/$slug'
     | '/account'
     | '/achievements'
+    | '/activity'
     | '/actualites'
     | '/admin-vault'
     | '/barkley'
@@ -358,6 +370,7 @@ export interface FileRouteTypes {
     | '/_authenticated/actualites/$slug'
     | '/_authenticated/account/'
     | '/_authenticated/achievements/'
+    | '/_authenticated/activity/'
     | '/_authenticated/actualites/'
     | '/_authenticated/admin-vault/'
     | '/_authenticated/barkley/'
@@ -558,6 +571,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedActualitesIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/activity/': {
+      id: '/_authenticated/activity/'
+      path: '/activity'
+      fullPath: '/activity/'
+      preLoaderRoute: typeof AuthenticatedActivityIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/achievements/': {
       id: '/_authenticated/achievements/'
       path: '/achievements'
@@ -593,6 +613,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedActualitesSlugRoute: typeof AuthenticatedActualitesSlugRoute
   AuthenticatedAccountIndexRoute: typeof AuthenticatedAccountIndexRoute
   AuthenticatedAchievementsIndexRoute: typeof AuthenticatedAchievementsIndexRoute
+  AuthenticatedActivityIndexRoute: typeof AuthenticatedActivityIndexRoute
   AuthenticatedActualitesIndexRoute: typeof AuthenticatedActualitesIndexRoute
   AuthenticatedAdminVaultIndexRoute: typeof AuthenticatedAdminVaultIndexRoute
   AuthenticatedBarkleyIndexRoute: typeof AuthenticatedBarkleyIndexRoute
@@ -614,6 +635,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedActualitesSlugRoute: AuthenticatedActualitesSlugRoute,
   AuthenticatedAccountIndexRoute: AuthenticatedAccountIndexRoute,
   AuthenticatedAchievementsIndexRoute: AuthenticatedAchievementsIndexRoute,
+  AuthenticatedActivityIndexRoute: AuthenticatedActivityIndexRoute,
   AuthenticatedActualitesIndexRoute: AuthenticatedActualitesIndexRoute,
   AuthenticatedAdminVaultIndexRoute: AuthenticatedAdminVaultIndexRoute,
   AuthenticatedBarkleyIndexRoute: AuthenticatedBarkleyIndexRoute,

--- a/apps/web/src/routes/_authenticated/activity/index.tsx
+++ b/apps/web/src/routes/_authenticated/activity/index.tsx
@@ -1,0 +1,35 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { Card, CardContent } from "@/components/ui/card";
+import { PageHeader } from "@/components/layout/page-header";
+import { RecentActivity } from "@/components/co-parent/recent-activity";
+import { useUiStore } from "@/stores/ui-store";
+
+export const Route = createFileRoute("/_authenticated/activity/")({
+  component: ActivityPage,
+  staticData: { crumb: "nav.activity" },
+});
+
+function ActivityPage() {
+  const { t } = useTranslation();
+  const activeChildId = useUiStore((s) => s.activeChildId);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t("activityPage.title")}
+        description={t("activityPage.subtitle")}
+      />
+
+      {!activeChildId ? (
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            {t("activityPage.selectChild")}
+          </CardContent>
+        </Card>
+      ) : (
+        <RecentActivity childId={activeChildId} limit={100} />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/_authenticated/dashboard/dashboard-page.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard/dashboard-page.tsx
@@ -31,6 +31,7 @@ import { DailyChecklist } from "@/components/dashboard/daily-checklist";
 import { DailyGreeting } from "@/components/dashboard/daily-greeting";
 import { DailyTipCard } from "@/components/dashboard/daily-tip-card";
 import { ParentMoodWidget } from "@/components/dashboard/parent-mood-widget";
+import { ActivityPreviewCard } from "@/components/dashboard/activity-preview-card";
 import { QuickActions } from "@/components/dashboard/quick-actions";
 import { MoodLogger } from "@/components/dashboard/mood-logger";
 const WeeklyChart = lazy(() =>
@@ -245,6 +246,8 @@ export default function DashboardPage() {
         {stats?.latestJournalEntry && (
           <LatestJournalCard entry={stats.latestJournalEntry} />
         )}
+
+        <ActivityPreviewCard />
       </motion.section>
     </div>
     </MotionConfig>


### PR DESCRIPTION
## Summary

The audit log existed since day one but lived buried inside the co-parent management section's second tab — useful only when the parent went hunting for it.

* New `/activity` route in the **Compte** sidebar group (History icon)
* 5-row preview card on the dashboard with a "Voir tout" link
* `recent-activity.tsx` gains a `limit` prop so the dashboard preview and the full page share the same component
* Missing entity types (`strength`, `admin_document`) added to the `AuditEntityType` union and to `ENTITY_ICONS`, plus matching FR/EN fallback summaries — newer rows render with the right icon and default copy when the server-side summary is absent

Data flow and ownership semantics unchanged — same `GET /api/audit-log/child/:childId` endpoint with its existing `assertChildAccess` check.

## Test plan

- [x] `pnpm typecheck`, `pnpm test` 4/4 packages pass
- [ ] Manual: dashboard shows the 5-row preview when a child is selected, hides when none is
- [ ] Manual: click "Voir tout" → /activity loads with the full feed
- [ ] Manual: log a strength + upload a vault document → both appear in the feed with correct icons (Sparkles, FileText) and FR copy

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYpTtTB9vgtiA3dsVdH2LT)_