### PR TITLE
feat(nav): rename Actualités to Base de connaissances and feature it at top of sidebar

### DIFF
--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -7,7 +7,7 @@ import {
   Pill,
   ClipboardList,
   ListChecks,
-  Newspaper,
+  Library,
   Sparkles,
   Timer,
   Stethoscope,
@@ -25,10 +25,11 @@ export type NavItem = {
   /** Surfaced in the mobile bottom tab bar (max 4). */
   primary?: boolean;
   /** Section grouping in the desktop sidebar. */
-  group: "tracking" | "care" | "account";
+  group: "knowledge" | "tracking" | "care" | "account";
 };
 
 export const navItems: readonly NavItem[] = [
+  { to: "/actualites", labelKey: "nav.knowledgeBase", icon: Library, group: "knowledge" },
   { to: "/dashboard", labelKey: "nav.dashboard", shortLabelKey: "nav.home", icon: BarChart3, primary: true, group: "tracking" },
   { to: "/journal", labelKey: "nav.journal", icon: BookOpen, primary: true, group: "tracking" },
   { to: "/symptoms", labelKey: "nav.symptoms", icon: Activity, group: "tracking" },
@@ -43,11 +44,11 @@ export const navItems: readonly NavItem[] = [
   { to: "/barkley", labelKey: "nav.barkley", shortLabelKey: "nav.barkleyShort", icon: ClipboardList, primary: true, group: "care" },
   { to: "/activity", labelKey: "nav.activity", icon: History, group: "account" },
   { to: "/achievements", labelKey: "nav.achievements", icon: Award, group: "account" },
-  { to: "/actualites", labelKey: "nav.news", icon: Newspaper, group: "account" },
   { to: "/account", labelKey: "nav.account", icon: UserCog, group: "account" },
 ] as const;
 
 export const navGroups: { key: NavItem["group"]; labelKey: string }[] = [
+  { key: "knowledge", labelKey: "nav.groupKnowledge" },
   { key: "tracking", labelKey: "nav.groupTracking" },
   { key: "care", labelKey: "nav.groupCare" },
   { key: "account", labelKey: "nav.groupAccount" },

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -227,7 +227,7 @@
     "barkleyShort": "Barkley",
     "routines": "Routines",
     "routinesShort": "Routines",
-    "news": "News",
+    "knowledgeBase": "Knowledge base",
     "account": "My account",
     "home": "Home",
     "crisis": "Crisis",
@@ -243,6 +243,7 @@
     "buildAt": "Built on {{date}} at {{time}}",
     "skipToContent": "Skip to main content",
     "toggleSidebar": "Toggle sidebar",
+    "groupKnowledge": "Resources",
     "groupTracking": "Tracking",
     "groupCare": "Care",
     "groupAccount": "Account",
@@ -1744,8 +1745,8 @@
     }
   ],
   "news": {
-    "title": "News",
-    "subtitle": "Guides, tips and resources to support your child daily — with an ADHD section for families who need it.",
+    "title": "Knowledge base",
+    "subtitle": "Everything about ADHD: guides, tips and resources to better understand and support your child daily.",
     "empty": "No news yet",
     "emptyHint": "Check back soon for the latest updates.",
     "readMore": "Read more",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -227,7 +227,7 @@
     "barkleyShort": "Barkley",
     "routines": "Routines",
     "routinesShort": "Routines",
-    "news": "Actualités",
+    "knowledgeBase": "Base de connaissances",
     "account": "Mon compte",
     "home": "Accueil",
     "crisis": "Crise",
@@ -243,6 +243,7 @@
     "buildAt": "Build du {{date}} à {{time}}",
     "skipToContent": "Aller au contenu principal",
     "toggleSidebar": "Afficher la navigation",
+    "groupKnowledge": "Ressources",
     "groupTracking": "Suivi",
     "groupCare": "Soins",
     "groupAccount": "Compte",
@@ -1744,8 +1745,8 @@
     }
   ],
   "news": {
-    "title": "Actualités",
-    "subtitle": "Guides, conseils et ressources pour accompagner votre enfant au quotidien — avec un volet TDAH pour les familles concernées.",
+    "title": "Base de connaissances",
+    "subtitle": "Tout sur le TDAH : guides, conseils et ressources pour mieux comprendre et accompagner votre enfant au quotidien.",
     "empty": "Aucune actualité pour le moment",
     "emptyHint": "Revenez bientôt pour découvrir les dernières nouvelles.",
     "readMore": "Lire la suite",

--- a/apps/web/src/routes/_authenticated/actualites/index.tsx
+++ b/apps/web/src/routes/_authenticated/actualites/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { Newspaper, Clock, ArrowRight } from "lucide-react";
+import { Library, Clock, ArrowRight } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -14,7 +14,7 @@ import { useTranslation } from "react-i18next";
 
 export const Route = createFileRoute("/_authenticated/actualites/")({
   component: ActualitesIndex,
-  staticData: { crumb: "nav.news" },
+  staticData: { crumb: "nav.knowledgeBase" },
 });
 
 function ActualitesIndex() {
@@ -27,7 +27,7 @@ function ActualitesIndex() {
     <div className="mx-auto max-w-4xl px-4 py-8">
       <div className="mb-8">
         <div className="flex items-center gap-3 mb-2">
-          <Newspaper className="h-6 w-6 text-primary" />
+          <Library className="h-6 w-6 text-primary" />
           <h1 className="font-heading text-3xl font-semibold tracking-tight">
             {t("news.title")}
           </h1>


### PR DESCRIPTION
Move the resources entry out of the "Compte" group into a new "Ressources"
group placed at the top of the sidebar so the ADHD knowledge base is the
first thing parents see. Refresh the page title and subtitle to frame the
content as a TDAH knowledge base.