### PR TITLE
feat(co-parent): harden invite flow with attestation, consent, and revoke cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,30 @@ jobs:
     name: Lint, Type Check & Test
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: toko
+          POSTGRES_PASSWORD: toko_secret
+          POSTGRES_DB: toko_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U toko"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      # Drives @focusflow/db's Postgres client + the test-DB harness in
+      # apps/api/src/__tests__/helpers/test-db.ts.
+      DATABASE_URL: postgres://toko:toko_secret@localhost:5432/toko_test
+      INTEGRATION_DB: "1"
+      # Required by encrypted-text columns (children.name etc.) — same
+      # opaque test value the local env.ts default uses.
+      DB_ENCRYPTION_KEY: "0000000000000000000000000000000000000000000000000000000000000001"
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/apps/api/src/__tests__/child-invitations.integration.test.ts
+++ b/apps/api/src/__tests__/child-invitations.integration.test.ts
@@ -1,0 +1,415 @@
+// Integration test suite for the co-parent flows. Skips entirely unless
+// INTEGRATION_DB=1 is set — see helpers/test-db.ts. Run locally with:
+//
+//   docker compose -f compose.local.yml up -d postgres
+//   DATABASE_URL=postgres://toko:toko_secret@localhost:5432/toko_test \
+//     INTEGRATION_DB=1 \
+//     DB_ENCRYPTION_KEY=$(openssl rand -hex 32) \
+//     pnpm --filter @focusflow/api test
+//
+// CI sets these on the lint-test job (.github/workflows/ci.yml).
+import { vi } from "vitest";
+
+// IMPORTANT: vi.mock calls are hoisted above imports, so the auth
+// middleware is replaced before app.ts loads its routes.
+vi.mock("../middleware/auth", async () => {
+  const { testAuthMiddleware } = await import("./helpers/auth-mock");
+  return { authMiddleware: testAuthMiddleware };
+});
+
+// Stub Resend so the invite POST doesn't 500 in CI: production refuses to
+// create an invite if the email never went out, which is correct, but in
+// tests we just need to know the route would have called sendEmail.
+vi.mock("../lib/email", () => ({
+  sendEmail: vi.fn(async () => ({ sent: true, id: "test-message-id" })),
+}));
+
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { and, eq, isNull } from "drizzle-orm";
+import { db } from "@focusflow/db";
+import {
+  childAccess,
+  childInvitations,
+  consents,
+} from "@focusflow/db";
+import { app } from "../app";
+import {
+  ensureMigrations,
+  truncateAll,
+  integrationDbAvailable,
+} from "./helpers/test-db";
+import {
+  createChild,
+  createUser,
+  createPendingInvite,
+  hashToken,
+} from "./helpers/fixtures";
+import { TEST_USER_HEADER } from "./helpers/auth-mock";
+
+const skip = !integrationDbAvailable;
+
+describe.skipIf(skip)("co-parent invitations — DB integration", () => {
+  beforeAll(async () => {
+    await ensureMigrations();
+  });
+
+  afterEach(async () => {
+    await truncateAll();
+  });
+
+  describe("POST /api/child-invitations", () => {
+    it("creates an invite + parental-authority consent row when owner attests", async () => {
+      const owner = await createUser({ name: "Sophie" });
+      const child = await createChild({ ownerId: owner.id, name: "Léa" });
+
+      const res = await app.request("/api/child-invitations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [TEST_USER_HEADER]: owner.id,
+        },
+        body: JSON.stringify({
+          childId: child.id,
+          email: "marc@famille.fr",
+          parentalAuthorityAttestation: true,
+        }),
+      });
+      expect(res.status).toBe(200);
+
+      const invites = await db
+        .select()
+        .from(childInvitations)
+        .where(eq(childInvitations.childId, child.id));
+      expect(invites).toHaveLength(1);
+      expect(invites[0]!.invitedEmail).toBe("marc@famille.fr");
+      expect(invites[0]!.acceptedAt).toBeNull();
+
+      const consentRows = await db
+        .select()
+        .from(consents)
+        .where(eq(consents.userId, owner.id));
+      expect(consentRows).toHaveLength(1);
+      expect(consentRows[0]!.type).toBe("parental_authority_attestation");
+    });
+
+    it("rejects 422 when the attestation is missing", async () => {
+      const owner = await createUser();
+      const child = await createChild({ ownerId: owner.id });
+
+      const res = await app.request("/api/child-invitations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [TEST_USER_HEADER]: owner.id,
+        },
+        body: JSON.stringify({
+          childId: child.id,
+          email: "marc@famille.fr",
+        }),
+      });
+      expect(res.status).toBe(422);
+    });
+
+    it("blocks self-invite with 403", async () => {
+      const owner = await createUser({ email: "self@famille.fr" });
+      const child = await createChild({ ownerId: owner.id });
+
+      const res = await app.request("/api/child-invitations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [TEST_USER_HEADER]: owner.id,
+        },
+        body: JSON.stringify({
+          childId: child.id,
+          email: "self@famille.fr",
+          parentalAuthorityAttestation: true,
+        }),
+      });
+      expect(res.status).toBe(403);
+    });
+
+    it("returns alreadyMember:true without writing when invitee is already a co-parent", async () => {
+      const owner = await createUser();
+      const coParent = await createUser({ email: "marc@famille.fr" });
+      const child = await createChild({ ownerId: owner.id });
+      await db.insert(childAccess).values({
+        childId: child.id,
+        userId: coParent.id,
+        role: "co_parent",
+      });
+
+      const res = await app.request("/api/child-invitations", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          [TEST_USER_HEADER]: owner.id,
+        },
+        body: JSON.stringify({
+          childId: child.id,
+          email: "marc@famille.fr",
+          parentalAuthorityAttestation: true,
+        }),
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { alreadyMember?: boolean };
+      expect(body.alreadyMember).toBe(true);
+
+      const invites = await db
+        .select()
+        .from(childInvitations)
+        .where(eq(childInvitations.childId, child.id));
+      expect(invites).toHaveLength(0);
+    });
+  });
+
+  describe("POST /api/child-invitations/:token/accept", () => {
+    it("happy path: creates child_access + co-parent consent + flips acceptedAt", async () => {
+      const owner = await createUser();
+      const child = await createChild({ ownerId: owner.id });
+      const invitee = await createUser({
+        email: "marc@famille.fr",
+        emailVerified: true,
+      });
+      const { token, id: inviteId } = await createPendingInvite({
+        childId: child.id,
+        invitedBy: owner.id,
+        invitedEmail: "marc@famille.fr",
+      });
+
+      const res = await app.request(
+        `/api/child-invitations/${token}/accept`,
+        {
+          method: "POST",
+          headers: { [TEST_USER_HEADER]: invitee.id },
+        },
+      );
+      expect(res.status).toBe(200);
+
+      const access = await db
+        .select()
+        .from(childAccess)
+        .where(
+          and(
+            eq(childAccess.childId, child.id),
+            eq(childAccess.userId, invitee.id),
+          ),
+        );
+      expect(access).toHaveLength(1);
+      expect(access[0]!.role).toBe("co_parent");
+
+      const consentRows = await db
+        .select()
+        .from(consents)
+        .where(eq(consents.userId, invitee.id));
+      expect(consentRows).toHaveLength(1);
+      expect(consentRows[0]!.type).toBe("co_parent_health_processing");
+
+      const [invite] = await db
+        .select()
+        .from(childInvitations)
+        .where(eq(childInvitations.id, inviteId));
+      expect(invite!.acceptedAt).not.toBeNull();
+    });
+
+    it("returns 404 (no leak as 403) when the signed-in email doesn't match", async () => {
+      const owner = await createUser();
+      const child = await createChild({ ownerId: owner.id });
+      const wrongUser = await createUser({
+        email: "other@famille.fr",
+        emailVerified: true,
+      });
+      const { token } = await createPendingInvite({
+        childId: child.id,
+        invitedBy: owner.id,
+        invitedEmail: "marc@famille.fr",
+      });
+
+      const res = await app.request(
+        `/api/child-invitations/${token}/accept`,
+        {
+          method: "POST",
+          headers: { [TEST_USER_HEADER]: wrongUser.id },
+        },
+      );
+      expect(res.status).toBe(404);
+    });
+
+    it("returns 403 when the invitee's email is not yet verified", async () => {
+      const owner = await createUser();
+      const child = await createChild({ ownerId: owner.id });
+      const unverified = await createUser({
+        email: "marc@famille.fr",
+        emailVerified: false,
+      });
+      const { token } = await createPendingInvite({
+        childId: child.id,
+        invitedBy: owner.id,
+        invitedEmail: "marc@famille.fr",
+      });
+
+      const res = await app.request(
+        `/api/child-invitations/${token}/accept`,
+        {
+          method: "POST",
+          headers: { [TEST_USER_HEADER]: unverified.id },
+        },
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it("rejects a second accept of the same token with 404 (idempotent)", async () => {
+      const owner = await createUser();
+      const child = await createChild({ ownerId: owner.id });
+      const invitee = await createUser({
+        email: "marc@famille.fr",
+        emailVerified: true,
+      });
+      const { token } = await createPendingInvite({
+        childId: child.id,
+        invitedBy: owner.id,
+        invitedEmail: "marc@famille.fr",
+      });
+
+      const first = await app.request(
+        `/api/child-invitations/${token}/accept`,
+        {
+          method: "POST",
+          headers: { [TEST_USER_HEADER]: invitee.id },
+        },
+      );
+      expect(first.status).toBe(200);
+
+      const second = await app.request(
+        `/api/child-invitations/${token}/accept`,
+        {
+          method: "POST",
+          headers: { [TEST_USER_HEADER]: invitee.id },
+        },
+      );
+      expect(second.status).toBe(404);
+
+      // Exactly one access row, regardless of replay attempts.
+      const access = await db
+        .select()
+        .from(childAccess)
+        .where(
+          and(
+            eq(childAccess.childId, child.id),
+            eq(childAccess.userId, invitee.id),
+          ),
+        );
+      expect(access).toHaveLength(1);
+    });
+  });
+
+  describe("DELETE /api/child-access/child/:childId/user/:userId", () => {
+    it("revoke deletes pending invites for the same email so a stale link can't undo it", async () => {
+      const owner = await createUser();
+      const coParent = await createUser({
+        email: "marc@famille.fr",
+        emailVerified: true,
+      });
+      const child = await createChild({ ownerId: owner.id });
+      // Co-parent already accepted a previous invite (so they're a member).
+      await db.insert(childAccess).values({
+        childId: child.id,
+        userId: coParent.id,
+        role: "co_parent",
+      });
+      // Owner had also fired off ANOTHER invite that's still pending. The
+      // canonical exploit: revoke the co-parent, they re-accept via the
+      // pending email link, access restored.
+      const stale = await createPendingInvite({
+        childId: child.id,
+        invitedBy: owner.id,
+        invitedEmail: "marc@famille.fr",
+      });
+
+      const res = await app.request(
+        `/api/child-access/child/${child.id}/user/${coParent.id}`,
+        { method: "DELETE", headers: { [TEST_USER_HEADER]: owner.id } },
+      );
+      expect(res.status).toBe(200);
+
+      const accessLeft = await db
+        .select()
+        .from(childAccess)
+        .where(
+          and(
+            eq(childAccess.childId, child.id),
+            eq(childAccess.userId, coParent.id),
+          ),
+        );
+      expect(accessLeft).toHaveLength(0);
+
+      // The pending invite must be gone too — the security fix.
+      const invites = await db
+        .select()
+        .from(childInvitations)
+        .where(eq(childInvitations.id, stale.id));
+      expect(invites).toHaveLength(0);
+    });
+  });
+
+  describe("GET /api/child-invitations/:token (public lookup)", () => {
+    it("returns childName + inviterName but NEVER invitedEmail", async () => {
+      const owner = await createUser({ name: "Sophie" });
+      const child = await createChild({ ownerId: owner.id, name: "Léa" });
+      const { token } = await createPendingInvite({
+        childId: child.id,
+        invitedBy: owner.id,
+        invitedEmail: "marc@famille.fr",
+      });
+
+      const res = await app.request(`/api/child-invitations/${token}`);
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, unknown>;
+      expect(body.childName).toBe("Léa");
+      expect(body.inviterName).toBe("Sophie");
+      expect(body).not.toHaveProperty("invitedEmail");
+    });
+
+    it("returns 404 once an invite has been accepted (replay defense)", async () => {
+      const owner = await createUser();
+      const child = await createChild({ ownerId: owner.id });
+      const { token, id } = await createPendingInvite({
+        childId: child.id,
+        invitedBy: owner.id,
+        invitedEmail: "marc@famille.fr",
+      });
+      // Mark accepted directly to avoid coupling this test to the accept route.
+      await db
+        .update(childInvitations)
+        .set({ acceptedAt: new Date() })
+        .where(eq(childInvitations.id, id));
+
+      const res = await app.request(`/api/child-invitations/${token}`);
+      expect(res.status).toBe(404);
+    });
+
+    it("does not match a token by an unrelated user via timing/lookup", async () => {
+      const owner = await createUser();
+      const child = await createChild({ ownerId: owner.id });
+      await createPendingInvite({
+        childId: child.id,
+        invitedBy: owner.id,
+        invitedEmail: "marc@famille.fr",
+      });
+
+      // Random valid-shape token that won't match any tokenHash.
+      const random = "f".repeat(64);
+      const res = await app.request(`/api/child-invitations/${random}`);
+      expect(res.status).toBe(404);
+      // The unrelated invite is still pending — we shouldn't have touched it.
+      const stillPending = await db
+        .select()
+        .from(childInvitations)
+        .where(isNull(childInvitations.acceptedAt));
+      expect(stillPending).toHaveLength(1);
+    });
+  });
+});
+
+// Reference unused imports so TS doesn't strip them when the suite is skipped.
+void hashToken;

--- a/apps/api/src/__tests__/child-invitations.routes.test.ts
+++ b/apps/api/src/__tests__/child-invitations.routes.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { app } from "../app";
+
+// Route-level smoke tests: these exercise the middleware ordering and the
+// validation paths that 404/401 BEFORE any database query, so they run in
+// CI without a Postgres harness. Anything that requires DB state (the
+// happy-path accept, the revoke→pending-cleanup integration, etc.) is
+// covered by the planned multi-user E2E in a follow-up branch.
+
+describe("GET /api/child-invitations/:token (public lookup)", () => {
+  it("returns 404 for a token shorter than the 20-char entropy floor", async () => {
+    const res = await app.request("/api/child-invitations/abc");
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 404 for an obviously-empty token (path traversal guard)", async () => {
+    // Trailing slash on the collection — Hono treats this as the parent
+    // GET / route, which requires auth → 401, never the lookup → no leak.
+    const res = await app.request("/api/child-invitations/");
+    expect([401, 404]).toContain(res.status);
+  });
+});
+
+describe("authentication gates on co-parent endpoints", () => {
+  it("POST /api/child-invitations without a session returns 401", async () => {
+    const res = await app.request("/api/child-invitations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        childId: "any",
+        email: "co@famille.fr",
+        parentalAuthorityAttestation: true,
+      }),
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/child-invitations (list pending) without a session returns 401", async () => {
+    const res = await app.request("/api/child-invitations?childId=any");
+    expect(res.status).toBe(401);
+  });
+
+  it("DELETE /api/child-invitations/:id without a session returns 401", async () => {
+    const res = await app.request("/api/child-invitations/some-id", {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /api/child-invitations/:token/accept without a session returns 401", async () => {
+    // Use a 64-hex-char token so we get past schema validation and prove
+    // it's the auth middleware that's blocking, not the validator.
+    const validShapeToken = "a".repeat(64);
+    const res = await app.request(
+      `/api/child-invitations/${validShapeToken}/accept`,
+      { method: "POST" },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/child-access/child/:childId without a session returns 401", async () => {
+    const res = await app.request("/api/child-access/child/some-id");
+    expect(res.status).toBe(401);
+  });
+
+  it("DELETE /api/child-access/child/:childId/user/:userId without a session returns 401", async () => {
+    const res = await app.request(
+      "/api/child-access/child/some-child/user/some-user",
+      { method: "DELETE" },
+    );
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/src/__tests__/child-invitations.test.ts
+++ b/apps/api/src/__tests__/child-invitations.test.ts
@@ -13,14 +13,37 @@ function hashToken(token: string): string {
 }
 
 describe("child invitation validators", () => {
-  it("inviteSchema accepts a normal email and rejects garbage", () => {
-    expect(inviteSchema.safeParse({ email: "co@famille.fr" }).success).toBe(
-      true,
-    );
-    expect(inviteSchema.safeParse({ email: "not-an-email" }).success).toBe(
-      false,
-    );
-    expect(inviteSchema.safeParse({ email: "" }).success).toBe(false);
+  it("inviteSchema requires a valid email AND a parental-authority attestation", () => {
+    expect(
+      inviteSchema.safeParse({
+        email: "co@famille.fr",
+        parentalAuthorityAttestation: true,
+      }).success,
+    ).toBe(true);
+
+    // No attestation → reject (RGPD Art. 9(2)(a) gate).
+    expect(
+      inviteSchema.safeParse({ email: "co@famille.fr" }).success,
+    ).toBe(false);
+    expect(
+      inviteSchema.safeParse({
+        email: "co@famille.fr",
+        parentalAuthorityAttestation: false,
+      }).success,
+    ).toBe(false);
+
+    expect(
+      inviteSchema.safeParse({
+        email: "not-an-email",
+        parentalAuthorityAttestation: true,
+      }).success,
+    ).toBe(false);
+    expect(
+      inviteSchema.safeParse({
+        email: "",
+        parentalAuthorityAttestation: true,
+      }).success,
+    ).toBe(false);
   });
 
   it("acceptInviteParamsSchema rejects short tokens (entropy floor)", () => {

--- a/apps/api/src/__tests__/co-parent-emails.test.ts
+++ b/apps/api/src/__tests__/co-parent-emails.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildInviteEmail,
+  buildAcceptanceEmail,
+} from "../lib/co-parent-emails";
+
+describe("buildInviteEmail", () => {
+  const baseParams = {
+    inviterName: "Sophie",
+    childName: "Léa",
+    acceptUrl: "https://app.toko.test/invite/abc123",
+    expiresAt: new Date("2026-05-23T00:00:00Z"),
+  };
+
+  it("renders French subject-area copy with inviter and child names", () => {
+    const html = buildInviteEmail(baseParams);
+    expect(html).toContain("Sophie aimerait partager avec vous le carnet de Léa");
+    expect(html).toContain("Tokō · invitation");
+  });
+
+  it("escapes HTML in the inviter and child names", () => {
+    const html = buildInviteEmail({
+      ...baseParams,
+      inviterName: "Sophie & co <script>",
+      childName: "L\"éa\"",
+    });
+    expect(html).toContain("Sophie &amp; co &lt;script&gt;");
+    expect(html).toContain("L&quot;éa&quot;");
+    expect(html).not.toContain("<script>");
+  });
+
+  it("includes the accept URL in both the button and the fallback line", () => {
+    const html = buildInviteEmail(baseParams);
+    const occurrences = html.match(/abc123/g) ?? [];
+    expect(occurrences.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("formats the expiry date in French long form", () => {
+    const html = buildInviteEmail(baseParams);
+    expect(html).toMatch(/L'invitation expire le 23 mai 2026/);
+  });
+
+  it("includes the silent-discard line so unsolicited recipients can ignore", () => {
+    const html = buildInviteEmail(baseParams);
+    expect(html).toContain("aucun compte n'est créé sans votre action");
+  });
+});
+
+describe("buildAcceptanceEmail", () => {
+  const baseParams = {
+    inviterName: "Sophie",
+    acceptorLabel: "Marc",
+    childName: "Léa",
+    appUrl: "https://app.toko.test",
+  };
+
+  it("addresses the inviter by name and announces the acceptor joined", () => {
+    const html = buildAcceptanceEmail(baseParams);
+    expect(html).toContain("Marc a rejoint le carnet de Léa");
+    expect(html).toContain("Sophie, votre invitation a été acceptée");
+  });
+
+  it("falls back to a neutral salutation when inviter name is empty", () => {
+    const html = buildAcceptanceEmail({ ...baseParams, inviterName: "" });
+    expect(html).toContain("Bonjour, votre invitation a été acceptée");
+  });
+
+  it("links the dashboard from the app URL", () => {
+    const html = buildAcceptanceEmail(baseParams);
+    expect(html).toContain('href="https://app.toko.test/dashboard"');
+  });
+
+  it("escapes HTML in all dynamic fields", () => {
+    const html = buildAcceptanceEmail({
+      inviterName: "<S>",
+      acceptorLabel: "<M>",
+      childName: "<L>",
+      appUrl: "https://app.toko.test",
+    });
+    expect(html).toContain("&lt;S&gt;");
+    expect(html).toContain("&lt;M&gt;");
+    expect(html).toContain("&lt;L&gt;");
+    expect(html).not.toMatch(/<S>|<M>|<L>/);
+  });
+
+  it("reminds the inviter they remain the subscription holder", () => {
+    const html = buildAcceptanceEmail(baseParams);
+    expect(html).toContain("Vous restez la personne qui gère l'abonnement");
+  });
+});

--- a/apps/api/src/__tests__/helpers/auth-mock.ts
+++ b/apps/api/src/__tests__/helpers/auth-mock.ts
@@ -1,0 +1,44 @@
+import type { Context, Next } from "hono";
+import { eq } from "drizzle-orm";
+import { db, user as userTable } from "@focusflow/db";
+
+// Drop-in replacement for the real authMiddleware in integration tests.
+// Tests authenticate by passing the fixture user's id in the
+// `x-test-user-id` header instead of a Better Auth session cookie — the
+// route handlers see the same `c.get("user")` shape they would in prod.
+//
+// Anything outside the test runner can't reach this code path because the
+// helper is only imported from __tests__.
+export const TEST_USER_HEADER = "x-test-user-id";
+
+export async function testAuthMiddleware(
+  c: Context,
+  next: Next,
+): Promise<Response | void> {
+  const userId = c.req.header(TEST_USER_HEADER);
+  if (!userId) {
+    return c.json({ error: "Non autorisé", code: "UNAUTHORIZED" }, 401);
+  }
+
+  const [row] = await db
+    .select({
+      id: userTable.id,
+      name: userTable.name,
+      email: userTable.email,
+      emailVerified: userTable.emailVerified,
+    })
+    .from(userTable)
+    .where(eq(userTable.id, userId))
+    .limit(1);
+
+  if (!row) {
+    return c.json({ error: "Non autorisé", code: "UNAUTHORIZED" }, 401);
+  }
+
+  c.set("user", row);
+  c.set("session", {
+    id: "test-session",
+    expiresAt: new Date(Date.now() + 60 * 60_000),
+  });
+  await next();
+}

--- a/apps/api/src/__tests__/helpers/fixtures.ts
+++ b/apps/api/src/__tests__/helpers/fixtures.ts
@@ -1,0 +1,101 @@
+import { randomBytes, createHash } from "node:crypto";
+import { db } from "@focusflow/db";
+import {
+  user as userTable,
+  children,
+  childAccess,
+  childInvitations,
+} from "@focusflow/db";
+
+export interface TestUser {
+  id: string;
+  email: string;
+  name: string;
+  emailVerified: boolean;
+}
+
+interface CreateUserOpts {
+  email?: string;
+  name?: string;
+  emailVerified?: boolean;
+}
+
+let userCounter = 0;
+
+export async function createUser(opts: CreateUserOpts = {}): Promise<TestUser> {
+  userCounter += 1;
+  const id = crypto.randomUUID();
+  const email = opts.email ?? `test-${userCounter}-${Date.now()}@toko.test`;
+  const name = opts.name ?? `Test User ${userCounter}`;
+  const emailVerified = opts.emailVerified ?? true;
+
+  await db.insert(userTable).values({
+    id,
+    name,
+    email,
+    emailVerified,
+  });
+
+  return { id, email, name, emailVerified };
+}
+
+export async function createChild(opts: {
+  ownerId: string;
+  name?: string;
+}): Promise<{ id: string }> {
+  // children.name is encrypted; we only need a string here. Drizzle's
+  // $defaultFn populates the id, and ageRange is required by the schema
+  // even if no test cares about it.
+  const [row] = await db
+    .insert(children)
+    .values({
+      name: opts.name ?? "Test Child",
+      parentId: opts.ownerId,
+      ageRange: "6-8",
+    })
+    .returning({ id: children.id });
+
+  // Grant the owner role on child_access — every other domain check
+  // reads this table, not children.parent_id.
+  await db.insert(childAccess).values({
+    childId: row!.id,
+    userId: opts.ownerId,
+    role: "owner",
+  });
+
+  return { id: row!.id };
+}
+
+export function makeRawToken(): string {
+  return randomBytes(32).toString("hex");
+}
+
+export function hashToken(token: string): string {
+  return createHash("sha256").update(token).digest("hex");
+}
+
+export async function createPendingInvite(opts: {
+  childId: string;
+  invitedBy: string;
+  invitedEmail: string;
+  expiresInDays?: number;
+}): Promise<{ token: string; id: string }> {
+  const token = makeRawToken();
+  const tokenHash = hashToken(token);
+  const expiresAt = new Date(
+    Date.now() + (opts.expiresInDays ?? 14) * 24 * 60 * 60_000,
+  );
+
+  const [row] = await db
+    .insert(childInvitations)
+    .values({
+      childId: opts.childId,
+      invitedBy: opts.invitedBy,
+      invitedEmail: opts.invitedEmail.toLowerCase(),
+      tokenHash,
+      expiresAt,
+    })
+    .returning({ id: childInvitations.id });
+
+  return { token, id: row!.id };
+}

--- a/apps/api/src/__tests__/helpers/test-db.ts
+++ b/apps/api/src/__tests__/helpers/test-db.ts
@@ -1,0 +1,38 @@
+import { sql } from "drizzle-orm";
+import { db, migrate } from "@focusflow/db";
+
+// Tables we touch in integration tests, in an order that respects FK
+// references. TRUNCATE ... CASCADE means we don't strictly need this, but
+// listing them explicitly makes test failures easier to diagnose and
+// guards against accidentally wiping a tag table that's been added since.
+const TEST_TABLES = [
+  "audit_log",
+  "consents",
+  "child_invitations",
+  "child_access",
+  "children",
+  "session",
+  '"user"',
+] as const;
+
+let migrated = false;
+
+export const integrationDbAvailable = process.env.INTEGRATION_DB === "1";
+
+// Lazy migration: only run once per test process. Skips entirely when the
+// integration flag isn't set so the unit-test path stays fast and DB-free.
+export async function ensureMigrations(): Promise<void> {
+  if (!integrationDbAvailable || migrated) return;
+  await migrate();
+  migrated = true;
+}
+
+// Wipe every table the co-parent flows touch. Cheaper than dropping/
+// recreating the schema and bullet-proof under FK constraints.
+export async function truncateAll(): Promise<void> {
+  if (!integrationDbAvailable) return;
+  const list = TEST_TABLES.join(", ");
+  await db.execute(sql.raw(`TRUNCATE TABLE ${list} RESTART IDENTITY CASCADE`));
+}
+
+export { db };

--- a/apps/api/src/lib/audit.ts
+++ b/apps/api/src/lib/audit.ts
@@ -16,7 +16,7 @@ type EntityType =
   | "routine_completion"
   | "admin_document";
 
-type Action = "create" | "update" | "delete" | "accept" | "revoke";
+type Action = "create" | "update" | "delete" | "accept" | "revoke" | "cancel";
 
 interface LogAuditOptions {
   actorId: string;

--- a/apps/api/src/lib/co-parent-emails.ts
+++ b/apps/api/src/lib/co-parent-emails.ts
@@ -1,0 +1,90 @@
+// Email HTML for the co-parent invitation lifecycle. Kept in a dedicated
+// module so the templates are unit-testable and so future copy changes can
+// happen without touching the route handler.
+
+interface InviteEmailParams {
+  inviterName: string;
+  childName: string;
+  acceptUrl: string;
+  expiresAt: Date;
+}
+
+interface AcceptanceEmailParams {
+  inviterName: string;
+  acceptorLabel: string;
+  childName: string;
+  appUrl: string;
+}
+
+export function buildInviteEmail({
+  inviterName,
+  childName,
+  acceptUrl,
+  expiresAt,
+}: InviteEmailParams): string {
+  const expiryFr = expiresAt.toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+  const safeInviter = escapeHtml(inviterName);
+  const safeChild = escapeHtml(childName);
+  return `<!DOCTYPE html>
+<html lang="fr"><head><meta charset="utf-8"><title>Invitation Tokō</title></head>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:24px;color:#1f2937">
+  <div style="border-bottom:2px solid #6366f1;padding-bottom:16px;margin-bottom:24px">
+    <p style="font-size:12px;text-transform:uppercase;letter-spacing:0.1em;color:#6366f1;margin:0">Tokō · invitation</p>
+    <h1 style="font-size:22px;margin:8px 0 4px">${safeInviter} aimerait partager avec vous le carnet de ${safeChild}</h1>
+  </div>
+  <p style="font-size:15px;line-height:1.6">
+    Tokō est un carnet de consultation TDAH partagé. En acceptant cette invitation, vous accédez aux mêmes informations que ${safeInviter} pour ${safeChild} : symptômes, journal, traitement, programme Barkley.
+  </p>
+  <p style="text-align:center;margin:24px 0">
+    <a href="${acceptUrl}" style="display:inline-block;background:#6366f1;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600">Accepter l'invitation</a>
+  </p>
+  <p style="font-size:13px;color:#6b7280">
+    Ou collez ce lien dans votre navigateur :<br>
+    <a href="${acceptUrl}" style="color:#6366f1;word-break:break-all">${acceptUrl}</a>
+  </p>
+  <p style="font-size:12px;color:#9ca3af;margin-top:24px">
+    L'invitation expire le ${expiryFr}. Si vous n'attendiez pas cet email, ignorez-le — aucun compte n'est créé sans votre action.
+  </p>
+</body></html>`;
+}
+
+export function buildAcceptanceEmail({
+  inviterName,
+  acceptorLabel,
+  childName,
+  appUrl,
+}: AcceptanceEmailParams): string {
+  const safeInviter = escapeHtml(inviterName || "Bonjour");
+  const safeAcceptor = escapeHtml(acceptorLabel);
+  const safeChild = escapeHtml(childName);
+  return `<!DOCTYPE html>
+<html lang="fr"><head><meta charset="utf-8"><title>Invitation acceptée</title></head>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:24px;color:#1f2937">
+  <div style="border-bottom:2px solid #16a34a;padding-bottom:16px;margin-bottom:24px">
+    <p style="font-size:12px;text-transform:uppercase;letter-spacing:0.1em;color:#16a34a;margin:0">Tokō · invitation acceptée</p>
+    <h1 style="font-size:22px;margin:8px 0 4px">${safeAcceptor} a rejoint le carnet de ${safeChild}</h1>
+  </div>
+  <p style="font-size:15px;line-height:1.6">
+    ${safeInviter}, votre invitation a été acceptée. ${safeAcceptor} dispose maintenant des mêmes accès que vous pour ${safeChild} : symptômes, journal, traitement, programme Barkley, rendez-vous.
+  </p>
+  <p style="text-align:center;margin:24px 0">
+    <a href="${appUrl}/dashboard" style="display:inline-block;background:#16a34a;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600">Ouvrir Tokō</a>
+  </p>
+  <p style="font-size:12px;color:#9ca3af;margin-top:24px">
+    Vous restez la personne qui gère l'abonnement et qui peut retirer l'accès à tout moment depuis les paramètres de l'enfant.
+  </p>
+</body></html>`;
+}
+
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");
+}

--- a/apps/api/src/routes/child-access.ts
+++ b/apps/api/src/routes/child-access.ts
@@ -1,8 +1,9 @@
 import { Hono } from "hono";
-import { and, eq } from "drizzle-orm";
+import { and, eq, isNull } from "drizzle-orm";
 import {
   db,
   childAccess,
+  childInvitations,
   user as userTable,
 } from "@focusflow/db";
 import { authMiddleware } from "../middleware/auth";
@@ -60,16 +61,42 @@ childAccessRoutes.delete("/child/:childId/user/:userId", async (c) => {
     );
   }
 
-  const deleted = await db
-    .delete(childAccess)
-    .where(
-      and(
-        eq(childAccess.childId, childId),
-        eq(childAccess.userId, targetUserId),
-        eq(childAccess.role, "co_parent"),
-      ),
-    )
-    .returning({ id: childAccess.id });
+  const [target] = await db
+    .select({ email: userTable.email })
+    .from(userTable)
+    .where(eq(userTable.id, targetUserId))
+    .limit(1);
+
+  // Delete the access row AND any not-yet-accepted invitations for the same
+  // (child, email) pair. Without this, revoke is bypassable: a previously
+  // emailed link still resolves, the invitee re-accepts, and the revoke is
+  // effectively undone. Done in one tx so we never leave a stale invite.
+  const deleted = await db.transaction(async (tx) => {
+    const removed = await tx
+      .delete(childAccess)
+      .where(
+        and(
+          eq(childAccess.childId, childId),
+          eq(childAccess.userId, targetUserId),
+          eq(childAccess.role, "co_parent"),
+        ),
+      )
+      .returning({ id: childAccess.id });
+
+    if (target?.email && removed.length > 0) {
+      await tx
+        .delete(childInvitations)
+        .where(
+          and(
+            eq(childInvitations.childId, childId),
+            eq(childInvitations.invitedEmail, target.email.toLowerCase()),
+            isNull(childInvitations.acceptedAt),
+          ),
+        );
+    }
+
+    return removed;
+  });
 
   if (deleted.length === 0) {
     throw new AppError("NOT_FOUND", "Co-parent non trouvé", 404);

--- a/apps/api/src/routes/child-invitations.ts
+++ b/apps/api/src/routes/child-invitations.ts
@@ -1,5 +1,5 @@
 import { Hono } from "hono";
-import { and, eq } from "drizzle-orm";
+import { and, eq, gt, isNull } from "drizzle-orm";
 import { createHash, randomBytes } from "node:crypto";
 import {
   db,
@@ -110,6 +110,80 @@ childInvitationsRoutes.get("/:token", tokenLookupRateLimiter, async (c) => {
     inviterName: row.inviterName ?? "Un parent",
     expiresAt: row.expiresAt,
   });
+});
+
+// List pending (not-yet-accepted, not-expired) invitations for a given child.
+// Owner-only: a co-parent shouldn't see invites the owner is sending on the
+// side, especially in separated-household scenarios.
+childInvitationsRoutes.get("/", authMiddleware, async (c) => {
+  const currentUser = c.get("user");
+  const childId = c.req.query("childId");
+  if (!childId) {
+    return c.json({ error: "childId requis" }, 400);
+  }
+
+  await assertChildOwner(currentUser.id, childId);
+
+  const rows = await db
+    .select({
+      id: childInvitations.id,
+      invitedEmail: childInvitations.invitedEmail,
+      createdAt: childInvitations.createdAt,
+      expiresAt: childInvitations.expiresAt,
+    })
+    .from(childInvitations)
+    .where(
+      and(
+        eq(childInvitations.childId, childId),
+        isNull(childInvitations.acceptedAt),
+        gt(childInvitations.expiresAt, new Date()),
+      ),
+    )
+    .orderBy(childInvitations.createdAt);
+
+  return c.json(rows);
+});
+
+// Owner cancels a pending invite (typo in the email, change of heart, etc.).
+// Already-accepted invites are no-ops here — to revoke a co-parent who has
+// accepted, use DELETE /child-access/child/:childId/user/:userId.
+childInvitationsRoutes.delete("/:id", authMiddleware, async (c) => {
+  const currentUser = c.get("user");
+  const id = c.req.param("id");
+  if (!id) {
+    throw new AppError("NOT_FOUND", "Invitation introuvable", 404);
+  }
+
+  const [invite] = await db
+    .select({
+      id: childInvitations.id,
+      childId: childInvitations.childId,
+      invitedEmail: childInvitations.invitedEmail,
+      acceptedAt: childInvitations.acceptedAt,
+    })
+    .from(childInvitations)
+    .where(eq(childInvitations.id, id))
+    .limit(1);
+
+  if (!invite || invite.acceptedAt) {
+    throw new AppError("NOT_FOUND", "Invitation introuvable", 404);
+  }
+
+  await assertChildOwner(currentUser.id, invite.childId);
+
+  await db.delete(childInvitations).where(eq(childInvitations.id, id));
+
+  void logAudit({
+    actorId: currentUser.id,
+    actorName: currentUser.name ?? null,
+    childId: invite.childId,
+    entityType: "child_invitation",
+    entityId: invite.id,
+    action: "cancel",
+    summary: `Invitation annulée pour ${invite.invitedEmail}`,
+  });
+
+  return c.json({ ok: true });
 });
 
 // Send an invite. Body: { childId, email }. Owner-only — co-parents can't
@@ -319,9 +393,59 @@ childInvitationsRoutes.post(
       summary: `${currentUser.name ?? "Un parent"} a accepté l'invitation`,
     });
 
+    // Notify the inviter so they know the link landed and the carnet is now
+    // shared. Fire-and-forget — a failed Resend call must not roll back the
+    // accept itself.
+    void notifyInviterOfAcceptance({
+      inviterId: invite.invitedBy,
+      childId: invite.childId,
+      acceptorName: currentUser.name ?? null,
+      acceptorEmail: currentUser.email,
+    });
+
     return c.json({ ok: true, childId: invite.childId });
   },
 );
+
+async function notifyInviterOfAcceptance({
+  inviterId,
+  childId,
+  acceptorName,
+  acceptorEmail,
+}: {
+  inviterId: string;
+  childId: string;
+  acceptorName: string | null;
+  acceptorEmail: string;
+}): Promise<void> {
+  try {
+    const [row] = await db
+      .select({
+        inviterEmail: userTable.email,
+        inviterName: userTable.name,
+        childName: children.name,
+      })
+      .from(userTable)
+      .innerJoin(children, eq(children.id, childId))
+      .where(eq(userTable.id, inviterId))
+      .limit(1);
+    if (!row?.inviterEmail) return;
+
+    const acceptorLabel = acceptorName?.trim() || acceptorEmail;
+    await sendEmail({
+      to: row.inviterEmail,
+      subject: `${acceptorLabel} a rejoint le carnet de ${row.childName}`,
+      html: buildAcceptanceEmail({
+        inviterName: row.inviterName ?? "",
+        acceptorLabel,
+        childName: row.childName,
+        appUrl: appOrigin(),
+      }),
+    });
+  } catch (err) {
+    console.error("co_parent_accept_notify_failed", err);
+  }
+}
 
 interface InviteEmailParams {
   inviterName: string;
@@ -362,6 +486,41 @@ function buildInviteEmail({
   </p>
   <p style="font-size:12px;color:#9ca3af;margin-top:24px">
     L'invitation expire le ${expiryFr}. Si vous n'attendiez pas cet email, ignorez-le — aucun compte n'est créé sans votre action.
+  </p>
+</body></html>`;
+}
+
+interface AcceptanceEmailParams {
+  inviterName: string;
+  acceptorLabel: string;
+  childName: string;
+  appUrl: string;
+}
+
+function buildAcceptanceEmail({
+  inviterName,
+  acceptorLabel,
+  childName,
+  appUrl,
+}: AcceptanceEmailParams): string {
+  const safeInviter = escapeHtml(inviterName || "Bonjour");
+  const safeAcceptor = escapeHtml(acceptorLabel);
+  const safeChild = escapeHtml(childName);
+  return `<!DOCTYPE html>
+<html lang="fr"><head><meta charset="utf-8"><title>Invitation acceptée</title></head>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:24px;color:#1f2937">
+  <div style="border-bottom:2px solid #16a34a;padding-bottom:16px;margin-bottom:24px">
+    <p style="font-size:12px;text-transform:uppercase;letter-spacing:0.1em;color:#16a34a;margin:0">Tokō · invitation acceptée</p>
+    <h1 style="font-size:22px;margin:8px 0 4px">${safeAcceptor} a rejoint le carnet de ${safeChild}</h1>
+  </div>
+  <p style="font-size:15px;line-height:1.6">
+    ${safeInviter}, votre invitation a été acceptée. ${safeAcceptor} dispose maintenant des mêmes accès que vous pour ${safeChild} : symptômes, journal, traitement, programme Barkley, rendez-vous.
+  </p>
+  <p style="text-align:center;margin:24px 0">
+    <a href="${appUrl}/dashboard" style="display:inline-block;background:#16a34a;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600">Ouvrir Tokō</a>
+  </p>
+  <p style="font-size:12px;color:#9ca3af;margin-top:24px">
+    Vous restez la personne qui gère l'abonnement et qui peut retirer l'accès à tout moment depuis les paramètres de l'enfant.
   </p>
 </body></html>`;
 }

--- a/apps/api/src/routes/child-invitations.ts
+++ b/apps/api/src/routes/child-invitations.ts
@@ -19,6 +19,7 @@ import { AppError } from "../middleware/error-handler";
 import { assertChildOwner } from "../lib/child-access";
 import { logAudit } from "../lib/audit";
 import { sendEmail } from "../lib/email";
+import { buildInviteEmail, buildAcceptanceEmail } from "../lib/co-parent-emails";
 import { env } from "../lib/env";
 import type { AppEnv } from "../types";
 
@@ -447,89 +448,3 @@ async function notifyInviterOfAcceptance({
   }
 }
 
-interface InviteEmailParams {
-  inviterName: string;
-  childName: string;
-  acceptUrl: string;
-  expiresAt: Date;
-}
-
-function buildInviteEmail({
-  inviterName,
-  childName,
-  acceptUrl,
-  expiresAt,
-}: InviteEmailParams): string {
-  const expiryFr = expiresAt.toLocaleDateString("fr-FR", {
-    day: "numeric",
-    month: "long",
-    year: "numeric",
-  });
-  const safeInviter = escapeHtml(inviterName);
-  const safeChild = escapeHtml(childName);
-  return `<!DOCTYPE html>
-<html lang="fr"><head><meta charset="utf-8"><title>Invitation Tokō</title></head>
-<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:24px;color:#1f2937">
-  <div style="border-bottom:2px solid #6366f1;padding-bottom:16px;margin-bottom:24px">
-    <p style="font-size:12px;text-transform:uppercase;letter-spacing:0.1em;color:#6366f1;margin:0">Tokō · invitation</p>
-    <h1 style="font-size:22px;margin:8px 0 4px">${safeInviter} vous invite à co-parenter ${safeChild}</h1>
-  </div>
-  <p style="font-size:15px;line-height:1.6">
-    Tokō est un carnet de consultation TDAH partagé. En acceptant cette invitation, vous accédez aux mêmes informations que ${safeInviter} pour ${safeChild} : symptômes, journal, traitement, programme Barkley.
-  </p>
-  <p style="text-align:center;margin:24px 0">
-    <a href="${acceptUrl}" style="display:inline-block;background:#6366f1;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600">Accepter l'invitation</a>
-  </p>
-  <p style="font-size:13px;color:#6b7280">
-    Ou collez ce lien dans votre navigateur :<br>
-    <a href="${acceptUrl}" style="color:#6366f1;word-break:break-all">${acceptUrl}</a>
-  </p>
-  <p style="font-size:12px;color:#9ca3af;margin-top:24px">
-    L'invitation expire le ${expiryFr}. Si vous n'attendiez pas cet email, ignorez-le — aucun compte n'est créé sans votre action.
-  </p>
-</body></html>`;
-}
-
-interface AcceptanceEmailParams {
-  inviterName: string;
-  acceptorLabel: string;
-  childName: string;
-  appUrl: string;
-}
-
-function buildAcceptanceEmail({
-  inviterName,
-  acceptorLabel,
-  childName,
-  appUrl,
-}: AcceptanceEmailParams): string {
-  const safeInviter = escapeHtml(inviterName || "Bonjour");
-  const safeAcceptor = escapeHtml(acceptorLabel);
-  const safeChild = escapeHtml(childName);
-  return `<!DOCTYPE html>
-<html lang="fr"><head><meta charset="utf-8"><title>Invitation acceptée</title></head>
-<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;max-width:560px;margin:0 auto;padding:24px;color:#1f2937">
-  <div style="border-bottom:2px solid #16a34a;padding-bottom:16px;margin-bottom:24px">
-    <p style="font-size:12px;text-transform:uppercase;letter-spacing:0.1em;color:#16a34a;margin:0">Tokō · invitation acceptée</p>
-    <h1 style="font-size:22px;margin:8px 0 4px">${safeAcceptor} a rejoint le carnet de ${safeChild}</h1>
-  </div>
-  <p style="font-size:15px;line-height:1.6">
-    ${safeInviter}, votre invitation a été acceptée. ${safeAcceptor} dispose maintenant des mêmes accès que vous pour ${safeChild} : symptômes, journal, traitement, programme Barkley, rendez-vous.
-  </p>
-  <p style="text-align:center;margin:24px 0">
-    <a href="${appUrl}/dashboard" style="display:inline-block;background:#16a34a;color:#fff;padding:12px 24px;border-radius:8px;text-decoration:none;font-weight:600">Ouvrir Tokō</a>
-  </p>
-  <p style="font-size:12px;color:#9ca3af;margin-top:24px">
-    Vous restez la personne qui gère l'abonnement et qui peut retirer l'accès à tout moment depuis les paramètres de l'enfant.
-  </p>
-</body></html>`;
-}
-
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#039;");
-}

--- a/apps/api/src/routes/child-invitations.ts
+++ b/apps/api/src/routes/child-invitations.ts
@@ -6,6 +6,7 @@ import {
   children,
   childAccess,
   childInvitations,
+  consents,
   user as userTable,
 } from "@focusflow/db";
 import {
@@ -25,6 +26,12 @@ export const childInvitationsRoutes = new Hono<AppEnv>();
 
 const INVITE_TTL_DAYS = 14;
 const TOKEN_BYTES = 32; // 256 bits — matches Better Auth's verification token strength.
+
+// Bumped whenever the inviter-facing attestation copy changes — pins the
+// consent row to the exact wording the user agreed to.
+const PARENTAL_AUTHORITY_VERSION = "2026-05-09";
+// Same idea on the invitee side (Art. 9(2)(a) RGPD consent text).
+const COPARENT_HEALTH_VERSION = "2026-05-09";
 
 function hashToken(token: string): string {
   return createHash("sha256").update(token).digest("hex");
@@ -52,11 +59,25 @@ const acceptRateLimiter = rateLimiter({
   limit: 10,
 });
 
+// Per-IP rate limit on the public GET — bearer tokens are 256 bits so brute
+// force is infeasible, but cap probing anyway.
+const tokenLookupRateLimiter = rateLimiter({
+  namespace: "child-invitations-lookup",
+  windowMs: 60_000,
+  limit: 30,
+});
+
 // Public lookup of an invitation's metadata. Doesn't require auth — the
 // invitee uses it to render an "accepter l'invitation" screen before they
 // know whether they need to sign up. Returns 404 on miss/expired/used so
-// invitation existence isn't leakable via timing.
-childInvitationsRoutes.get("/:token", async (c) => {
+// invitation existence isn't leakable.
+//
+// Deliberately does NOT return the `invitedEmail`: a forwarded link would
+// otherwise expose which address was invited to which child (a real concern
+// for separated households). The accept endpoint still enforces the email
+// match server-side, and the UI surfaces a hint via `currentEmail` when the
+// signed-in account is wrong.
+childInvitationsRoutes.get("/:token", tokenLookupRateLimiter, async (c) => {
   const token = c.req.param("token");
   const parsed = acceptInviteParamsSchema.safeParse({ token });
   if (!parsed.success) {
@@ -69,7 +90,6 @@ childInvitationsRoutes.get("/:token", async (c) => {
     .select({
       id: childInvitations.id,
       childId: childInvitations.childId,
-      invitedEmail: childInvitations.invitedEmail,
       expiresAt: childInvitations.expiresAt,
       acceptedAt: childInvitations.acceptedAt,
       childName: children.name,
@@ -88,7 +108,6 @@ childInvitationsRoutes.get("/:token", async (c) => {
   return c.json({
     childName: row.childName,
     inviterName: row.inviterName ?? "Un parent",
-    invitedEmail: row.invitedEmail,
     expiresAt: row.expiresAt,
   });
 });
@@ -104,7 +123,10 @@ childInvitationsRoutes.post(
     const body = await c.req.json().catch(() => ({}));
 
     const childId = typeof body?.childId === "string" ? body.childId : "";
-    const parsed = inviteSchema.safeParse({ email: body?.email });
+    const parsed = inviteSchema.safeParse({
+      email: body?.email,
+      parentalAuthorityAttestation: body?.parentalAuthorityAttestation,
+    });
     if (!parsed.success || !childId) {
       return c.json(
         { error: "Données invalides", details: parsed.error?.flatten() },
@@ -161,12 +183,21 @@ childInvitationsRoutes.post(
       throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
     }
 
-    await db.insert(childInvitations).values({
-      childId,
-      invitedEmail,
-      invitedBy: currentUser.id,
-      tokenHash,
-      expiresAt,
+    await db.transaction(async (tx) => {
+      await tx.insert(childInvitations).values({
+        childId,
+        invitedEmail,
+        invitedBy: currentUser.id,
+        tokenHash,
+        expiresAt,
+      });
+      // Append-only consent record: the inviter affirms parental authority
+      // for this specific share. RGPD Art. 5 + Art. 9(2)(a).
+      await tx.insert(consents).values({
+        userId: currentUser.id,
+        type: "parental_authority_attestation",
+        version: PARENTAL_AUTHORITY_VERSION,
+      });
     });
 
     void logAudit({
@@ -241,6 +272,17 @@ childInvitationsRoutes.post(
       throw new AppError("NOT_FOUND", "Invitation introuvable", 404);
     }
 
+    // Better Auth lets a user register an email without verifying it. Without
+    // this guard, an attacker who knows the invitee's address could sign up
+    // with that address (unverified) and accept. Block until verified.
+    if (!currentUser.emailVerified) {
+      throw new AppError(
+        "FORBIDDEN",
+        "Veuillez vérifier votre adresse e-mail avant d'accepter l'invitation.",
+        403,
+      );
+    }
+
     await db.transaction(async (tx) => {
       await tx
         .insert(childAccess)
@@ -257,6 +299,14 @@ childInvitationsRoutes.post(
         .update(childInvitations)
         .set({ acceptedAt: new Date() })
         .where(eq(childInvitations.id, invite.id));
+      // Invitee's explicit RGPD Art. 9(2)(a) consent to process the child's
+      // health data. Append-only — keeps the audit trail intact across
+      // revoke/re-invite cycles.
+      await tx.insert(consents).values({
+        userId: currentUser.id,
+        type: "co_parent_health_processing",
+        version: COPARENT_HEALTH_VERSION,
+      });
     });
 
     void logAudit({

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -1,6 +1,11 @@
 export interface AppEnv {
   Variables: {
-    user: { id: string; name: string; email: string };
+    user: {
+      id: string;
+      name: string;
+      email: string;
+      emailVerified: boolean;
+    };
     session: { id: string; expiresAt: Date };
   };
 }

--- a/apps/web/src/components/co-parent/co-parent-section.tsx
+++ b/apps/web/src/components/co-parent/co-parent-section.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Tabs,
@@ -32,6 +33,7 @@ export function CoParentSection({ childId }: Props) {
   const invite = useInviteCoParent(childId);
   const revoke = useRevokeAccess(childId);
   const [email, setEmail] = useState("");
+  const [attested, setAttested] = useState(false);
 
   const currentUserId = session.data?.user?.id ?? null;
   const myRow = access.data?.find((r) => r.userId === currentUserId) ?? null;
@@ -40,10 +42,16 @@ export function CoParentSection({ childId }: Props) {
   const handleInvite = (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = email.trim();
-    if (!trimmed) return;
-    invite.mutate(trimmed, {
-      onSuccess: () => setEmail(""),
-    });
+    if (!trimmed || !attested) return;
+    invite.mutate(
+      { email: trimmed, parentalAuthorityAttestation: true },
+      {
+        onSuccess: () => {
+          setEmail("");
+          setAttested(false);
+        },
+      },
+    );
   };
 
   return (
@@ -87,7 +95,7 @@ export function CoParentSection({ childId }: Props) {
             />
             <Button
               type="submit"
-              disabled={invite.isPending || !email.trim()}
+              disabled={invite.isPending || !email.trim() || !attested}
               className="gap-1.5 whitespace-nowrap"
             >
               {invite.isPending ? (
@@ -98,6 +106,24 @@ export function CoParentSection({ childId }: Props) {
               {t("childAccess.inviteCta")}
             </Button>
           </div>
+          <div className="flex items-start gap-2 rounded-lg border border-border/60 bg-muted/30 p-3">
+            <Checkbox
+              id={`co-parent-attest-${childId}`}
+              checked={attested}
+              onCheckedChange={(v) => setAttested(v === true)}
+              className="mt-0.5"
+            />
+            <Label
+              htmlFor={`co-parent-attest-${childId}`}
+              className="text-xs font-normal leading-relaxed text-muted-foreground"
+            >
+              {t("childAccess.attestationLabel")}
+            </Label>
+          </div>
+          <p className="text-[11px] leading-relaxed text-muted-foreground">
+            {t("childAccess.consentNoticeShort")}{" "}
+            {t("childAccess.controllerNotice")}
+          </p>
         </form>
       )}
 

--- a/apps/web/src/components/co-parent/co-parent-section.tsx
+++ b/apps/web/src/components/co-parent/co-parent-section.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Loader2, Mail, Trash2, Crown, User } from "lucide-react";
+import { Loader2, Mail, Trash2, Crown, User, Clock } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -18,7 +18,10 @@ import {
   useChildAccess,
   useInviteCoParent,
   useRevokeAccess,
+  usePendingInvitations,
+  useCancelInvitation,
   type ChildAccessRow,
+  type PendingInvitation,
 } from "@/hooks/use-child-access";
 import { RecentActivity } from "@/components/co-parent/recent-activity";
 
@@ -38,6 +41,12 @@ export function CoParentSection({ childId }: Props) {
   const currentUserId = session.data?.user?.id ?? null;
   const myRow = access.data?.find((r) => r.userId === currentUserId) ?? null;
   const isOwner = myRow?.role === "owner";
+
+  const pending = usePendingInvitations(childId, isOwner);
+  const cancelInvite = useCancelInvitation(childId);
+  const hasOnlyOwner =
+    !!access.data && access.data.length === 1 && isOwner;
+  const hasPending = (pending.data?.length ?? 0) > 0;
 
   const handleInvite = (e: React.FormEvent) => {
     e.preventDefault();
@@ -127,6 +136,24 @@ export function CoParentSection({ childId }: Props) {
         </form>
       )}
 
+          {isOwner && hasPending && (
+            <div className="space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                {t("childAccess.pendingTitle")}
+              </p>
+              <ul className="space-y-2">
+                {pending.data?.map((row) => (
+                  <PendingRow
+                    key={row.id}
+                    row={row}
+                    onCancel={() => cancelInvite.mutate(row.id)}
+                    cancelPending={cancelInvite.isPending}
+                  />
+                ))}
+              </ul>
+            </div>
+          )}
+
           <div className="space-y-2">
             <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
               {t("childAccess.membersTitle")}
@@ -134,18 +161,25 @@ export function CoParentSection({ childId }: Props) {
             {access.isLoading ? (
               <Skeleton className="h-12 w-full" />
             ) : (
-              <ul className="space-y-2">
-                {access.data?.map((row) => (
-                  <MemberRow
-                    key={row.id}
-                    row={row}
-                    isViewerOwner={isOwner}
-                    viewerUserId={currentUserId}
-                    onRevoke={() => revoke.mutate(row.userId)}
-                    revokePending={revoke.isPending}
-                  />
-                ))}
-              </ul>
+              <>
+                <ul className="space-y-2">
+                  {access.data?.map((row) => (
+                    <MemberRow
+                      key={row.id}
+                      row={row}
+                      isViewerOwner={isOwner}
+                      viewerUserId={currentUserId}
+                      onRevoke={() => revoke.mutate(row.userId)}
+                      revokePending={revoke.isPending}
+                    />
+                  ))}
+                </ul>
+                {hasOnlyOwner && !hasPending && (
+                  <p className="rounded-lg border border-dashed border-border/60 bg-muted/20 p-3 text-xs text-muted-foreground">
+                    {t("childAccess.noCoParentYet")}
+                  </p>
+                )}
+              </>
             )}
           </div>
         </TabsContent>
@@ -154,6 +188,53 @@ export function CoParentSection({ childId }: Props) {
         </TabsContent>
       </Tabs>
     </div>
+  );
+}
+
+interface PendingRowProps {
+  row: PendingInvitation;
+  onCancel: () => void;
+  cancelPending: boolean;
+}
+
+function PendingRow({ row, onCancel, cancelPending }: PendingRowProps) {
+  const { t, i18n: i18nInstance } = useTranslation();
+  const expiry = new Date(row.expiresAt).toLocaleDateString(
+    i18nInstance.language || "fr-FR",
+    { day: "numeric", month: "long", year: "numeric" },
+  );
+
+  return (
+    <li className="flex items-center justify-between gap-3 rounded-lg border border-dashed border-border/60 bg-muted/20 p-3">
+      <div className="flex min-w-0 items-center gap-3">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-muted text-muted-foreground">
+          <Clock className="h-4 w-4" />
+        </div>
+        <div className="min-w-0">
+          <p className="truncate text-sm font-medium">{row.invitedEmail}</p>
+          <p className="truncate text-xs text-muted-foreground">
+            {t("childAccess.pendingExpires", { date: expiry })}
+          </p>
+        </div>
+      </div>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={onCancel}
+        disabled={cancelPending}
+        aria-label={t("childAccess.pendingCancelAria", {
+          email: row.invitedEmail,
+        })}
+        className="shrink-0 text-muted-foreground hover:text-destructive"
+      >
+        {cancelPending ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          t("childAccess.pendingCancel")
+        )}
+      </Button>
+    </li>
   );
 }
 

--- a/apps/web/src/hooks/use-child-access.ts
+++ b/apps/web/src/hooks/use-child-access.ts
@@ -18,6 +18,47 @@ export const childAccessKeys = {
   forChild: (childId: string) => ["child-access", "child", childId] as const,
 };
 
+export const childInvitationsKeys = {
+  all: ["child-invitations"] as const,
+  pendingForChild: (childId: string) =>
+    ["child-invitations", "pending", childId] as const,
+};
+
+export interface PendingInvitation {
+  id: string;
+  invitedEmail: string;
+  createdAt: string;
+  expiresAt: string;
+}
+
+// Owner-only: surface pending invites so a typo'd email or stale invite is
+// visible and cancelable instead of vanishing after the form submit.
+export function usePendingInvitations(childId: string, enabled = true) {
+  return useQuery({
+    queryKey: childInvitationsKeys.pendingForChild(childId),
+    queryFn: () =>
+      api.get<PendingInvitation[]>(
+        `/child-invitations?childId=${encodeURIComponent(childId)}`,
+      ),
+    enabled: !!childId && enabled,
+  });
+}
+
+export function useCancelInvitation(childId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (invitationId: string) =>
+      api.delete<{ ok: true }>(`/child-invitations/${invitationId}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: childInvitationsKeys.pendingForChild(childId),
+      });
+      toast.success(i18n.t("childAccess.cancelSuccess"));
+    },
+    onError: () => toast.error(i18n.t("childAccess.cancelError")),
+  });
+}
+
 export function useChildAccess(childId: string) {
   return useQuery({
     queryKey: childAccessKeys.forChild(childId),
@@ -59,6 +100,9 @@ export function useInviteCoParent(childId: string) {
     onSuccess: (data) => {
       queryClient.invalidateQueries({
         queryKey: childAccessKeys.forChild(childId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: childInvitationsKeys.pendingForChild(childId),
       });
       if (data.alreadyMember) {
         toast.info(i18n.t("childAccess.alreadyMember"));

--- a/apps/web/src/hooks/use-child-access.ts
+++ b/apps/web/src/hooks/use-child-access.ts
@@ -43,13 +43,18 @@ export function useRevokeAccess(childId: string) {
   });
 }
 
+export interface InvitePayload {
+  email: string;
+  parentalAuthorityAttestation: true;
+}
+
 export function useInviteCoParent(childId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (email: string) =>
+    mutationFn: (payload: InvitePayload) =>
       api.post<{ ok: true; alreadyMember?: boolean }>(
         "/child-invitations",
-        { childId, email },
+        { childId, ...payload },
       ),
     onSuccess: (data) => {
       queryClient.invalidateQueries({
@@ -77,7 +82,6 @@ export function useInviteCoParent(childId: string) {
 export interface InviteMetadata {
   childName: string;
   inviterName: string;
-  invitedEmail: string;
   expiresAt: string;
 }
 

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -1180,9 +1180,30 @@
     "attestationRequired": "You must confirm you hold parental authority.",
     "consentNotice": "By accepting, I give explicit consent to process the child's health data (GDPR Art. 9). I can withdraw access at any time from my account.",
     "consentNoticeShort": "Data shared: symptoms, journal, medications, Barkley programme, appointments.",
-    "controllerNotice": "Data controller: Tokō. Retention: for the lifetime of the account. Email sent via Resend (EU/US). You can exercise your rights or contact your DPA at any time."
+    "controllerNotice": "Data controller: Tokō. Retention: for the lifetime of the account. Email sent via Resend (EU/US). You can exercise your rights or contact your DPA at any time.",
+    "pendingTitle": "Pending invitations",
+    "pendingEmptyOwner": "No pending invitations.",
+    "pendingExpires": "Expires on {{date}}",
+    "pendingCancel": "Cancel",
+    "pendingCancelAria": "Cancel invitation sent to {{email}}",
+    "cancelSuccess": "Invitation cancelled.",
+    "cancelError": "Could not cancel this invitation.",
+    "noCoParentYet": "No one else has access yet. You manage this child's logbook on your own."
   },
   "invitePage": {
+    "title": "You're invited to co-parent",
+    "subtitle": "Tokō · shared ADHD logbook",
+    "expiredTitle": "Invitation not found or expired",
+    "expiredHelp": "Ask the parent who sent it to you for a new invitation.",
+    "acceptedTitle": "Invitation accepted — redirecting…",
+    "intro": "<strong>{{inviter}}</strong> would like to share the logbook for <strong>{{child}}</strong> with you. You'll be able to view and update symptoms, journal, medications, the Barkley programme, and appointments — with the same access as {{inviter}}.",
+    "expires": "Expires on {{date}}",
+    "signedOutPrompt": "Sign in or create an account using the address this invitation was sent to.",
+    "signedOutCta": "Sign in / Register",
+    "emailUnverifiedTitle": "Verify your email address before accepting.",
+    "emailUnverifiedHelp": "Check the verification email sent to {{email}}, then reload this page.",
+    "acceptCta": "Accept invitation",
+    "backHome": "Back to home",
     "errorEmailUnverified": "Verify your email address before accepting this invitation.",
     "errorNotFound": "This invitation is not found, expired, or not addressed to your account.",
     "errorGeneric": "Could not accept the invitation right now."
@@ -1233,7 +1254,8 @@
       },
       "child_invitation": {
         "create": "Invitation sent",
-        "accept": "Invitation accepted"
+        "accept": "Invitation accepted",
+        "cancel": "Invitation cancelled"
       },
       "routine": {
         "create": "Routine created",

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -1175,7 +1175,17 @@
     "alreadyMember": "This person already has access.",
     "inviteInvalidEmail": "Invalid email address.",
     "inviteForbidden": "Only the owner can invite.",
-    "inviteError": "Invite failed to send."
+    "inviteError": "Invite failed to send.",
+    "attestationLabel": "I hold parental authority over this child and authorise sharing their health logbook with the invited person.",
+    "attestationRequired": "You must confirm you hold parental authority.",
+    "consentNotice": "By accepting, I give explicit consent to process the child's health data (GDPR Art. 9). I can withdraw access at any time from my account.",
+    "consentNoticeShort": "Data shared: symptoms, journal, medications, Barkley programme, appointments.",
+    "controllerNotice": "Data controller: Tokō. Retention: for the lifetime of the account. Email sent via Resend (EU/US). You can exercise your rights or contact your DPA at any time."
+  },
+  "invitePage": {
+    "errorEmailUnverified": "Verify your email address before accepting this invitation.",
+    "errorNotFound": "This invitation is not found, expired, or not addressed to your account.",
+    "errorGeneric": "Could not accept the invitation right now."
   },
   "activityPage": {
     "title": "Recent activity",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -1175,7 +1175,17 @@
     "alreadyMember": "Cette personne a déjà accès à cet enfant.",
     "inviteInvalidEmail": "Adresse email invalide.",
     "inviteForbidden": "Seul le propriétaire peut inviter.",
-    "inviteError": "L'invitation n'a pas pu être envoyée."
+    "inviteError": "L'invitation n'a pas pu être envoyée.",
+    "attestationLabel": "Je détiens l'autorité parentale sur cet enfant et j'autorise le partage de son carnet de santé avec la personne invitée.",
+    "attestationRequired": "Vous devez confirmer détenir l'autorité parentale.",
+    "consentNotice": "En acceptant, je donne mon consentement explicite au traitement des données de santé de l'enfant (RGPD Art. 9). Je peux retirer mon accès à tout moment depuis mon compte.",
+    "consentNoticeShort": "Données concernées : symptômes, journal, traitement, programme Barkley, rendez-vous.",
+    "controllerNotice": "Responsable de traitement : Tokō. Durée de conservation : pendant la vie du compte. Email envoyé via Resend (UE/US). Vous pouvez exercer vos droits ou saisir la CNIL à tout moment."
+  },
+  "invitePage": {
+    "errorEmailUnverified": "Vérifiez votre adresse e-mail avant d'accepter cette invitation.",
+    "errorNotFound": "Cette invitation est introuvable, expirée, ou n'est pas destinée à votre compte.",
+    "errorGeneric": "Impossible d'accepter l'invitation pour le moment."
   },
   "activityPage": {
     "title": "Activité récente",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -1180,9 +1180,30 @@
     "attestationRequired": "Vous devez confirmer détenir l'autorité parentale.",
     "consentNotice": "En acceptant, je donne mon consentement explicite au traitement des données de santé de l'enfant (RGPD Art. 9). Je peux retirer mon accès à tout moment depuis mon compte.",
     "consentNoticeShort": "Données concernées : symptômes, journal, traitement, programme Barkley, rendez-vous.",
-    "controllerNotice": "Responsable de traitement : Tokō. Durée de conservation : pendant la vie du compte. Email envoyé via Resend (UE/US). Vous pouvez exercer vos droits ou saisir la CNIL à tout moment."
+    "controllerNotice": "Responsable de traitement : Tokō. Durée de conservation : pendant la vie du compte. Email envoyé via Resend (UE/US). Vous pouvez exercer vos droits ou saisir la CNIL à tout moment.",
+    "pendingTitle": "Invitations en attente",
+    "pendingEmptyOwner": "Aucune invitation en attente.",
+    "pendingExpires": "Expire le {{date}}",
+    "pendingCancel": "Annuler",
+    "pendingCancelAria": "Annuler l'invitation envoyée à {{email}}",
+    "cancelSuccess": "Invitation annulée.",
+    "cancelError": "Impossible d'annuler cette invitation.",
+    "noCoParentYet": "Personne d'autre n'a encore accès. Vous gérez seul·e le carnet de cet enfant."
   },
   "invitePage": {
+    "title": "On vous invite à co-parenter",
+    "subtitle": "Tokō · carnet de consultation TDAH partagé",
+    "expiredTitle": "Invitation introuvable ou expirée",
+    "expiredHelp": "Demandez une nouvelle invitation au parent qui vous l'a envoyée.",
+    "acceptedTitle": "Invitation acceptée — on vous redirige…",
+    "intro": "<strong>{{inviter}}</strong> aimerait partager avec vous le carnet de <strong>{{child}}</strong>. Vous pourrez consulter et compléter les symptômes, le journal, les traitements, le programme Barkley et les rendez-vous, avec les mêmes droits que {{inviter}}.",
+    "expires": "Expire le {{date}}",
+    "signedOutPrompt": "Connectez-vous ou créez un compte avec l'adresse à laquelle cette invitation a été envoyée pour l'accepter.",
+    "signedOutCta": "Se connecter / S'inscrire",
+    "emailUnverifiedTitle": "Vérifiez votre adresse e-mail avant d'accepter.",
+    "emailUnverifiedHelp": "Consultez l'e-mail de vérification envoyé à {{email}}, puis rechargez cette page.",
+    "acceptCta": "Accepter l'invitation",
+    "backHome": "Retour à l'accueil",
     "errorEmailUnverified": "Vérifiez votre adresse e-mail avant d'accepter cette invitation.",
     "errorNotFound": "Cette invitation est introuvable, expirée, ou n'est pas destinée à votre compte.",
     "errorGeneric": "Impossible d'accepter l'invitation pour le moment."
@@ -1233,7 +1254,8 @@
       },
       "child_invitation": {
         "create": "Invitation envoyée",
-        "accept": "Invitation acceptée"
+        "accept": "Invitation acceptée",
+        "cancel": "Invitation annulée"
       },
       "routine": {
         "create": "Routine créée",

--- a/apps/web/src/routes/invite/$token.tsx
+++ b/apps/web/src/routes/invite/$token.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
 import { Heart, AlertTriangle, Check, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -22,7 +22,7 @@ export const Route = createFileRoute("/invite/$token")({
 });
 
 function InviteAcceptPage() {
-  const { t } = useTranslation();
+  const { t, i18n: i18nInstance } = useTranslation();
   const { token } = Route.useParams();
   const navigate = useNavigate();
   const session = useSession();
@@ -34,13 +34,13 @@ function InviteAcceptPage() {
   // Once accepted, drop the user into the dashboard for the new child.
   useEffect(() => {
     if (accepted) {
-      const t = setTimeout(() => navigate({ to: "/dashboard" }), 1500);
-      return () => clearTimeout(t);
+      const handle = setTimeout(() => navigate({ to: "/dashboard" }), 1500);
+      return () => clearTimeout(handle);
     }
   }, [accepted, navigate]);
 
   const formatDate = (iso: string) =>
-    new Date(iso).toLocaleDateString("fr-FR", {
+    new Date(iso).toLocaleDateString(i18nInstance.language || "fr-FR", {
       day: "numeric",
       month: "long",
       year: "numeric",
@@ -54,11 +54,9 @@ function InviteAcceptPage() {
             <Heart className="h-6 w-6" />
           </div>
           <CardTitle className="font-heading text-2xl">
-            Invitation à co-parenter
+            {t("invitePage.title")}
           </CardTitle>
-          <CardDescription>
-            Tokō · carnet de consultation TDAH partagé
-          </CardDescription>
+          <CardDescription>{t("invitePage.subtitle")}</CardDescription>
         </CardHeader>
 
         <CardContent className="space-y-4">
@@ -70,16 +68,16 @@ function InviteAcceptPage() {
             <div className="flex flex-col items-center gap-3 py-6 text-center">
               <AlertTriangle className="h-8 w-8 text-destructive" />
               <div>
-                <p className="font-medium">Invitation introuvable ou expirée</p>
+                <p className="font-medium">{t("invitePage.expiredTitle")}</p>
                 <p className="mt-1 text-sm text-muted-foreground">
-                  Demandez une nouvelle invitation au parent qui vous l'a envoyée.
+                  {t("invitePage.expiredHelp")}
                 </p>
               </div>
             </div>
           ) : accepted ? (
             <div className="flex flex-col items-center gap-3 py-6 text-center">
               <Check className="h-8 w-8 text-success-foreground" />
-              <p className="font-medium">Invitation acceptée — redirection…</p>
+              <p className="font-medium">{t("invitePage.acceptedTitle")}</p>
             </div>
           ) : (
             <InviteAcceptBody
@@ -107,7 +105,6 @@ function InviteAcceptPage() {
               token={token}
               expiresAt={meta.data.expiresAt}
               formatDate={formatDate}
-              t={t}
             />
           )}
         </CardContent>
@@ -117,7 +114,7 @@ function InviteAcceptPage() {
             to="/"
             className="text-xs text-muted-foreground hover:text-foreground"
           >
-            Retour à l'accueil
+            {t("invitePage.backHome")}
           </Link>
         </CardFooter>
       </Card>
@@ -135,7 +132,6 @@ interface BodyProps {
   token: string;
   expiresAt: string;
   formatDate: (iso: string) => string;
-  t: (key: string, opts?: Record<string, unknown>) => string;
 }
 
 function InviteAcceptBody({
@@ -148,22 +144,22 @@ function InviteAcceptBody({
   token,
   expiresAt,
   formatDate,
-  t,
 }: BodyProps) {
+  const { t } = useTranslation();
   const signedIn = !!currentEmail;
 
   return (
     <div className="space-y-4">
       <p className="text-sm leading-relaxed">
-        <span className="font-semibold">{meta.inviterName}</span> vous invite à
-        accéder au carnet de{" "}
-        <span className="font-semibold">{meta.childName}</span>. Vous pourrez
-        consulter et compléter les symptômes, le journal, le traitement, et le
-        programme Barkley — comme l'inviteur.
+        <Trans
+          i18nKey="invitePage.intro"
+          values={{ inviter: meta.inviterName, child: meta.childName }}
+          components={{ strong: <span className="font-semibold" /> }}
+        />
       </p>
 
       <p className="text-xs text-muted-foreground">
-        Expire le {formatDate(expiresAt)}
+        {t("invitePage.expires", { date: formatDate(expiresAt) })}
       </p>
 
       <div className="rounded-lg border border-border/60 bg-muted/20 p-3 text-xs leading-relaxed text-muted-foreground">
@@ -173,26 +169,22 @@ function InviteAcceptBody({
 
       {!signedIn ? (
         <div className="space-y-2 rounded-lg border border-border/60 bg-muted/30 p-3 text-sm">
-          <p>
-            Connectez-vous ou créez un compte avec l'adresse à laquelle cette
-            invitation a été envoyée pour l'accepter.
-          </p>
+          <p>{t("invitePage.signedOutPrompt")}</p>
           <Link
             to="/login"
             search={{ next: `/invite/${token}` } as never}
             className="inline-block"
           >
-            <Button size="sm">Se connecter / S'inscrire</Button>
+            <Button size="sm">{t("invitePage.signedOutCta")}</Button>
           </Link>
         </div>
       ) : !emailVerified ? (
         <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm">
           <p className="font-medium text-destructive">
-            Vérifiez votre adresse e-mail avant d'accepter.
+            {t("invitePage.emailUnverifiedTitle")}
           </p>
           <p className="mt-1">
-            Consultez l'e-mail de vérification envoyé à {currentEmail}, puis
-            rechargez cette page.
+            {t("invitePage.emailUnverifiedHelp", { email: currentEmail })}
           </p>
         </div>
       ) : (
@@ -210,7 +202,7 @@ function InviteAcceptBody({
                   data-icon="inline-start"
                 />
               )}
-              Accepter l'invitation
+              {t("invitePage.acceptCta")}
             </Button>
           </div>
         </>

--- a/apps/web/src/routes/invite/$token.tsx
+++ b/apps/web/src/routes/invite/$token.tsx
@@ -1,5 +1,6 @@
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { Heart, AlertTriangle, Check, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -21,12 +22,14 @@ export const Route = createFileRoute("/invite/$token")({
 });
 
 function InviteAcceptPage() {
+  const { t } = useTranslation();
   const { token } = Route.useParams();
   const navigate = useNavigate();
   const session = useSession();
   const meta = useInviteMetadata(token);
   const accept = useAcceptInvite();
   const [accepted, setAccepted] = useState(false);
+  const [acceptError, setAcceptError] = useState<string | null>(null);
 
   // Once accepted, drop the user into the dashboard for the new child.
   useEffect(() => {
@@ -82,15 +85,29 @@ function InviteAcceptPage() {
             <InviteAcceptBody
               meta={meta.data}
               currentEmail={session.data?.user?.email ?? null}
+              emailVerified={session.data?.user?.emailVerified ?? false}
               isPending={accept.isPending}
-              onAccept={() =>
+              acceptError={acceptError}
+              onAccept={() => {
+                setAcceptError(null);
                 accept.mutate(token, {
                   onSuccess: () => setAccepted(true),
-                })
-              }
+                  onError: (err: unknown) => {
+                    const status = (err as { status?: number } | null)?.status;
+                    if (status === 403) {
+                      setAcceptError(t("invitePage.errorEmailUnverified"));
+                    } else if (status === 404) {
+                      setAcceptError(t("invitePage.errorNotFound"));
+                    } else {
+                      setAcceptError(t("invitePage.errorGeneric"));
+                    }
+                  },
+                });
+              }}
               token={token}
               expiresAt={meta.data.expiresAt}
               formatDate={formatDate}
+              t={t}
             />
           )}
         </CardContent>
@@ -109,28 +126,31 @@ function InviteAcceptPage() {
 }
 
 interface BodyProps {
-  meta: { childName: string; inviterName: string; invitedEmail: string };
+  meta: { childName: string; inviterName: string };
   currentEmail: string | null;
+  emailVerified: boolean;
   isPending: boolean;
+  acceptError: string | null;
   onAccept: () => void;
   token: string;
   expiresAt: string;
   formatDate: (iso: string) => string;
+  t: (key: string, opts?: Record<string, unknown>) => string;
 }
 
 function InviteAcceptBody({
   meta,
   currentEmail,
+  emailVerified,
   isPending,
+  acceptError,
   onAccept,
   token,
   expiresAt,
   formatDate,
+  t,
 }: BodyProps) {
   const signedIn = !!currentEmail;
-  const emailMatches =
-    signedIn &&
-    currentEmail!.toLowerCase() === meta.invitedEmail.toLowerCase();
 
   return (
     <div className="space-y-4">
@@ -143,17 +163,19 @@ function InviteAcceptBody({
       </p>
 
       <p className="text-xs text-muted-foreground">
-        Adresse invitée : <span className="font-medium">{meta.invitedEmail}</span>
-        {" · "}
         Expire le {formatDate(expiresAt)}
       </p>
+
+      <div className="rounded-lg border border-border/60 bg-muted/20 p-3 text-xs leading-relaxed text-muted-foreground">
+        <p>{t("childAccess.consentNotice")}</p>
+        <p className="mt-2">{t("childAccess.controllerNotice")}</p>
+      </div>
 
       {!signedIn ? (
         <div className="space-y-2 rounded-lg border border-border/60 bg-muted/30 p-3 text-sm">
           <p>
-            Connectez-vous ou créez un compte avec{" "}
-            <span className="font-medium">{meta.invitedEmail}</span> pour
-            accepter cette invitation.
+            Connectez-vous ou créez un compte avec l'adresse à laquelle cette
+            invitation a été envoyée pour l'accepter.
           </p>
           <Link
             to="/login"
@@ -163,29 +185,35 @@ function InviteAcceptBody({
             <Button size="sm">Se connecter / S'inscrire</Button>
           </Link>
         </div>
-      ) : !emailMatches ? (
-        <div className="space-y-2 rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm">
+      ) : !emailVerified ? (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm">
           <p className="font-medium text-destructive">
-            Cette invitation a été envoyée à {meta.invitedEmail}, mais vous êtes
-            connecté avec {currentEmail}.
+            Vérifiez votre adresse e-mail avant d'accepter.
           </p>
-          <p>
-            Déconnectez-vous, puis reconnectez-vous avec l'adresse invitée pour
-            poursuivre.
+          <p className="mt-1">
+            Consultez l'e-mail de vérification envoyé à {currentEmail}, puis
+            rechargez cette page.
           </p>
         </div>
       ) : (
-        <div className="flex justify-end">
-          <Button onClick={onAccept} disabled={isPending}>
-            {isPending && (
-              <Loader2
-                className="h-4 w-4 animate-spin"
-                data-icon="inline-start"
-              />
-            )}
-            Accepter l'invitation
-          </Button>
-        </div>
+        <>
+          {acceptError && (
+            <p className="rounded-lg border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+              {acceptError}
+            </p>
+          )}
+          <div className="flex justify-end">
+            <Button onClick={onAccept} disabled={isPending}>
+              {isPending && (
+                <Loader2
+                  className="h-4 w-4 animate-spin"
+                  data-icon="inline-start"
+                />
+              )}
+              Accepter l'invitation
+            </Button>
+          </div>
+        </>
       )}
     </div>
   );

--- a/packages/db/src/schema/audit-log.ts
+++ b/packages/db/src/schema/audit-log.ts
@@ -42,7 +42,7 @@ export const auditLog = pgTable("audit_log", {
   }).notNull(),
   entityId: text("entity_id"),
   action: text("action", {
-    enum: ["create", "update", "delete", "accept", "revoke"],
+    enum: ["create", "update", "delete", "accept", "revoke", "cancel"],
   }).notNull(),
   summary: encryptedText("summary"),
   createdAt: timestamp("created_at").notNull().defaultNow(),

--- a/packages/db/src/schema/consents.ts
+++ b/packages/db/src/schema/consents.ts
@@ -14,7 +14,19 @@ export const consents = pgTable(
       .notNull()
       .references(() => user.id, { onDelete: "cascade" }),
     type: text("type", {
-      enum: ["terms", "privacy", "ai_usage", "research"],
+      enum: [
+        "terms",
+        "privacy",
+        "ai_usage",
+        "research",
+        // Inviter affirms they hold parental authority over the child whose
+        // carnet they are sharing (Art. 371-1 C. civ.). One row per invite.
+        "parental_authority_attestation",
+        // Invitee's Art. 9(2)(a) RGPD consent to process the minor's health
+        // data as a co-parent. Written inside the same tx as the
+        // child_access insert on accept.
+        "co_parent_health_processing",
+      ],
     }).notNull(),
     // Free-form version identifier, e.g. "2026-04-23" or "v2.1". Opaque
     // from the schema's perspective — the client is responsible for

--- a/packages/validators/src/child-invitation.ts
+++ b/packages/validators/src/child-invitation.ts
@@ -2,6 +2,14 @@ import { z } from "zod";
 
 export const inviteSchema = z.object({
   email: z.string().email("L'adresse e-mail est invalide"),
+  // RGPD Art. 9(2)(a) + Art. 371-1 C. civ.: the inviter must affirm they
+  // hold parental authority over the child before sharing health data.
+  parentalAuthorityAttestation: z.literal(true, {
+    errorMap: () => ({
+      message:
+        "Vous devez confirmer détenir l'autorité parentale pour inviter un co-parent.",
+    }),
+  }),
 });
 
 export const acceptInviteParamsSchema = z.object({

--- a/packages/validators/src/consent.ts
+++ b/packages/validators/src/consent.ts
@@ -5,6 +5,8 @@ export const consentTypeSchema = z.enum([
   "privacy",
   "ai_usage",
   "research",
+  "parental_authority_attestation",
+  "co_parent_health_processing",
 ]);
 
 export const grantConsentSchema = z.object({


### PR DESCRIPTION
- Require parental-authority attestation on POST /child-invitations (RGPD
  Art. 9(2)(a) + Art. 371-1 C. civ.) and persist it as a consent row
- Capture invitee's explicit health-data consent inside the accept tx
- Block accept unless currentUser.emailVerified — prevents account-takeover
  via unverified Better Auth signups on the invitee address
- Strip invitedEmail from the public GET response so a forwarded link no
  longer leaks who was invited; rate-limit the lookup endpoint
- Revoke now deletes pending invites for (childId, invitedEmail) in the
  same transaction so a stale email link can't undo the revoke
- Frontend: add attestation checkbox to invite form, drop invitedEmail
  references on /invite/:token, surface 403 emailVerified errors, and
  show RGPD/controller notice on the accept page