### PR TITLE
feat(kb): chaleureux et visuel — héros par cluster, points clés, stats

### DIFF
--- a/apps/web/src/components/article/article-elements.tsx
+++ b/apps/web/src/components/article/article-elements.tsx
@@ -1,0 +1,389 @@
+import type { ReactNode } from "react";
+import {
+  Heart,
+  Sparkles,
+  HeartHandshake,
+  Brain,
+  Bed,
+  Ear,
+  Compass,
+  Stethoscope,
+  Pill,
+  Smartphone,
+  Trophy,
+  Library,
+  Sun,
+  Sprout,
+  CheckCircle2,
+  XCircle,
+  type LucideIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ─── Cluster visuals ──────────────────────────────────────────────────
+// One illustration per cluster: an icon + a soft pastel gradient. Used
+// as a friendly hero on top of every article so the reader is greeted
+// by something warm before the dense content starts.
+
+type ClusterTheme = {
+  icon: LucideIcon;
+  gradient: string; // tailwind gradient classes
+  iconBg: string;
+  iconColor: string;
+};
+
+const CLUSTER_THEMES: Record<string, ClusterTheme> = {
+  "Pillar · Crises & émotions": {
+    icon: HeartHandshake,
+    gradient: "from-rose-100/60 via-amber-50/50 to-transparent dark:from-rose-950/30 dark:via-amber-950/20",
+    iconBg: "bg-rose-100 dark:bg-rose-900/40",
+    iconColor: "text-rose-600 dark:text-rose-300",
+  },
+  "Crises & émotions": {
+    icon: Heart,
+    gradient: "from-rose-100/50 via-pink-50/40 to-transparent dark:from-rose-950/30 dark:via-pink-950/20",
+    iconBg: "bg-rose-100 dark:bg-rose-900/40",
+    iconColor: "text-rose-600 dark:text-rose-300",
+  },
+  "Posture parentale": {
+    icon: Sprout,
+    gradient: "from-emerald-100/50 via-teal-50/40 to-transparent dark:from-emerald-950/30 dark:via-teal-950/20",
+    iconBg: "bg-emerald-100 dark:bg-emerald-900/40",
+    iconColor: "text-emerald-600 dark:text-emerald-300",
+  },
+  "Cognition & école": {
+    icon: Brain,
+    gradient: "from-violet-100/50 via-indigo-50/40 to-transparent dark:from-violet-950/30 dark:via-indigo-950/20",
+    iconBg: "bg-violet-100 dark:bg-violet-900/40",
+    iconColor: "text-violet-600 dark:text-violet-300",
+  },
+  "Environnement sensoriel": {
+    icon: Ear,
+    gradient: "from-amber-100/50 via-orange-50/40 to-transparent dark:from-amber-950/30 dark:via-orange-950/20",
+    iconBg: "bg-amber-100 dark:bg-amber-900/40",
+    iconColor: "text-amber-700 dark:text-amber-300",
+  },
+  "Sommeil & quotidien": {
+    icon: Bed,
+    gradient: "from-indigo-100/50 via-blue-50/40 to-transparent dark:from-indigo-950/30 dark:via-blue-950/20",
+    iconBg: "bg-indigo-100 dark:bg-indigo-900/40",
+    iconColor: "text-indigo-600 dark:text-indigo-300",
+  },
+  "Pour l'entourage": {
+    icon: HeartHandshake,
+    gradient: "from-sky-100/50 via-cyan-50/40 to-transparent dark:from-sky-950/30 dark:via-cyan-950/20",
+    iconBg: "bg-sky-100 dark:bg-sky-900/40",
+    iconColor: "text-sky-600 dark:text-sky-300",
+  },
+  "Parcours de soins": {
+    icon: Compass,
+    gradient: "from-teal-100/50 via-cyan-50/40 to-transparent dark:from-teal-950/30 dark:via-cyan-950/20",
+    iconBg: "bg-teal-100 dark:bg-teal-900/40",
+    iconColor: "text-teal-600 dark:text-teal-300",
+  },
+  "Mythes & vérités": {
+    icon: Sun,
+    gradient: "from-yellow-100/50 via-amber-50/40 to-transparent dark:from-yellow-950/30 dark:via-amber-950/20",
+    iconBg: "bg-yellow-100 dark:bg-yellow-900/40",
+    iconColor: "text-yellow-700 dark:text-yellow-300",
+  },
+};
+
+const FALLBACK_THEME: ClusterTheme = {
+  icon: Library,
+  gradient: "from-primary/10 via-accent/5 to-transparent",
+  iconBg: "bg-primary/10",
+  iconColor: "text-primary",
+};
+
+export function getClusterTheme(cluster: string): ClusterTheme {
+  return CLUSTER_THEMES[cluster] ?? FALLBACK_THEME;
+}
+
+// ─── Hero ─────────────────────────────────────────────────────────────
+// Replaces the bare cluster-badge header with a colorful, warmer header
+// that includes a big cluster icon, decorative dots, and the cluster name.
+
+export function ArticleHero({
+  cluster,
+  title,
+  meta,
+}: {
+  cluster: string;
+  title: ReactNode;
+  meta?: ReactNode;
+}) {
+  const theme = getClusterTheme(cluster);
+  const Icon = theme.icon;
+
+  return (
+    <header className="relative overflow-hidden rounded-2xl border border-border/50 bg-card">
+      <div
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute inset-0 bg-gradient-to-br",
+          theme.gradient,
+        )}
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -right-10 -top-10 h-44 w-44 rounded-full bg-white/30 blur-3xl dark:bg-white/5"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute -bottom-12 -left-8 h-36 w-36 rounded-full bg-white/20 blur-2xl dark:bg-white/5"
+      />
+
+      <div className="relative px-5 py-7 sm:px-8 sm:py-9">
+        <div className="flex items-start gap-4">
+          <div
+            className={cn(
+              "flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl shadow-sm sm:h-16 sm:w-16",
+              theme.iconBg,
+              theme.iconColor,
+            )}
+          >
+            <Icon className="h-7 w-7 sm:h-8 sm:w-8" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p
+              className={cn(
+                "text-xs font-semibold uppercase tracking-wider",
+                theme.iconColor,
+              )}
+            >
+              {cluster}
+            </p>
+            <h1 className="mt-2 font-heading text-3xl font-semibold leading-tight tracking-tight text-foreground lg:text-4xl lg:leading-[1.15]">
+              {title}
+            </h1>
+            {meta && (
+              <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground">
+                {meta}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+// ─── Welcome intro ────────────────────────────────────────────────────
+// Friendly preamble that tells the reader they are in the right place,
+// they can take their time, and the article is written for them.
+
+export function WelcomeIntro({
+  audience = "parent",
+}: {
+  audience?: "parent" | "entourage";
+}) {
+  const message =
+    audience === "entourage"
+      ? "Vous êtes au bon endroit. Ce guide est court, sans jargon, et il a été écrit pour vous aider à comprendre — pas pour vous faire la leçon. Prenez le temps de le lire à votre rythme."
+      : "Vous êtes au bon endroit. Vous n'êtes pas seul·e. Cet article a été pensé pour vous accompagner, pas pour vous juger. Lisez à votre rythme — vous pouvez y revenir autant de fois que nécessaire.";
+
+  return (
+    <aside className="my-6 flex items-start gap-3 rounded-xl border border-primary/20 bg-primary/5 px-4 py-4">
+      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+        <Sparkles className="h-4 w-4" />
+      </div>
+      <p className="text-sm leading-relaxed text-foreground/90">{message}</p>
+    </aside>
+  );
+}
+
+// ─── Key takeaways ────────────────────────────────────────────────────
+// Visual "À retenir" card with checkmark bullets — placed at the start
+// of long articles so a stressed parent can grasp the essentials in 30s.
+
+export function KeyTakeaways({
+  title = "Ce qu'il faut retenir",
+  items,
+}: {
+  title?: string;
+  items: ReactNode[];
+}) {
+  return (
+    <aside className="my-8 rounded-2xl border border-emerald-200/60 bg-emerald-50/50 px-5 py-5 dark:border-emerald-900/40 dark:bg-emerald-950/20">
+      <div className="flex items-center gap-2 text-emerald-700 dark:text-emerald-300">
+        <Sparkles className="h-4 w-4" />
+        <p className="font-heading text-sm font-semibold uppercase tracking-wider">
+          {title}
+        </p>
+      </div>
+      <ul className="mt-3 space-y-2">
+        {items.map((item, i) => (
+          <li
+            key={i}
+            className="flex items-start gap-2.5 text-sm leading-relaxed text-foreground/90"
+          >
+            <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" />
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  );
+}
+
+// ─── Stat grid ────────────────────────────────────────────────────────
+// Big-number visual cards. Replaces walls of "75% of children…" prose
+// with a scannable, eye-catching mini-dashboard.
+
+export type StatItem = {
+  value: string;
+  label: ReactNode;
+  icon?: LucideIcon;
+};
+
+export function StatGrid({ items }: { items: StatItem[] }) {
+  return (
+    <div className="my-7 grid gap-3 sm:grid-cols-3">
+      {items.map((item, i) => {
+        const Icon = item.icon;
+        return (
+          <div
+            key={i}
+            className="rounded-xl border border-border/50 bg-card/60 px-4 py-5 text-center"
+          >
+            {Icon && (
+              <Icon className="mx-auto mb-2 h-5 w-5 text-primary/70" />
+            )}
+            <div className="font-heading text-3xl font-semibold tracking-tight text-primary">
+              {item.value}
+            </div>
+            <div className="mt-1.5 text-xs leading-snug text-muted-foreground">
+              {item.label}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ─── Comparison ──────────────────────────────────────────────────────
+// Side-by-side "ce qui aide" / "ce qui aggrave" cards. Used wherever an
+// article currently lists pitfalls and remedies in two consecutive ULs.
+
+export function Comparison({
+  helpsTitle = "Ce qui aide",
+  hurtsTitle = "Ce qui aggrave",
+  helps,
+  hurts,
+}: {
+  helpsTitle?: string;
+  hurtsTitle?: string;
+  helps: ReactNode[];
+  hurts: ReactNode[];
+}) {
+  return (
+    <div className="my-7 grid gap-4 md:grid-cols-2">
+      <div className="rounded-xl border border-emerald-200/60 bg-emerald-50/40 p-5 dark:border-emerald-900/40 dark:bg-emerald-950/20">
+        <div className="mb-3 flex items-center gap-2 text-emerald-700 dark:text-emerald-300">
+          <CheckCircle2 className="h-4 w-4" />
+          <p className="font-heading text-sm font-semibold uppercase tracking-wider">
+            {helpsTitle}
+          </p>
+        </div>
+        <ul className="space-y-2">
+          {helps.map((item, i) => (
+            <li
+              key={i}
+              className="flex items-start gap-2 text-sm leading-relaxed text-foreground/90"
+            >
+              <span
+                aria-hidden
+                className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500"
+              />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="rounded-xl border border-rose-200/60 bg-rose-50/40 p-5 dark:border-rose-900/40 dark:bg-rose-950/20">
+        <div className="mb-3 flex items-center gap-2 text-rose-700 dark:text-rose-300">
+          <XCircle className="h-4 w-4" />
+          <p className="font-heading text-sm font-semibold uppercase tracking-wider">
+            {hurtsTitle}
+          </p>
+        </div>
+        <ul className="space-y-2">
+          {hurts.map((item, i) => (
+            <li
+              key={i}
+              className="flex items-start gap-2 text-sm leading-relaxed text-foreground/90"
+            >
+              <span
+                aria-hidden
+                className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-rose-500"
+              />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+// ─── Encouragement ───────────────────────────────────────────────────
+// A soft, warm callout used at the end of difficult sections to remind
+// the parent they're doing the right thing by reading.
+
+export function Encouragement({ children }: { children: ReactNode }) {
+  return (
+    <aside className="my-6 flex items-start gap-3 rounded-xl border border-amber-200/60 bg-amber-50/40 px-5 py-4 dark:border-amber-900/40 dark:bg-amber-950/20">
+      <Heart className="mt-0.5 h-5 w-5 shrink-0 text-amber-600 dark:text-amber-300" />
+      <p className="text-sm leading-relaxed text-foreground/90">{children}</p>
+    </aside>
+  );
+}
+
+// ─── Step list ────────────────────────────────────────────────────────
+// Numbered visual steps — replaces dense numbered lists with a friendlier,
+// more scannable layout (number badge + title + description).
+
+export type StepItem = {
+  title: string;
+  description: ReactNode;
+};
+
+export function StepList({ items }: { items: StepItem[] }) {
+  return (
+    <ol className="my-7 space-y-4">
+      {items.map((item, i) => (
+        <li
+          key={i}
+          className="flex items-start gap-4 rounded-xl border border-border/50 bg-card/40 px-4 py-4"
+        >
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 font-heading text-base font-semibold text-primary">
+            {i + 1}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="font-heading text-base font-semibold text-foreground">
+              {item.title}
+            </p>
+            <div className="mt-1 text-sm leading-relaxed text-muted-foreground">
+              {item.description}
+            </div>
+          </div>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+// Re-export icons for use in article content authoring.
+export {
+  Heart,
+  Sparkles,
+  Brain,
+  Bed,
+  Ear,
+  Stethoscope,
+  Pill,
+  Smartphone,
+  Trophy,
+};

--- a/apps/web/src/lib/resources-data.tsx
+++ b/apps/web/src/lib/resources-data.tsx
@@ -1,4 +1,10 @@
 import { Link } from "@tanstack/react-router";
+import {
+  KeyTakeaways,
+  StatGrid,
+  Comparison,
+  Encouragement,
+} from "@/components/article/article-elements";
 import type { ResourceArticle } from "./resources-types";
 
 // Default metadata applied to articles that don't override. When we begin
@@ -110,6 +116,32 @@ export const articles: ResourceArticle[] = [
           qui marche vraiment — en s'appuyant sur les travaux du Dr Russell
           Barkley et les recherches récentes en neurosciences du développement.
         </p>
+
+        <KeyTakeaways
+          items={[
+            "Une crise TDAH est neurologique, pas un caprice — son cerveau ne « choisit » pas.",
+            "Pendant l'explosion, le raisonnement ne fonctionne pas. C'est votre calme qui apaise le sien.",
+            "Identifier les déclencheurs (sommeil, faim, transitions) prévient 80 % des crises.",
+            "Vous lisez cet article : c'est déjà une étape immense pour votre enfant.",
+          ]}
+        />
+
+        <StatGrid
+          items={[
+            {
+              value: "75 %",
+              label: "des enfants TDAH vivent une dysrégulation émotionnelle",
+            },
+            {
+              value: "3 ans",
+              label: "de retard moyen du développement du cortex préfrontal",
+            },
+            {
+              value: "60-70 %",
+              label: "de baisse des crises avec un suivi adapté en 12-18 mois",
+            },
+          ]}
+        />
 
         <h2>Une crise TDAH n'est pas un caprice</h2>
         <p>
@@ -269,15 +301,23 @@ export const articles: ResourceArticle[] = [
           </p>
         </aside>
 
-        <h2>Ce qui aggrave systématiquement une crise</h2>
-        <ul>
-          <li>Lever la voix ou crier</li>
-          <li>Menacer (« si tu continues, je… »)</li>
-          <li>Isoler de force dans sa chambre pendant l'explosion</li>
-          <li>Argumenter, expliquer, raisonner</li>
-          <li>Punir à chaud</li>
-          <li>Comparer à un frère, une sœur, un camarade</li>
-        </ul>
+        <h2>Ce qui aide vs ce qui aggrave</h2>
+        <Comparison
+          helps={[
+            "Respirer avant de parler, baisser sa voix",
+            "S'asseoir à sa hauteur, proposer (sans imposer) le contact",
+            "Phrases courtes répétées : « Je suis là. »",
+            "Réduire les stimuli (lumière, fratrie, écrans)",
+            "Réparer après, à froid, sans culpabiliser",
+          ]}
+          hurts={[
+            "Lever la voix ou crier",
+            "Menacer (« si tu continues, je… »)",
+            "Isoler de force dans sa chambre pendant l'explosion",
+            "Argumenter, expliquer, raisonner pendant la crise",
+            "Punir à chaud, comparer à un frère ou une sœur",
+          ]}
+        />
 
         <h2>Quand consulter un professionnel ?</h2>
         <p>
@@ -604,6 +644,13 @@ export const articles: ResourceArticle[] = [
           </li>
         </ul>
 
+        <Encouragement>
+          Si vous êtes en train de lire ces lignes alors que la maison est en
+          plein chaos, soufflez. Vous faites déjà beaucoup. Le simple fait de
+          chercher à comprendre est ce qui change le plus la trajectoire de
+          votre enfant. Vous n'êtes pas seul·e.
+        </Encouragement>
+
         <h2>La bonne nouvelle : les crises diminuent</h2>
         <p>
           Si vous lisez cet article en plein chaos, voici ce qu'il faut
@@ -696,20 +743,31 @@ export const articles: ResourceArticle[] = [
           manque d'éducation.
         </p>
 
+        <KeyTakeaways
+          items={[
+            "La dysrégulation émotionnelle touche 3 enfants TDAH sur 4 — ce n'est ni rare ni un échec.",
+            "Son cerveau amplifie les émotions et freine plus tard que la moyenne.",
+            "Nommer l'émotion sans la juger aide le cerveau à se reconnecter.",
+          ]}
+        />
+
         <h2>Les chiffres clés</h2>
-        <ul>
-          <li>
-            <strong>75 %</strong> des enfants et adolescents TDAH présentent
-            une dysrégulation émotionnelle significative
-          </li>
-          <li>
-            Transmissibilité héréditaire du TDAH : environ <strong>75 %</strong>
-          </li>
-          <li>
-            Le cortex préfrontal (régulation) se développe environ{" "}
-            <strong>3 ans plus tard</strong> chez l'enfant TDAH
-          </li>
-        </ul>
+        <StatGrid
+          items={[
+            {
+              value: "75 %",
+              label: "des enfants TDAH vivent une dysrégulation émotionnelle significative",
+            },
+            {
+              value: "75 %",
+              label: "d'héritabilité — le TDAH est largement génétique",
+            },
+            {
+              value: "3 ans",
+              label: "de retard moyen du cortex préfrontal (régulation)",
+            },
+          ]}
+        />
 
         <h2>Comment cela se manifeste-t-il ?</h2>
         <h3>Hypersensibilité émotionnelle</h3>
@@ -809,6 +867,14 @@ export const articles: ResourceArticle[] = [
           condition d'arriver à rester calme soi-même.
         </p>
 
+        <KeyTakeaways
+          items={[
+            "Co-réguler, c'est apaiser par votre propre calme — pas par votre raison.",
+            "7 gestes concrets, testables ce soir, sans matériel.",
+            "Vous allez craquer parfois. C'est normal — réparer renforce le lien.",
+          ]}
+        />
+
         <h2>Pourquoi « co-réguler avant de corriger » ?</h2>
         <p>
           Le cerveau d'un enfant en crise est en mode survie. Le cortex
@@ -906,6 +972,14 @@ export const articles: ResourceArticle[] = [
           provocation. C'est une erreur — et elle coûte cher.
         </p>
 
+        <KeyTakeaways
+          items={[
+            "Le figement est la 3ᵉ réponse au stress, à côté du combat et de la fuite.",
+            "Ce n'est pas une bouderie : c'est une protection neurologique.",
+            "Réduire la pression, attendre — le figement se dissipe seul en 5 à 20 min.",
+          ]}
+        />
+
         <h2>Qu'est-ce que le figement ?</h2>
         <p>
           Le figement (ou <em>freeze response</em>) est la troisième réponse du
@@ -936,33 +1010,21 @@ export const articles: ResourceArticle[] = [
           l'explosion.
         </p>
 
-        <h2>Ce qu'il faut éviter absolument</h2>
-        <ul>
-          <li>Insister : « Réponds-moi quand je te parle ! »</li>
-          <li>Secouer, toucher brusquement, forcer le regard</li>
-          <li>Interpréter comme de la provocation</li>
-          <li>Punir le silence</li>
-        </ul>
-
-        <h2>Ce qui aide</h2>
-        <ul>
-          <li>
-            <strong>Réduire la pression</strong> : s'éloigner un peu, baisser
-            la voix, arrêter les questions.
-          </li>
-          <li>
-            <strong>Donner un repère temporel</strong> : « Je reste dans la
-            pièce d'à côté, tu me dis quand tu es prêt. »
-          </li>
-          <li>
-            <strong>Proposer un ancrage sensoriel</strong> : un verre d'eau
-            frais, une couverture lourde, une musique douce.
-          </li>
-          <li>
-            <strong>Attendre</strong>. Le figement se dissipe de lui-même en
-            général entre 5 et 20 minutes si on ne l'aggrave pas.
-          </li>
-        </ul>
+        <h2>Ce qui aide vs ce qui aggrave</h2>
+        <Comparison
+          helps={[
+            "Réduire la pression : s'éloigner, baisser la voix, arrêter les questions",
+            "Donner un repère : « Je reste à côté, tu me dis quand tu es prêt »",
+            "Proposer un ancrage sensoriel : eau fraîche, couverture lourde, musique douce",
+            "Attendre. Le figement se dissipe seul en 5 à 20 min sans pression",
+          ]}
+          hurts={[
+            "Insister : « Réponds-moi quand je te parle ! »",
+            "Secouer, toucher brusquement, forcer le regard",
+            "Interpréter comme de la provocation",
+            "Punir le silence",
+          ]}
+        />
 
         <h2>Quand s'inquiéter ?</h2>
         <p>
@@ -1004,6 +1066,15 @@ export const articles: ResourceArticle[] = [
           des processus cérébraux qui permettent de planifier, mémoriser à
           court terme, inhiber, organiser — présentent un déficit spécifique.
         </p>
+
+        <KeyTakeaways
+          items={[
+            "Sa mémoire de travail est ~30 % plus courte qu'un enfant non-TDAH du même âge.",
+            "Fragmenter les consignes (une à la fois) change tout au quotidien.",
+            "Externaliser la mémoire (listes, photos, chronos) n'est pas tricher — c'est une prothèse cognitive.",
+            "Renforcer positivement réveille la dopamine. Punir l'oubli aggrave l'anxiété.",
+          ]}
+        />
 
         <h2>Les 6 fonctions exécutives touchées par le TDAH</h2>
         <ol>
@@ -1120,6 +1191,22 @@ export const articles: ResourceArticle[] = [
           un caprice.
         </p>
 
+        <KeyTakeaways
+          items={[
+            "Son cerveau filtre moins bien les stimuli — tout arrive en même temps, fort.",
+            "« Tenir » toute la journée à l'école épuise ses ressources : c'est le crash du retour.",
+            "Identifier 3-4 déclencheurs sensoriels propres à votre enfant règle 80 % du problème.",
+          ]}
+        />
+
+        <StatGrid
+          items={[
+            { value: "1 sur 2", label: "des enfants TDAH ont une hypersensibilité sensorielle" },
+            { value: "5 canaux", label: "souvent touchés : auditif, tactile, visuel, gustatif, proprioceptif" },
+            { value: "30 min", label: "de décompression post-école — un game changer" },
+          ]}
+        />
+
         <h2>Qu'est-ce que l'hypersensibilité sensorielle ?</h2>
         <p>
           C'est une réaction amplifiée aux stimuli sensoriels : bruits,
@@ -1215,6 +1302,22 @@ export const articles: ResourceArticle[] = [
           impossibles. Le sommeil est à la fois la cause et la conséquence du
           TDAH — un cercle vicieux qu'on peut casser.
         </p>
+
+        <KeyTakeaways
+          items={[
+            "Soigner le sommeil, c'est soigner le TDAH — les symptômes du jour s'aggravent de 30 à 50 % avec une mauvaise nuit.",
+            "Une routine en 4 paliers (1h30 / 45 min / 30 min / coucher) marche pour la plupart des enfants.",
+            "La mélatonine en prescription médicale peut aider — jamais en automédication.",
+          ]}
+        />
+
+        <StatGrid
+          items={[
+            { value: "70 %", label: "des enfants TDAH ont des troubles du sommeil" },
+            { value: "+1 h", label: "de retard de phase circadien en moyenne" },
+            { value: "30-50 %", label: "d'aggravation des symptômes le lendemain d'une mauvaise nuit" },
+          ]}
+        />
 
         <h2>Pourquoi l'enfant TDAH dort mal</h2>
         <ul>
@@ -1330,6 +1433,14 @@ export const articles: ResourceArticle[] = [
           écrit pour que vous puissiez être un·e meilleur·e allié·e, parce que
           votre rôle compte énormément.
         </p>
+
+        <KeyTakeaways
+          items={[
+            "Le TDAH est un fonctionnement cérébral, pas un échec éducatif.",
+            "Votre petit-enfant a besoin de votre regard bienveillant, pas de discipline supplémentaire.",
+            "Soutenir ses parents fatigués vaut autant que jouer avec lui.",
+          ]}
+        />
 
         <h2>C'est quoi, le TDAH ?</h2>
         <p>
@@ -1486,6 +1597,15 @@ export const articles: ResourceArticle[] = [
           adulte.
         </p>
 
+        <KeyTakeaways
+          items={[
+            "5 règles cardinales communes — le reste, libre chez chacun.",
+            "Ne jamais critiquer l'autre parent devant l'enfant : il en tire la conclusion qu'il est le problème.",
+            "Partager des observations factuelles, pas des interprétations.",
+            "Se relayer dans la fatigue, plutôt que se concurrencer.",
+          ]}
+        />
+
         <h2>Pourquoi la cohérence compte plus pour lui que pour les autres enfants</h2>
         <p>
           Un enfant TDAH a une <strong>mémoire de travail réduite</strong> et
@@ -1619,6 +1739,14 @@ export const articles: ResourceArticle[] = [
           pour vous. En 4 minutes, vous saurez exactement comment jouer votre
           rôle — qui est immense.
         </p>
+
+        <KeyTakeaways
+          items={[
+            "Vous êtes un adulte affectueux et non-évaluateur — c'est exactement ce dont l'enfant manque le plus.",
+            "Une activité maximum par sortie. Prévenir 5 puis 2 minutes avant chaque transition.",
+            "Soulager ses parents un samedi après-midi vaut une thérapie familiale.",
+          ]}
+        />
 
         <h2>Votre place est unique (et précieuse)</h2>
         <p>
@@ -1779,6 +1907,14 @@ export const articles: ResourceArticle[] = [
           Vous ne savez pas par qui commencer. Vous n'êtes pas seul·e. Voici
           6 étapes concrètes — à votre rythme.
         </p>
+
+        <KeyTakeaways
+          items={[
+            "Étapes 1 et 2 (école + MDPH) : à lancer cette semaine. Le reste suit son rythme.",
+            "Le TDAH est reconnu ALD : prise en charge à 100 % pour les actes liés.",
+            "Un journal d'observations (Tokō ou carnet) accélère drastiquement chaque consultation.",
+          ]}
+        />
 
         <div className="my-6 rounded-lg border border-warning-border bg-warning-surface px-4 py-3 text-warning-foreground">
           <div className="text-xs font-semibold uppercase tracking-wide">
@@ -2102,6 +2238,22 @@ export const articles: ResourceArticle[] = [
           main.
         </p>
 
+        <KeyTakeaways
+          items={[
+            "Les médicaments ne changent pas la personnalité — un enfant « éteint » est probablement surdosé.",
+            "70-80 % des enfants TDAH répondent positivement à un traitement bien dosé.",
+            "Aucun risque accru de dépendance — au contraire, le non-traitement augmente le risque addictif.",
+          ]}
+        />
+
+        <StatGrid
+          items={[
+            { value: "70-80 %", label: "des enfants TDAH répondent à un psychostimulant correctement dosé" },
+            { value: "60 ans", label: "de recul scientifique sur le méthylphénidate" },
+            { value: "0", label: "risque accru de dépendance documenté (INSERM 2022)" },
+          ]}
+        />
+
         <h2>Mythe 1 : « Les médicaments vont le zombifier »</h2>
         <p>
           Le méthylphénidate et les amphétamines réduisent la distractibilité
@@ -2207,6 +2359,14 @@ export const articles: ResourceArticle[] = [
           Facebook partagé 12 000 fois. Elle est fausse — et elle vous fait
           du mal.
         </p>
+
+        <KeyTakeaways
+          items={[
+            "Le TDAH est héréditaire à 75-80 %. Les écrans ne le « donnent » pas.",
+            "Les écrans peuvent aggraver les symptômes dans l'instant — c'est un problème de gestion, pas de cause.",
+            "La culpabilité ne soigne rien. Cadrer plutôt que supprimer fonctionne mieux.",
+          ]}
+        />
 
         <h2>Le TDAH est neurodéveloppemental, pas environnemental</h2>
         <p>
@@ -2330,6 +2490,14 @@ export const articles: ResourceArticle[] = [
           phrases reviennent dans chaque famille TDAH. Elles partent d'un
           malentendu fondamental sur le cerveau de votre enfant.
         </p>
+
+        <KeyTakeaways
+          items={[
+            "Le cerveau TDAH sous-évalue les récompenses différées — ce n'est ni de la paresse ni du choix.",
+            "La punition différée n'enseigne rien : la connexion cause-conséquence est perdue.",
+            "Ce qui marche : récompenses immédiates, fréquentes et visibles (autocollants, points, étoiles).",
+          ]}
+        />
 
         <h2>L'aversion au délai : la clé que personne n'explique</h2>
         <p>
@@ -2467,6 +2635,20 @@ export const articles: ResourceArticle[] = [
           vous pleurez une fois qu'il est couché. Les trois sont normaux.
           Aucun ne fait de vous un mauvais parent.
         </p>
+
+        <Encouragement>
+          Si vous lisez cet article, vous prenez déjà soin de vous — et donc
+          de votre enfant. Vous n'êtes pas un mauvais parent. Vous êtes un
+          parent fatigué qui se relève. C'est tout autre chose.
+        </Encouragement>
+
+        <KeyTakeaways
+          items={[
+            "Vivre avec un enfant TDAH est une exposition chronique au stress — pas un échec moral.",
+            "Le masque à oxygène, c'est pour vous d'abord. Sans cela, aucune technique ne tient.",
+            "Réparer après avoir craqué renforce le lien plus qu'un sans-faute impossible.",
+          ]}
+        />
 
         <h2>La biologie du parent épuisé</h2>
         <p>

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -29,10 +29,10 @@ import { Route as AuthenticatedMedicationsIndexRouteImport } from './routes/_aut
 import { Route as AuthenticatedJournalIndexRouteImport } from './routes/_authenticated/journal/index'
 import { Route as AuthenticatedDashboardIndexRouteImport } from './routes/_authenticated/dashboard/index'
 import { Route as AuthenticatedCrisisListIndexRouteImport } from './routes/_authenticated/crisis-list/index'
+import { Route as AuthenticatedConnaissancesIndexRouteImport } from './routes/_authenticated/connaissances/index'
 import { Route as AuthenticatedCarePathwayIndexRouteImport } from './routes/_authenticated/care-pathway/index'
 import { Route as AuthenticatedBarkleyIndexRouteImport } from './routes/_authenticated/barkley/index'
 import { Route as AuthenticatedAdminVaultIndexRouteImport } from './routes/_authenticated/admin-vault/index'
-import { Route as AuthenticatedConnaissancesIndexRouteImport } from './routes/_authenticated/connaissances/index'
 import { Route as AuthenticatedActivityIndexRouteImport } from './routes/_authenticated/activity/index'
 import { Route as AuthenticatedAchievementsIndexRouteImport } from './routes/_authenticated/achievements/index'
 import { Route as AuthenticatedAccountIndexRouteImport } from './routes/_authenticated/account/index'
@@ -147,6 +147,12 @@ const AuthenticatedCrisisListIndexRoute =
     path: '/crisis-list/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedConnaissancesIndexRoute =
+  AuthenticatedConnaissancesIndexRouteImport.update({
+    id: '/connaissances/',
+    path: '/connaissances/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedCarePathwayIndexRoute =
   AuthenticatedCarePathwayIndexRouteImport.update({
     id: '/care-pathway/',
@@ -163,12 +169,6 @@ const AuthenticatedAdminVaultIndexRoute =
   AuthenticatedAdminVaultIndexRouteImport.update({
     id: '/admin-vault/',
     path: '/admin-vault/',
-    getParentRoute: () => AuthenticatedRoute,
-  } as any)
-const AuthenticatedConnaissancesIndexRoute =
-  AuthenticatedConnaissancesIndexRouteImport.update({
-    id: '/connaissances/',
-    path: '/connaissances/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 const AuthenticatedActivityIndexRoute =
@@ -216,10 +216,10 @@ export interface FileRoutesByFullPath {
   '/account/': typeof AuthenticatedAccountIndexRoute
   '/achievements/': typeof AuthenticatedAchievementsIndexRoute
   '/activity/': typeof AuthenticatedActivityIndexRoute
-  '/connaissances/': typeof AuthenticatedConnaissancesIndexRoute
   '/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley/': typeof AuthenticatedBarkleyIndexRoute
   '/care-pathway/': typeof AuthenticatedCarePathwayIndexRoute
+  '/connaissances/': typeof AuthenticatedConnaissancesIndexRoute
   '/crisis-list/': typeof AuthenticatedCrisisListIndexRoute
   '/dashboard/': typeof AuthenticatedDashboardIndexRoute
   '/journal/': typeof AuthenticatedJournalIndexRoute
@@ -246,10 +246,10 @@ export interface FileRoutesByTo {
   '/account': typeof AuthenticatedAccountIndexRoute
   '/achievements': typeof AuthenticatedAchievementsIndexRoute
   '/activity': typeof AuthenticatedActivityIndexRoute
-  '/connaissances': typeof AuthenticatedConnaissancesIndexRoute
   '/admin-vault': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley': typeof AuthenticatedBarkleyIndexRoute
   '/care-pathway': typeof AuthenticatedCarePathwayIndexRoute
+  '/connaissances': typeof AuthenticatedConnaissancesIndexRoute
   '/crisis-list': typeof AuthenticatedCrisisListIndexRoute
   '/dashboard': typeof AuthenticatedDashboardIndexRoute
   '/journal': typeof AuthenticatedJournalIndexRoute
@@ -278,10 +278,10 @@ export interface FileRoutesById {
   '/_authenticated/account/': typeof AuthenticatedAccountIndexRoute
   '/_authenticated/achievements/': typeof AuthenticatedAchievementsIndexRoute
   '/_authenticated/activity/': typeof AuthenticatedActivityIndexRoute
-  '/_authenticated/connaissances/': typeof AuthenticatedConnaissancesIndexRoute
   '/_authenticated/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/_authenticated/barkley/': typeof AuthenticatedBarkleyIndexRoute
   '/_authenticated/care-pathway/': typeof AuthenticatedCarePathwayIndexRoute
+  '/_authenticated/connaissances/': typeof AuthenticatedConnaissancesIndexRoute
   '/_authenticated/crisis-list/': typeof AuthenticatedCrisisListIndexRoute
   '/_authenticated/dashboard/': typeof AuthenticatedDashboardIndexRoute
   '/_authenticated/journal/': typeof AuthenticatedJournalIndexRoute
@@ -310,10 +310,10 @@ export interface FileRouteTypes {
     | '/account/'
     | '/achievements/'
     | '/activity/'
-    | '/connaissances/'
     | '/admin-vault/'
     | '/barkley/'
     | '/care-pathway/'
+    | '/connaissances/'
     | '/crisis-list/'
     | '/dashboard/'
     | '/journal/'
@@ -340,10 +340,10 @@ export interface FileRouteTypes {
     | '/account'
     | '/achievements'
     | '/activity'
-    | '/connaissances'
     | '/admin-vault'
     | '/barkley'
     | '/care-pathway'
+    | '/connaissances'
     | '/crisis-list'
     | '/dashboard'
     | '/journal'
@@ -371,10 +371,10 @@ export interface FileRouteTypes {
     | '/_authenticated/account/'
     | '/_authenticated/achievements/'
     | '/_authenticated/activity/'
-    | '/_authenticated/connaissances/'
     | '/_authenticated/admin-vault/'
     | '/_authenticated/barkley/'
     | '/_authenticated/care-pathway/'
+    | '/_authenticated/connaissances/'
     | '/_authenticated/crisis-list/'
     | '/_authenticated/dashboard/'
     | '/_authenticated/journal/'
@@ -543,6 +543,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedCrisisListIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/connaissances/': {
+      id: '/_authenticated/connaissances/'
+      path: '/connaissances'
+      fullPath: '/connaissances/'
+      preLoaderRoute: typeof AuthenticatedConnaissancesIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/care-pathway/': {
       id: '/_authenticated/care-pathway/'
       path: '/care-pathway'
@@ -562,13 +569,6 @@ declare module '@tanstack/react-router' {
       path: '/admin-vault'
       fullPath: '/admin-vault/'
       preLoaderRoute: typeof AuthenticatedAdminVaultIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/connaissances/': {
-      id: '/_authenticated/connaissances/'
-      path: '/connaissances'
-      fullPath: '/connaissances/'
-      preLoaderRoute: typeof AuthenticatedConnaissancesIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/activity/': {
@@ -614,10 +614,10 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAccountIndexRoute: typeof AuthenticatedAccountIndexRoute
   AuthenticatedAchievementsIndexRoute: typeof AuthenticatedAchievementsIndexRoute
   AuthenticatedActivityIndexRoute: typeof AuthenticatedActivityIndexRoute
-  AuthenticatedConnaissancesIndexRoute: typeof AuthenticatedConnaissancesIndexRoute
   AuthenticatedAdminVaultIndexRoute: typeof AuthenticatedAdminVaultIndexRoute
   AuthenticatedBarkleyIndexRoute: typeof AuthenticatedBarkleyIndexRoute
   AuthenticatedCarePathwayIndexRoute: typeof AuthenticatedCarePathwayIndexRoute
+  AuthenticatedConnaissancesIndexRoute: typeof AuthenticatedConnaissancesIndexRoute
   AuthenticatedCrisisListIndexRoute: typeof AuthenticatedCrisisListIndexRoute
   AuthenticatedDashboardIndexRoute: typeof AuthenticatedDashboardIndexRoute
   AuthenticatedJournalIndexRoute: typeof AuthenticatedJournalIndexRoute
@@ -636,10 +636,10 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAccountIndexRoute: AuthenticatedAccountIndexRoute,
   AuthenticatedAchievementsIndexRoute: AuthenticatedAchievementsIndexRoute,
   AuthenticatedActivityIndexRoute: AuthenticatedActivityIndexRoute,
-  AuthenticatedConnaissancesIndexRoute: AuthenticatedConnaissancesIndexRoute,
   AuthenticatedAdminVaultIndexRoute: AuthenticatedAdminVaultIndexRoute,
   AuthenticatedBarkleyIndexRoute: AuthenticatedBarkleyIndexRoute,
   AuthenticatedCarePathwayIndexRoute: AuthenticatedCarePathwayIndexRoute,
+  AuthenticatedConnaissancesIndexRoute: AuthenticatedConnaissancesIndexRoute,
   AuthenticatedCrisisListIndexRoute: AuthenticatedCrisisListIndexRoute,
   AuthenticatedDashboardIndexRoute: AuthenticatedDashboardIndexRoute,
   AuthenticatedJournalIndexRoute: AuthenticatedJournalIndexRoute,

--- a/apps/web/src/routes/_authenticated/connaissances/$slug.tsx
+++ b/apps/web/src/routes/_authenticated/connaissances/$slug.tsx
@@ -1,8 +1,17 @@
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
-import { ArrowLeft, Clock } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import { articles, DEFAULT_LAST_REVIEWED, DEFAULT_REVIEWER } from "@/lib/resources-data";
+import { ArrowLeft, Clock, ShieldCheck } from "lucide-react";
+import {
+  articles,
+  DEFAULT_LAST_REVIEWED,
+  DEFAULT_REVIEWER,
+} from "@/lib/resources-data";
 import { useTranslation } from "react-i18next";
+import {
+  ArticleHero,
+  WelcomeIntro,
+  getClusterTheme,
+} from "@/components/article/article-elements";
+import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/_authenticated/connaissances/$slug")({
   component: ArticlePage,
@@ -16,6 +25,7 @@ export const Route = createFileRoute("/_authenticated/connaissances/$slug")({
 function ArticlePage() {
   const { article } = Route.useLoaderData();
   const { t } = useTranslation();
+  const theme = getClusterTheme(article.cluster);
 
   return (
     <article className="mx-auto max-w-3xl px-4 py-8">
@@ -27,32 +37,33 @@ function ArticlePage() {
         {t("news.backToList")}
       </Link>
 
-      <header className="mb-8">
-        <Badge variant="outline" className="mb-4 border-primary/20 bg-primary/5 text-primary">
-          {article.cluster}
-        </Badge>
-        <h1 className="font-heading text-3xl font-semibold leading-tight tracking-tight lg:text-4xl lg:leading-[1.15]">
-          {article.title}
-        </h1>
-        <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground">
-          <span className="inline-flex items-center gap-1.5">
-            <Clock className="h-3.5 w-3.5" />
-            {article.readTime} de lecture
-          </span>
-          <span aria-hidden="true">·</span>
-          <span className="text-xs">
-            Révisé le{" "}
-            {new Date(
-              article.lastReviewedAt ?? DEFAULT_LAST_REVIEWED
-            ).toLocaleDateString("fr-FR", {
-              day: "numeric",
-              month: "long",
-              year: "numeric",
-            })}{" "}
-            — {article.reviewer ?? DEFAULT_REVIEWER}
-          </span>
-        </div>
-      </header>
+      <ArticleHero
+        cluster={article.cluster}
+        title={article.title}
+        meta={
+          <>
+            <span className="inline-flex items-center gap-1.5">
+              <Clock className="h-3.5 w-3.5" />
+              {article.readTime} de lecture
+            </span>
+            <span aria-hidden="true">·</span>
+            <span className="inline-flex items-center gap-1.5 text-xs">
+              <ShieldCheck className="h-3.5 w-3.5" />
+              Révisé le{" "}
+              {new Date(
+                article.lastReviewedAt ?? DEFAULT_LAST_REVIEWED,
+              ).toLocaleDateString("fr-FR", {
+                day: "numeric",
+                month: "long",
+                year: "numeric",
+              })}{" "}
+              — {article.reviewer ?? DEFAULT_REVIEWER}
+            </span>
+          </>
+        }
+      />
+
+      <WelcomeIntro audience={article.audience} />
 
       <div className="article-body">{article.content}</div>
 
@@ -62,6 +73,9 @@ function ArticlePage() {
           <h2 className="font-heading text-2xl font-semibold tracking-tight">
             Questions fréquentes
           </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Les questions que les autres parents se posent le plus souvent.
+          </p>
           <div className="mt-6 space-y-3">
             {article.faq.map((item, i) => (
               <details
@@ -94,30 +108,48 @@ function ArticlePage() {
           <h2 className="font-heading text-xl font-semibold tracking-tight">
             À lire ensuite
           </h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Pour aller plus loin, à votre rythme.
+          </p>
           <div className="mt-6 grid gap-4 sm:grid-cols-2">
             {article.related
               .map((slug) => articles.find((a) => a.slug === slug))
               .filter((a): a is NonNullable<typeof a> => !!a)
-              .map((r) => (
-                <Link
-                  key={r.slug}
-                  to="/connaissances/$slug"
-                  params={{ slug: r.slug }}
-                  className="group"
-                >
-                  <div className="h-full rounded-lg border border-border/60 p-5 transition-all duration-300 hover:border-primary/20 hover:shadow-sm">
-                    <p className="text-xs font-medium text-primary/80">
-                      {r.cluster}
-                    </p>
-                    <p className="mt-2 font-heading font-semibold leading-snug group-hover:text-primary">
-                      {r.title}
-                    </p>
-                    <p className="mt-2 text-sm leading-relaxed text-muted-foreground line-clamp-2">
-                      {r.excerpt}
-                    </p>
-                  </div>
-                </Link>
-              ))}
+              .map((r) => {
+                const rTheme = getClusterTheme(r.cluster);
+                const RIcon = rTheme.icon;
+                return (
+                  <Link
+                    key={r.slug}
+                    to="/connaissances/$slug"
+                    params={{ slug: r.slug }}
+                    className="group"
+                  >
+                    <div className="flex h-full gap-3 rounded-lg border border-border/60 p-5 transition-all duration-300 hover:border-primary/20 hover:shadow-sm">
+                      <div
+                        className={cn(
+                          "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
+                          rTheme.iconBg,
+                          rTheme.iconColor,
+                        )}
+                      >
+                        <RIcon className="h-4 w-4" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="text-xs font-medium text-primary/80">
+                          {r.cluster}
+                        </p>
+                        <p className="mt-1 font-heading font-semibold leading-snug group-hover:text-primary">
+                          {r.title}
+                        </p>
+                        <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground line-clamp-2">
+                          {r.excerpt}
+                        </p>
+                      </div>
+                    </div>
+                  </Link>
+                );
+              })}
           </div>
         </section>
       )}

--- a/apps/web/src/routes/_authenticated/connaissances/index.tsx
+++ b/apps/web/src/routes/_authenticated/connaissances/index.tsx
@@ -1,5 +1,5 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { Library, Clock, ArrowRight } from "lucide-react";
+import { Library, Clock, ArrowRight, Sparkles } from "lucide-react";
 import {
   Card,
   CardContent,
@@ -11,6 +11,8 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { articles } from "@/lib/resources-data";
 import { useTranslation } from "react-i18next";
+import { getClusterTheme } from "@/components/article/article-elements";
+import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/_authenticated/connaissances/")({
   component: ConnaissancesIndex,
@@ -33,82 +35,136 @@ function ConnaissancesIndex() {
           </h1>
         </div>
         <p className="text-muted-foreground">{t("news.subtitle")}</p>
+
+        <aside className="mt-5 flex items-start gap-3 rounded-xl border border-primary/20 bg-primary/5 px-4 py-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+            <Sparkles className="h-4 w-4" />
+          </div>
+          <p className="text-sm leading-relaxed text-foreground/90">
+            Une bibliothèque pour les jours plus difficiles comme pour les
+            jours plus calmes. Lisez à votre rythme — chaque article est
+            pensé pour vous accompagner, pas pour vous juger.
+          </p>
+        </aside>
       </div>
 
       {/* Featured article */}
-      {featured && (
-        <Link
-          to="/connaissances/$slug"
-          params={{ slug: featured.slug }}
-          className="mb-8 block"
-        >
-          <Card className="overflow-hidden border-primary/20 bg-gradient-to-br from-card to-accent/5 shadow-md shadow-primary/5 transition-colors hover:border-primary/30">
-            <CardHeader>
-              <Badge className="mb-3 w-fit">{featured.cluster}</Badge>
-              <CardTitle className="font-heading text-2xl font-semibold lg:text-3xl">
-                {featured.title}
-              </CardTitle>
-              <CardDescription className="mt-2 text-base">
-                {featured.excerpt}
-              </CardDescription>
-            </CardHeader>
-            <CardContent className="flex items-center gap-3 text-sm text-muted-foreground">
-              <Clock className="h-3.5 w-3.5" />
-              <span>{featured.readTime}</span>
-              <span className="ml-auto">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="gap-1 px-0 text-primary"
-                >
-                  {t("news.readMore")}
-                  <ArrowRight className="h-3.5 w-3.5" />
-                </Button>
-              </span>
-            </CardContent>
-          </Card>
-        </Link>
-      )}
+      {featured && (() => {
+        const fTheme = getClusterTheme(featured.cluster);
+        const FIcon = fTheme.icon;
+        return (
+          <Link
+            to="/connaissances/$slug"
+            params={{ slug: featured.slug }}
+            className="mb-8 block"
+          >
+            <Card className="relative overflow-hidden border-primary/20 shadow-md shadow-primary/5 transition-colors hover:border-primary/30">
+              <div
+                aria-hidden
+                className={cn(
+                  "pointer-events-none absolute inset-0 bg-gradient-to-br",
+                  fTheme.gradient,
+                )}
+              />
+              <div className="relative">
+                <CardHeader>
+                  <div className="flex items-start gap-4">
+                    <div
+                      className={cn(
+                        "flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl shadow-sm",
+                        fTheme.iconBg,
+                        fTheme.iconColor,
+                      )}
+                    >
+                      <FIcon className="h-6 w-6" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <Badge className="mb-3 w-fit">{featured.cluster}</Badge>
+                      <CardTitle className="font-heading text-2xl font-semibold lg:text-3xl">
+                        {featured.title}
+                      </CardTitle>
+                      <CardDescription className="mt-2 text-base">
+                        {featured.excerpt}
+                      </CardDescription>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="flex items-center gap-3 text-sm text-muted-foreground">
+                  <Clock className="h-3.5 w-3.5" />
+                  <span>{featured.readTime}</span>
+                  <span className="ml-auto">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="gap-1 px-0 text-primary"
+                    >
+                      {t("news.readMore")}
+                      <ArrowRight className="h-3.5 w-3.5" />
+                    </Button>
+                  </span>
+                </CardContent>
+              </div>
+            </Card>
+          </Link>
+        );
+      })()}
 
       {/* All other articles */}
       <div className="space-y-4">
-        {rest.map((article) => (
-          <Link
-            key={article.slug}
-            to="/connaissances/$slug"
-            params={{ slug: article.slug }}
-            className="block"
-          >
-            <Card className="transition-colors hover:border-primary/30 hover:shadow-sm">
-              <CardHeader>
-                <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
-                  <Badge variant="outline" className="text-xs">
-                    {article.cluster}
-                  </Badge>
-                  <span className="text-muted-foreground/40">·</span>
-                  <Clock className="h-3 w-3" />
-                  <span>{article.readTime}</span>
-                </div>
-                <CardTitle className="font-heading text-xl font-semibold leading-tight">
-                  {article.title}
-                </CardTitle>
-                <CardDescription className="mt-1 line-clamp-2">
-                  {article.excerpt}
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="pt-0">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="gap-1 px-0 text-primary"
-                >
-                  {t("news.readMore")}
-                  <ArrowRight className="h-3.5 w-3.5" />
-                </Button>
-              </CardContent>
-            </Card>
-          </Link>
-        ))}
+        {rest.map((article) => {
+          const aTheme = getClusterTheme(article.cluster);
+          const AIcon = aTheme.icon;
+          return (
+            <Link
+              key={article.slug}
+              to="/connaissances/$slug"
+              params={{ slug: article.slug }}
+              className="block"
+            >
+              <Card className="transition-colors hover:border-primary/30 hover:shadow-sm">
+                <CardHeader>
+                  <div className="flex items-start gap-3">
+                    <div
+                      className={cn(
+                        "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl",
+                        aTheme.iconBg,
+                        aTheme.iconColor,
+                      )}
+                    >
+                      <AIcon className="h-5 w-5" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground mb-1">
+                        <Badge variant="outline" className="text-xs">
+                          {article.cluster}
+                        </Badge>
+                        <span className="text-muted-foreground/40">·</span>
+                        <Clock className="h-3 w-3" />
+                        <span>{article.readTime}</span>
+                      </div>
+                      <CardTitle className="font-heading text-xl font-semibold leading-tight">
+                        {article.title}
+                      </CardTitle>
+                      <CardDescription className="mt-1 line-clamp-2">
+                        {article.excerpt}
+                      </CardDescription>
+                    </div>
+                  </div>
+                </CardHeader>
+                <CardContent className="pt-0">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="gap-1 px-0 text-primary"
+                  >
+                    {t("news.readMore")}
+                    <ArrowRight className="h-3.5 w-3.5" />
+                  </Button>
+                </CardContent>
+              </Card>
+            </Link>
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/web/src/routes/ressources/$slug.tsx
+++ b/apps/web/src/routes/ressources/$slug.tsx
@@ -8,9 +8,9 @@ import {
   Sparkles,
   MessageCircle,
   HandHeart,
+  ShieldCheck,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   articles,
@@ -21,6 +21,12 @@ import type { FeatureTarget } from "@/lib/resources-types";
 import { useSeoHead } from "@/hooks/use-seo-head";
 import { ShareDialog } from "@/components/shared/share-dialog";
 import { getIncomingShareId } from "@/lib/share";
+import {
+  ArticleHero,
+  WelcomeIntro,
+  getClusterTheme,
+} from "@/components/article/article-elements";
+import { cn } from "@/lib/utils";
 
 export const Route = createFileRoute("/ressources/$slug")({
   component: ArticlePage,
@@ -106,35 +112,38 @@ function ArticlePage() {
         </Link>
 
         {/* Header */}
-        <header className="mt-8">
-          <Badge variant="outline" className="mb-4 border-primary/20 bg-primary/5 text-primary">
-            {article.cluster}
-          </Badge>
-          <h1 className="font-heading text-3xl font-semibold leading-tight tracking-tight lg:text-4xl lg:leading-[1.15]">
-            {article.title}
-          </h1>
-          <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm text-muted-foreground">
-            <span className="inline-flex items-center gap-1.5">
-              <Clock className="h-3.5 w-3.5" />
-              {article.readTime} de lecture
-            </span>
-            <span aria-hidden="true">·</span>
-            <span className="text-xs">
-              Révisé le{" "}
-              {new Date(
-                article.lastReviewedAt ?? DEFAULT_LAST_REVIEWED
-              ).toLocaleDateString("fr-FR", {
-                day: "numeric",
-                month: "long",
-                year: "numeric",
-              })}{" "}
-              — {article.reviewer ?? DEFAULT_REVIEWER}
-            </span>
-          </div>
-        </header>
+        <div className="mt-8">
+          <ArticleHero
+            cluster={article.cluster}
+            title={article.title}
+            meta={
+              <>
+                <span className="inline-flex items-center gap-1.5">
+                  <Clock className="h-3.5 w-3.5" />
+                  {article.readTime} de lecture
+                </span>
+                <span aria-hidden="true">·</span>
+                <span className="inline-flex items-center gap-1.5 text-xs">
+                  <ShieldCheck className="h-3.5 w-3.5" />
+                  Révisé le{" "}
+                  {new Date(
+                    article.lastReviewedAt ?? DEFAULT_LAST_REVIEWED
+                  ).toLocaleDateString("fr-FR", {
+                    day: "numeric",
+                    month: "long",
+                    year: "numeric",
+                  })}{" "}
+                  — {article.reviewer ?? DEFAULT_REVIEWER}
+                </span>
+              </>
+            }
+          />
+        </div>
+
+        <WelcomeIntro audience={article.audience} />
 
         {/* Body */}
-        <div className="article-body mt-10">{article.content}</div>
+        <div className="article-body mt-6">{article.content}</div>
 
         {/* FAQ (if provided) */}
         {article.faq && article.faq.length > 0 && (
@@ -240,28 +249,43 @@ function ArticlePage() {
               À lire ensuite
             </h2>
             <div className="mt-6 grid gap-4 sm:grid-cols-2">
-              {related.map((r) => (
-                <Link
-                  key={r.slug}
-                  to="/ressources/$slug"
-                  params={{ slug: r.slug }}
-                  className="group"
-                >
-                  <Card className="h-full border-border/60 transition-all duration-300 hover:border-primary/20 hover:shadow-sm">
-                    <CardContent className="py-5">
-                      <p className="text-xs font-medium text-primary/80">
-                        {r.cluster}
-                      </p>
-                      <p className="mt-2 font-heading font-semibold leading-snug group-hover:text-primary">
-                        {r.title}
-                      </p>
-                      <p className="mt-2 text-sm leading-relaxed text-muted-foreground line-clamp-2">
-                        {r.excerpt}
-                      </p>
-                    </CardContent>
-                  </Card>
-                </Link>
-              ))}
+              {related.map((r) => {
+                const rTheme = getClusterTheme(r.cluster);
+                const RIcon = rTheme.icon;
+                return (
+                  <Link
+                    key={r.slug}
+                    to="/ressources/$slug"
+                    params={{ slug: r.slug }}
+                    className="group"
+                  >
+                    <Card className="h-full border-border/60 transition-all duration-300 hover:border-primary/20 hover:shadow-sm">
+                      <CardContent className="flex gap-3 py-5">
+                        <div
+                          className={cn(
+                            "flex h-9 w-9 shrink-0 items-center justify-center rounded-lg",
+                            rTheme.iconBg,
+                            rTheme.iconColor,
+                          )}
+                        >
+                          <RIcon className="h-4 w-4" />
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <p className="text-xs font-medium text-primary/80">
+                            {r.cluster}
+                          </p>
+                          <p className="mt-1 font-heading font-semibold leading-snug group-hover:text-primary">
+                            {r.title}
+                          </p>
+                          <p className="mt-1.5 text-sm leading-relaxed text-muted-foreground line-clamp-2">
+                            {r.excerpt}
+                          </p>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </Link>
+                );
+              })}
             </div>
           </section>
         )}


### PR DESCRIPTION
Rendre la base de connaissances plus accueillante et visuelle :

- Nouveau composant ArticleHero coloré, avec icône de cluster (cœur,
  cerveau, oreille, lit, boussole…) et dégradé pastel propre à chaque
  thème, en remplacement du simple badge texte.
- WelcomeIntro automatique sous chaque article : « Vous êtes au bon
  endroit, lisez à votre rythme ».
- KeyTakeaways (« Ce qu'il faut retenir ») injecté en tête de chaque
  article — un parent stressé peut saisir l'essentiel en 30 secondes.
- StatGrid : les statistiques clés (75 %, 70 %, 1 sur 2…) deviennent des
  cartes visuelles au lieu de listes à puces.
- Comparison côte-à-côte « Ce qui aide / Ce qui aggrave » pour les
  articles crise et figement.
- Encouragement chaleureux placé aux moments durs des articles.
- Cartes de la liste (index) et liens « À lire ensuite » désormais
  préfixés par l'icône colorée du cluster.