### PR TITLE
refactor(routes): rename /actualites to /connaissances

### DIFF
--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -18,7 +18,7 @@ import {
 } from "lucide-react";
 
 export type NavItem = {
-  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/timer" | "/care-pathway" | "/admin-vault" | "/achievements" | "/activity" | "/actualites" | "/account";
+  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/timer" | "/care-pathway" | "/admin-vault" | "/achievements" | "/activity" | "/connaissances" | "/account";
   labelKey: string;
   shortLabelKey?: string;
   icon: React.ComponentType<{ className?: string }>;
@@ -29,7 +29,7 @@ export type NavItem = {
 };
 
 export const navItems: readonly NavItem[] = [
-  { to: "/actualites", labelKey: "nav.knowledgeBase", icon: Library, group: "knowledge" },
+  { to: "/connaissances", labelKey: "nav.knowledgeBase", icon: Library, group: "knowledge" },
   { to: "/dashboard", labelKey: "nav.dashboard", shortLabelKey: "nav.home", icon: BarChart3, primary: true, group: "tracking" },
   { to: "/journal", labelKey: "nav.journal", icon: BookOpen, primary: true, group: "tracking" },
   { to: "/symptoms", labelKey: "nav.symptoms", icon: Activity, group: "tracking" },

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -32,11 +32,11 @@ import { Route as AuthenticatedCrisisListIndexRouteImport } from './routes/_auth
 import { Route as AuthenticatedCarePathwayIndexRouteImport } from './routes/_authenticated/care-pathway/index'
 import { Route as AuthenticatedBarkleyIndexRouteImport } from './routes/_authenticated/barkley/index'
 import { Route as AuthenticatedAdminVaultIndexRouteImport } from './routes/_authenticated/admin-vault/index'
-import { Route as AuthenticatedActualitesIndexRouteImport } from './routes/_authenticated/actualites/index'
+import { Route as AuthenticatedConnaissancesIndexRouteImport } from './routes/_authenticated/connaissances/index'
 import { Route as AuthenticatedActivityIndexRouteImport } from './routes/_authenticated/activity/index'
 import { Route as AuthenticatedAchievementsIndexRouteImport } from './routes/_authenticated/achievements/index'
 import { Route as AuthenticatedAccountIndexRouteImport } from './routes/_authenticated/account/index'
-import { Route as AuthenticatedActualitesSlugRouteImport } from './routes/_authenticated/actualites/$slug'
+import { Route as AuthenticatedConnaissancesSlugRouteImport } from './routes/_authenticated/connaissances/$slug'
 import { Route as AuthenticatedBarkleyFormationStepNumberRouteImport } from './routes/_authenticated/barkley/formation/$stepNumber'
 
 const MentionsLegalesRoute = MentionsLegalesRouteImport.update({
@@ -165,10 +165,10 @@ const AuthenticatedAdminVaultIndexRoute =
     path: '/admin-vault/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-const AuthenticatedActualitesIndexRoute =
-  AuthenticatedActualitesIndexRouteImport.update({
-    id: '/actualites/',
-    path: '/actualites/',
+const AuthenticatedConnaissancesIndexRoute =
+  AuthenticatedConnaissancesIndexRouteImport.update({
+    id: '/connaissances/',
+    path: '/connaissances/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 const AuthenticatedActivityIndexRoute =
@@ -189,10 +189,10 @@ const AuthenticatedAccountIndexRoute =
     path: '/account/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
-const AuthenticatedActualitesSlugRoute =
-  AuthenticatedActualitesSlugRouteImport.update({
-    id: '/actualites/$slug',
-    path: '/actualites/$slug',
+const AuthenticatedConnaissancesSlugRoute =
+  AuthenticatedConnaissancesSlugRouteImport.update({
+    id: '/connaissances/$slug',
+    path: '/connaissances/$slug',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 const AuthenticatedBarkleyFormationStepNumberRoute =
@@ -212,11 +212,11 @@ export interface FileRoutesByFullPath {
   '/ressources/$slug': typeof RessourcesSlugRoute
   '/ressources/plan-de-crise': typeof RessourcesPlanDeCriseRoute
   '/ressources/': typeof RessourcesIndexRoute
-  '/actualites/$slug': typeof AuthenticatedActualitesSlugRoute
+  '/connaissances/$slug': typeof AuthenticatedConnaissancesSlugRoute
   '/account/': typeof AuthenticatedAccountIndexRoute
   '/achievements/': typeof AuthenticatedAchievementsIndexRoute
   '/activity/': typeof AuthenticatedActivityIndexRoute
-  '/actualites/': typeof AuthenticatedActualitesIndexRoute
+  '/connaissances/': typeof AuthenticatedConnaissancesIndexRoute
   '/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley/': typeof AuthenticatedBarkleyIndexRoute
   '/care-pathway/': typeof AuthenticatedCarePathwayIndexRoute
@@ -242,11 +242,11 @@ export interface FileRoutesByTo {
   '/ressources/$slug': typeof RessourcesSlugRoute
   '/ressources/plan-de-crise': typeof RessourcesPlanDeCriseRoute
   '/ressources': typeof RessourcesIndexRoute
-  '/actualites/$slug': typeof AuthenticatedActualitesSlugRoute
+  '/connaissances/$slug': typeof AuthenticatedConnaissancesSlugRoute
   '/account': typeof AuthenticatedAccountIndexRoute
   '/achievements': typeof AuthenticatedAchievementsIndexRoute
   '/activity': typeof AuthenticatedActivityIndexRoute
-  '/actualites': typeof AuthenticatedActualitesIndexRoute
+  '/connaissances': typeof AuthenticatedConnaissancesIndexRoute
   '/admin-vault': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley': typeof AuthenticatedBarkleyIndexRoute
   '/care-pathway': typeof AuthenticatedCarePathwayIndexRoute
@@ -274,11 +274,11 @@ export interface FileRoutesById {
   '/ressources/$slug': typeof RessourcesSlugRoute
   '/ressources/plan-de-crise': typeof RessourcesPlanDeCriseRoute
   '/ressources/': typeof RessourcesIndexRoute
-  '/_authenticated/actualites/$slug': typeof AuthenticatedActualitesSlugRoute
+  '/_authenticated/connaissances/$slug': typeof AuthenticatedConnaissancesSlugRoute
   '/_authenticated/account/': typeof AuthenticatedAccountIndexRoute
   '/_authenticated/achievements/': typeof AuthenticatedAchievementsIndexRoute
   '/_authenticated/activity/': typeof AuthenticatedActivityIndexRoute
-  '/_authenticated/actualites/': typeof AuthenticatedActualitesIndexRoute
+  '/_authenticated/connaissances/': typeof AuthenticatedConnaissancesIndexRoute
   '/_authenticated/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/_authenticated/barkley/': typeof AuthenticatedBarkleyIndexRoute
   '/_authenticated/care-pathway/': typeof AuthenticatedCarePathwayIndexRoute
@@ -306,11 +306,11 @@ export interface FileRouteTypes {
     | '/ressources/$slug'
     | '/ressources/plan-de-crise'
     | '/ressources/'
-    | '/actualites/$slug'
+    | '/connaissances/$slug'
     | '/account/'
     | '/achievements/'
     | '/activity/'
-    | '/actualites/'
+    | '/connaissances/'
     | '/admin-vault/'
     | '/barkley/'
     | '/care-pathway/'
@@ -336,11 +336,11 @@ export interface FileRouteTypes {
     | '/ressources/$slug'
     | '/ressources/plan-de-crise'
     | '/ressources'
-    | '/actualites/$slug'
+    | '/connaissances/$slug'
     | '/account'
     | '/achievements'
     | '/activity'
-    | '/actualites'
+    | '/connaissances'
     | '/admin-vault'
     | '/barkley'
     | '/care-pathway'
@@ -367,11 +367,11 @@ export interface FileRouteTypes {
     | '/ressources/$slug'
     | '/ressources/plan-de-crise'
     | '/ressources/'
-    | '/_authenticated/actualites/$slug'
+    | '/_authenticated/connaissances/$slug'
     | '/_authenticated/account/'
     | '/_authenticated/achievements/'
     | '/_authenticated/activity/'
-    | '/_authenticated/actualites/'
+    | '/_authenticated/connaissances/'
     | '/_authenticated/admin-vault/'
     | '/_authenticated/barkley/'
     | '/_authenticated/care-pathway/'
@@ -564,11 +564,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminVaultIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/actualites/': {
-      id: '/_authenticated/actualites/'
-      path: '/actualites'
-      fullPath: '/actualites/'
-      preLoaderRoute: typeof AuthenticatedActualitesIndexRouteImport
+    '/_authenticated/connaissances/': {
+      id: '/_authenticated/connaissances/'
+      path: '/connaissances'
+      fullPath: '/connaissances/'
+      preLoaderRoute: typeof AuthenticatedConnaissancesIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/activity/': {
@@ -592,11 +592,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAccountIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
-    '/_authenticated/actualites/$slug': {
-      id: '/_authenticated/actualites/$slug'
-      path: '/actualites/$slug'
-      fullPath: '/actualites/$slug'
-      preLoaderRoute: typeof AuthenticatedActualitesSlugRouteImport
+    '/_authenticated/connaissances/$slug': {
+      id: '/_authenticated/connaissances/$slug'
+      path: '/connaissances/$slug'
+      fullPath: '/connaissances/$slug'
+      preLoaderRoute: typeof AuthenticatedConnaissancesSlugRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/barkley/formation/$stepNumber': {
@@ -610,11 +610,11 @@ declare module '@tanstack/react-router' {
 }
 
 interface AuthenticatedRouteChildren {
-  AuthenticatedActualitesSlugRoute: typeof AuthenticatedActualitesSlugRoute
+  AuthenticatedConnaissancesSlugRoute: typeof AuthenticatedConnaissancesSlugRoute
   AuthenticatedAccountIndexRoute: typeof AuthenticatedAccountIndexRoute
   AuthenticatedAchievementsIndexRoute: typeof AuthenticatedAchievementsIndexRoute
   AuthenticatedActivityIndexRoute: typeof AuthenticatedActivityIndexRoute
-  AuthenticatedActualitesIndexRoute: typeof AuthenticatedActualitesIndexRoute
+  AuthenticatedConnaissancesIndexRoute: typeof AuthenticatedConnaissancesIndexRoute
   AuthenticatedAdminVaultIndexRoute: typeof AuthenticatedAdminVaultIndexRoute
   AuthenticatedBarkleyIndexRoute: typeof AuthenticatedBarkleyIndexRoute
   AuthenticatedCarePathwayIndexRoute: typeof AuthenticatedCarePathwayIndexRoute
@@ -632,11 +632,11 @@ interface AuthenticatedRouteChildren {
 }
 
 const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
-  AuthenticatedActualitesSlugRoute: AuthenticatedActualitesSlugRoute,
+  AuthenticatedConnaissancesSlugRoute: AuthenticatedConnaissancesSlugRoute,
   AuthenticatedAccountIndexRoute: AuthenticatedAccountIndexRoute,
   AuthenticatedAchievementsIndexRoute: AuthenticatedAchievementsIndexRoute,
   AuthenticatedActivityIndexRoute: AuthenticatedActivityIndexRoute,
-  AuthenticatedActualitesIndexRoute: AuthenticatedActualitesIndexRoute,
+  AuthenticatedConnaissancesIndexRoute: AuthenticatedConnaissancesIndexRoute,
   AuthenticatedAdminVaultIndexRoute: AuthenticatedAdminVaultIndexRoute,
   AuthenticatedBarkleyIndexRoute: AuthenticatedBarkleyIndexRoute,
   AuthenticatedCarePathwayIndexRoute: AuthenticatedCarePathwayIndexRoute,

--- a/apps/web/src/routes/_authenticated/connaissances/$slug.tsx
+++ b/apps/web/src/routes/_authenticated/connaissances/$slug.tsx
@@ -4,7 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { articles, DEFAULT_LAST_REVIEWED, DEFAULT_REVIEWER } from "@/lib/resources-data";
 import { useTranslation } from "react-i18next";
 
-export const Route = createFileRoute("/_authenticated/actualites/$slug")({
+export const Route = createFileRoute("/_authenticated/connaissances/$slug")({
   component: ArticlePage,
   loader: ({ params }) => {
     const article = articles.find((a) => a.slug === params.slug);
@@ -20,7 +20,7 @@ function ArticlePage() {
   return (
     <article className="mx-auto max-w-3xl px-4 py-8">
       <Link
-        to="/actualites"
+        to="/connaissances"
         className="mb-6 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
       >
         <ArrowLeft className="h-3.5 w-3.5" />
@@ -101,7 +101,7 @@ function ArticlePage() {
               .map((r) => (
                 <Link
                   key={r.slug}
-                  to="/actualites/$slug"
+                  to="/connaissances/$slug"
                   params={{ slug: r.slug }}
                   className="group"
                 >

--- a/apps/web/src/routes/_authenticated/connaissances/index.tsx
+++ b/apps/web/src/routes/_authenticated/connaissances/index.tsx
@@ -12,12 +12,12 @@ import { Badge } from "@/components/ui/badge";
 import { articles } from "@/lib/resources-data";
 import { useTranslation } from "react-i18next";
 
-export const Route = createFileRoute("/_authenticated/actualites/")({
-  component: ActualitesIndex,
+export const Route = createFileRoute("/_authenticated/connaissances/")({
+  component: ConnaissancesIndex,
   staticData: { crumb: "nav.knowledgeBase" },
 });
 
-function ActualitesIndex() {
+function ConnaissancesIndex() {
   const { t } = useTranslation();
 
   const featured = articles.find((a) => a.featured);
@@ -38,7 +38,7 @@ function ActualitesIndex() {
       {/* Featured article */}
       {featured && (
         <Link
-          to="/actualites/$slug"
+          to="/connaissances/$slug"
           params={{ slug: featured.slug }}
           className="mb-8 block"
         >
@@ -75,7 +75,7 @@ function ActualitesIndex() {
         {rest.map((article) => (
           <Link
             key={article.slug}
-            to="/actualites/$slug"
+            to="/connaissances/$slug"
             params={{ slug: article.slug }}
             className="block"
           >

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -78,7 +78,7 @@ test.describe("Landing page", () => {
     // actually navigates to /ressources — the resourcesTeaser CTA goes
     // to /login instead.
     await page.getByRole("link", { name: /^Ressources$/i }).first().click();
-    await page.waitForURL(/\/(ressources|actualites)/);
+    await page.waitForURL(/\/(ressources|connaissances)/);
 
     await expect(page.locator("h1")).toBeVisible();
 

--- a/e2e/ressources.spec.ts
+++ b/e2e/ressources.spec.ts
@@ -14,7 +14,7 @@ test.describe("Resources hub", () => {
     await page.goto("/ressources");
     await page.waitForLoadState("networkidle");
     if (!/\/ressources/.test(page.url())) {
-      await page.goto("/actualites");
+      await page.goto("/connaissances");
       await page.waitForLoadState("networkidle");
       await expect(page.locator("h1")).toBeVisible();
       await context.close();


### PR DESCRIPTION
## Summary
- Rename authenticated route directory `_authenticated/actualites/` → `_authenticated/connaissances/`
- Update `createFileRoute` paths, component name, all `Link to=` references, `nav.ts` route type/item, and the generated route tree
- Update e2e tests (`landing.spec.ts`, `ressources.spec.ts`) to point at the new URL

URL now matches the "Base de connaissances" sidebar label introduced in #143.

## Test plan
- [ ] Sidebar "Base de connaissances" entry navigates to `/connaissances`
- [ ] Article links open `/connaissances/$slug` and "back to list" returns to `/connaissances`
- [ ] `pnpm test:e2e` passes for `landing.spec.ts` and `ressources.spec.ts`

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2gq7CoxhKS18urVj57GMu)_