### PR TITLE
feat(onboarding): add first-login guided tour of core features

### DIFF
--- a/apps/web/src/components/shared/onboarding-tour.tsx
+++ b/apps/web/src/components/shared/onboarding-tour.tsx
@@ -1,0 +1,164 @@
+import { useState, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  Sparkles,
+  BarChart3,
+  Activity,
+  ListChecks,
+  HandHeart,
+  PartyPopper,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { useUiStore } from "@/stores/ui-store";
+import { useSession } from "@/lib/auth-client";
+import { cn } from "@/lib/utils";
+
+type StepKey =
+  | "welcome"
+  | "dashboard"
+  | "tracking"
+  | "routines"
+  | "care"
+  | "ready";
+
+const STEPS: {
+  key: StepKey;
+  icon: React.ComponentType<{ className?: string }>;
+}[] = [
+  { key: "welcome", icon: Sparkles },
+  { key: "dashboard", icon: BarChart3 },
+  { key: "tracking", icon: Activity },
+  { key: "routines", icon: ListChecks },
+  { key: "care", icon: HandHeart },
+  { key: "ready", icon: PartyPopper },
+];
+
+export function OnboardingTour() {
+  const { t } = useTranslation();
+  const session = useSession();
+  const onboardingCompleted = useUiStore((s) => s.onboardingCompleted);
+  const completeOnboarding = useUiStore((s) => s.completeOnboarding);
+  const [open, setOpen] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
+
+  // Open the tour automatically when an authenticated parent has not yet
+  // completed it. Wait for the session so we don't flash it on logout.
+  useEffect(() => {
+    if (session.isPending) return;
+    if (!session.data?.user) return;
+    if (onboardingCompleted) return;
+    setOpen(true);
+  }, [session.isPending, session.data, onboardingCompleted]);
+
+  const isLast = stepIndex === STEPS.length - 1;
+  const isFirst = stepIndex === 0;
+  const step = STEPS[stepIndex] ?? STEPS[0]!;
+  const Icon = step.icon;
+
+  const handleClose = () => {
+    completeOnboarding();
+    setOpen(false);
+    setStepIndex(0);
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      handleClose();
+    } else {
+      setOpen(true);
+    }
+  };
+
+  const handleNext = () => {
+    if (isLast) {
+      handleClose();
+    } else {
+      setStepIndex((i) => i + 1);
+    }
+  };
+
+  const handlePrev = () => {
+    setStepIndex((i) => Math.max(0, i - 1));
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader className="items-center text-center">
+          <span
+            aria-hidden="true"
+            className="mb-2 flex h-12 w-12 items-center justify-center rounded-full bg-primary/10 text-primary"
+          >
+            <Icon className="h-6 w-6" />
+          </span>
+          <DialogTitle className="text-lg">
+            {t(`onboarding.steps.${step.key}.title`)}
+          </DialogTitle>
+          <DialogDescription className="text-center">
+            {t(`onboarding.steps.${step.key}.body`)}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div
+          role="tablist"
+          aria-label={t("onboarding.progressLabel")}
+          className="flex justify-center gap-1.5"
+        >
+          {STEPS.map((s, i) => (
+            <span
+              key={s.key}
+              role="tab"
+              aria-selected={i === stepIndex}
+              aria-label={t("onboarding.stepAria", {
+                index: i + 1,
+                total: STEPS.length,
+              })}
+              className={cn(
+                "h-1.5 rounded-full transition-all",
+                i === stepIndex
+                  ? "w-6 bg-primary"
+                  : i < stepIndex
+                    ? "w-1.5 bg-primary/60"
+                    : "w-1.5 bg-muted"
+              )}
+            />
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between gap-2">
+          {isFirst ? (
+            <Button variant="ghost" size="sm" onClick={handleClose}>
+              {t("onboarding.skip")}
+            </Button>
+          ) : (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handlePrev}
+              aria-label={t("onboarding.previous")}
+            >
+              <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+              {t("onboarding.previous")}
+            </Button>
+          )}
+
+          <Button size="sm" onClick={handleNext}>
+            {isLast ? t("onboarding.finish") : t("onboarding.next")}
+            {!isLast && (
+              <ChevronRight className="h-4 w-4" aria-hidden="true" />
+            )}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -239,6 +239,7 @@
     "lock": "Lock screen",
     "loggedInAs": "Signed in as",
     "support": "Help & support",
+    "tour": "Guided tour",
     "userMenu": "User menu",
     "buildAt": "Built on {{date}} at {{time}}",
     "skipToContent": "Skip to main content",
@@ -472,6 +473,40 @@
     "medicalReportFamilyOnly": " — Family plan only",
     "generateReport": "Generate the report",
     "discoverFeature": "Discover the feature"
+  },
+  "onboarding": {
+    "skip": "Skip",
+    "next": "Next",
+    "previous": "Back",
+    "finish": "Finish",
+    "progressLabel": "Tour progress",
+    "stepAria": "Step {{index}} of {{total}}",
+    "steps": {
+      "welcome": {
+        "title": "Welcome to Tokō",
+        "body": "Tokō supports you day to day in caring for your ADHD child. Let's take a quick tour of the essential features together."
+      },
+      "dashboard": {
+        "title": "Your dashboard",
+        "body": "Check mood, consistency, weekly stars and a fresh tip every day. Everything starts here."
+      },
+      "tracking": {
+        "title": "Symptoms & journal",
+        "body": "Log symptoms in seconds and keep a free-form journal. Trends appear automatically after a few days of tracking."
+      },
+      "routines": {
+        "title": "Routines & rewards",
+        "body": "Build calming routines and a star reward chart to encourage positive behaviours, one star at a time."
+      },
+      "care": {
+        "title": "Crisis support",
+        "body": "Crisis list, medications, care pathway and an SOS button — everything you need to stay grounded, even on tough days."
+      },
+      "ready": {
+        "title": "You're all set",
+        "body": "Start by adding your child and a first entry. You can relaunch this tour anytime from the user menu."
+      }
+    }
   },
   "notifications": {
     "title": "Notifications",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -239,6 +239,7 @@
     "lock": "Verrouiller",
     "loggedInAs": "Connecté en tant que",
     "support": "Aide & support",
+    "tour": "Visite guidée",
     "userMenu": "Menu utilisateur",
     "buildAt": "Build du {{date}} à {{time}}",
     "skipToContent": "Aller au contenu principal",
@@ -472,6 +473,40 @@
     "medicalReportFamilyOnly": " — réservé au plan Famille",
     "generateReport": "Générer le rapport",
     "discoverFeature": "Découvrir la fonctionnalité"
+  },
+  "onboarding": {
+    "skip": "Passer",
+    "next": "Suivant",
+    "previous": "Précédent",
+    "finish": "Terminer",
+    "progressLabel": "Progression de la visite",
+    "stepAria": "Étape {{index}} sur {{total}}",
+    "steps": {
+      "welcome": {
+        "title": "Bienvenue sur Tokō",
+        "body": "Tokō vous accompagne au quotidien dans le suivi de votre enfant TDAH. Faisons ensemble un rapide tour des fonctionnalités essentielles."
+      },
+      "dashboard": {
+        "title": "Votre tableau de bord",
+        "body": "Retrouvez chaque jour l'humeur, la constance, les étoiles de la semaine et un conseil adapté. Tout commence ici."
+      },
+      "tracking": {
+        "title": "Symptômes & journal",
+        "body": "Notez en quelques secondes les symptômes observés et tenez un journal libre. Les tendances apparaissent automatiquement après quelques jours."
+      },
+      "routines": {
+        "title": "Routines & récompenses",
+        "body": "Créez des routines apaisantes et un tableau de récompenses pour encourager les comportements positifs, étoile après étoile."
+      },
+      "care": {
+        "title": "Soutien en cas de crise",
+        "body": "Liste de crise, médicaments, parcours de soins et bouton SOS : tout pour garder un cap serein, même dans les moments difficiles."
+      },
+      "ready": {
+        "title": "Vous êtes prêt·e",
+        "body": "Commencez par ajouter votre enfant et un premier relevé. Vous pourrez relancer cette visite à tout moment depuis le menu utilisateur."
+      }
+    }
   },
   "notifications": {
     "title": "Notifications",

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -6,7 +6,7 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { Heart, LogOut, LifeBuoy, ChevronDown, Menu, Lock, UserCog } from "lucide-react";
+import { Heart, LogOut, LifeBuoy, ChevronDown, Menu, Lock, UserCog, Compass } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -42,6 +42,7 @@ import { FloatingTipButton } from "@/components/shared/floating-tip-button";
 import { InstallPrompt } from "@/components/shared/install-prompt";
 import { SOSCrisisButton } from "@/components/shared/sos-crisis-button";
 import { LockOverlay } from "@/components/shared/lock-overlay";
+import { OnboardingTour } from "@/components/shared/onboarding-tour";
 import { useIdleLock } from "@/hooks/use-idle-lock";
 import { useUiStore } from "@/stores/ui-store";
 import { Breadcrumbs, useBreadcrumbs } from "@/components/layout/breadcrumbs";
@@ -129,6 +130,7 @@ function AuthenticatedShell() {
       <KoeWidget />
       <LockOverlay />
       <InstallPrompt />
+      <OnboardingTour />
     </>
   );
 }
@@ -284,6 +286,10 @@ function UserMenu() {
         <DropdownMenuItem render={<Link to="/account" />}>
           <UserCog className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           {t("nav.account")}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => useUiStore.getState().resetOnboarding()}>
+          <Compass className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          {t("nav.tour")}
         </DropdownMenuItem>
         {koeAvailable && (
           <DropdownMenuItem onClick={openKoe}>

--- a/apps/web/src/stores/ui-store.ts
+++ b/apps/web/src/stores/ui-store.ts
@@ -6,11 +6,14 @@ interface UiState {
   dismissedTips: string[];
   rewardsKidView: boolean;
   isLocked: boolean;
+  onboardingCompleted: boolean;
   setActiveChild: (id: string | null) => void;
   dismissTip: (id: string) => void;
   toggleRewardsKidView: () => void;
   lock: () => void;
   unlock: () => void;
+  completeOnboarding: () => void;
+  resetOnboarding: () => void;
 }
 
 export const useUiStore = create<UiState>()(
@@ -20,6 +23,7 @@ export const useUiStore = create<UiState>()(
       dismissedTips: [],
       rewardsKidView: false,
       isLocked: false,
+      onboardingCompleted: false,
       setActiveChild: (id) => set({ activeChildId: id }),
       dismissTip: (id) =>
         set((s) =>
@@ -31,6 +35,8 @@ export const useUiStore = create<UiState>()(
         set((s) => ({ rewardsKidView: !s.rewardsKidView })),
       lock: () => set({ isLocked: true }),
       unlock: () => set({ isLocked: false }),
+      completeOnboarding: () => set({ onboardingCompleted: true }),
+      resetOnboarding: () => set({ onboardingCompleted: false }),
     }),
     {
       name: "toko-ui",
@@ -38,6 +44,7 @@ export const useUiStore = create<UiState>()(
         activeChildId: state.activeChildId,
         dismissedTips: state.dismissedTips,
         rewardsKidView: state.rewardsKidView,
+        onboardingCompleted: state.onboardingCompleted,
         // isLocked intentionally NOT persisted — a fresh tab should open unlocked
       }),
     }


### PR DESCRIPTION
Introduces a six-step modal tour that auto-opens on first authenticated
visit. The tour walks new parents through the dashboard, symptom & journal
tracking, routines & rewards, and crisis support so they understand what
Tokō offers before adding their first child.

Completion is persisted in the existing ui-store (onboardingCompleted),
and a "Visite guidée" entry in the user menu lets parents replay it on
demand.

https://claude.ai/code/session_01AAdzUvxnPmzqS14s6mqpjh