### PR TITLE
feat(report): server-side PDF extractor with medications and care pathway

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -20,6 +20,7 @@
     "better-auth": "^1.5.6",
     "drizzle-orm": "0.45.2",
     "hono": "^4.12.12",
+    "pdfkit": "^0.18.0",
     "stripe": "^20.4.1",
     "tsx": "^4.19.0",
     "web-push": "^3.6.7",
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.5.0",
+    "@types/pdfkit": "^0.17.6",
     "@types/web-push": "^3.6.4",
     "typescript": "^5.7.0",
     "vitest": "^4.1.0"

--- a/apps/api/src/routes/report.ts
+++ b/apps/api/src/routes/report.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { AppEnv } from "../types";
-import { eq, and, gte, lte, asc } from "drizzle-orm";
+import { eq, and, gte, lte, asc, inArray } from "drizzle-orm";
 import {
     db,
     children,
@@ -9,7 +9,11 @@ import {
     barkleySteps,
     crisisItems,
     subscription,
+    medications,
+    medicationLogs,
+    carePathwayProgress,
 } from "@focusflow/db";
+import PDFDocument from "pdfkit";
 import { authMiddleware } from "../middleware/auth";
 import { rateLimiter } from "../middleware/rate-limiter";
 import { AppError } from "../middleware/error-handler";
@@ -39,14 +43,20 @@ const PERIOD_DAYS: Record<string, number> = {
     quarter: 90,
 };
 
-const sendEmailSchema = z.object({
+const rangeShape = {
     childId: z.string().uuid(),
-    recipientEmail: z.string().email(),
     period: z.enum(["week", "month", "quarter"]).optional(),
     from: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
     to: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
     questions: z.string().max(5000).optional(),
+} as const;
+
+const sendEmailSchema = z.object({
+    ...rangeShape,
+    recipientEmail: z.string().email(),
 });
+
+const pdfSchema = z.object(rangeShape);
 
 reportRoutes.post("/send-email", async (c) => {
     const user = c.get("user");
@@ -63,10 +73,110 @@ reportRoutes.post("/send-email", async (c) => {
     const { childId, recipientEmail, period, from, to, questions } = parsed.data;
 
     await assertChildAccess(user.id, childId);
+    await assertOwnerHasFamillePlan(childId);
 
-    // Child-context plan check: the report is gated on the *owner's*
-    // subscription, so a co-parent can send a report for an owner who has
-    // a Famille plan without needing their own.
+    const range = resolveDateRange({ period, from, to });
+    if ("error" in range) {
+        return c.json({ error: range.error }, 422);
+    }
+
+    const data = await loadReportData({
+        childId,
+        sinceDate: range.sinceDate,
+        untilDate: range.untilDate,
+        questions,
+        parentName: user.name ?? "Parent",
+    });
+
+    const html = buildReportHtml(data);
+
+    const formatDate = (d: string) =>
+        new Date(d).toLocaleDateString("fr-FR", {
+            day: "numeric",
+            month: "long",
+            year: "numeric",
+        });
+
+    const result = await sendEmail({
+        to: recipientEmail,
+        subject: `Rapport TDAH — ${data.child.name} (${formatDate(range.sinceDate)} → ${formatDate(range.untilDate)})`,
+        html,
+    });
+
+    if (!result.sent) {
+        throw new AppError(
+            "INTERNAL",
+            result.reason === "no-api-key"
+                ? "Service email non configuré"
+                : `Erreur d'envoi: ${result.detail ?? "inconnue"}`,
+            500
+        );
+    }
+
+    return c.json({ sent: true, id: result.id });
+});
+
+// PDF download — same auth and plan gate as /send-email but no email
+// dispatch. Returns application/pdf with a filename derived from the child
+// name and period. Costs little (pdfkit is pure JS); the global IP rate
+// limiter on /api/* is enough — no separate per-user quota.
+reportRoutes.post("/pdf", async (c) => {
+    const user = c.get("user");
+    const body = await c.req.json();
+    const parsed = pdfSchema.safeParse(body);
+
+    if (!parsed.success) {
+        return c.json(
+            { error: "Données invalides", details: parsed.error.flatten() },
+            422
+        );
+    }
+
+    const { childId, period, from, to, questions } = parsed.data;
+
+    await assertChildAccess(user.id, childId);
+    await assertOwnerHasFamillePlan(childId);
+
+    const range = resolveDateRange({ period, from, to });
+    if ("error" in range) {
+        return c.json({ error: range.error }, 422);
+    }
+
+    const data = await loadReportData({
+        childId,
+        sinceDate: range.sinceDate,
+        untilDate: range.untilDate,
+        questions,
+        parentName: user.name ?? "Parent",
+    });
+
+    const pdf = await buildReportPdf(data);
+
+    const safeName = data.child.name.replace(/[^a-zA-Z0-9-_]/g, "_");
+    const filename = `toko-rapport-${safeName}-${range.sinceDate}_${range.untilDate}.pdf`;
+
+    // Copy into a fresh Uint8Array so the response body has a
+    // typed-array-on-ArrayBuffer shape (BodyInit) instead of
+    // Buffer<ArrayBufferLike>, which TS won't accept.
+    const pdfBytes = new Uint8Array(pdf.byteLength);
+    pdfBytes.set(pdf);
+
+    return new Response(pdfBytes, {
+        status: 200,
+        headers: {
+            "Content-Type": "application/pdf",
+            "Content-Disposition": `attachment; filename="${filename}"`,
+            "Content-Length": String(pdfBytes.byteLength),
+            "Cache-Control": "private, no-store",
+        },
+    });
+});
+
+// ─── Shared helpers ───────────────────────────────────────
+
+async function assertOwnerHasFamillePlan(childId: string): Promise<void> {
+    // Child-context plan check: paid features are gated on the *owner's*
+    // subscription, so a co-parent can use them when the owner has Famille.
     const ownerId = await getChildOwnerId(childId);
     if (!ownerId) {
         throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
@@ -76,14 +186,53 @@ reportRoutes.post("/send-email", async (c) => {
         .from(subscription)
         .where(eq(subscription.userId, ownerId))
         .limit(1);
-    const ownerPlanActive =
+    const active =
         ownerSub?.status === "active" || ownerSub?.status === "trialing";
-    if (!ownerPlanActive) {
-        return c.json(
-            { error: "Fonctionnalité réservée au plan Famille", code: "PLAN_REQUIRED", upgrade: true },
+    if (!active) {
+        throw new AppError(
+            "PLAN_REQUIRED",
+            "Fonctionnalité réservée au plan Famille",
             403
         );
     }
+}
+
+type ResolvedRange =
+    | { sinceDate: string; untilDate: string }
+    | { error: string };
+
+function resolveDateRange(input: {
+    period?: "week" | "month" | "quarter";
+    from?: string;
+    to?: string;
+}): ResolvedRange {
+    if (input.from) {
+        const sinceDate = input.from;
+        const untilDate = input.to ?? new Date().toISOString().split("T")[0]!;
+        if (sinceDate > untilDate) {
+            return { error: "La date de début doit précéder la date de fin." };
+        }
+        return { sinceDate, untilDate };
+    }
+    const days = PERIOD_DAYS[input.period ?? "quarter"] ?? 90;
+    return {
+        sinceDate: new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+            .toISOString()
+            .split("T")[0]!,
+        untilDate: new Date().toISOString().split("T")[0]!,
+    };
+}
+
+interface LoadReportDataInput {
+    childId: string;
+    sinceDate: string;
+    untilDate: string;
+    questions?: string;
+    parentName: string;
+}
+
+async function loadReportData(input: LoadReportDataInput): Promise<ReportData> {
+    const { childId, sinceDate, untilDate, questions, parentName } = input;
 
     const [child] = await db
         .select()
@@ -94,28 +243,14 @@ reportRoutes.post("/send-email", async (c) => {
         throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
     }
 
-    // Compute date range
-    let sinceDate: string;
-    let untilDate: string;
-    if (from) {
-        sinceDate = from;
-        untilDate = to ?? new Date().toISOString().split("T")[0]!;
-        if (sinceDate > untilDate) {
-            return c.json(
-                { error: "La date de début doit précéder la date de fin." },
-                422
-            );
-        }
-    } else {
-        const days = PERIOD_DAYS[period ?? "quarter"] ?? 90;
-        sinceDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-            .toISOString()
-            .split("T")[0]!;
-        untilDate = new Date().toISOString().split("T")[0]!;
-    }
-
-    // Fetch data
-    const [periodSymptoms, periodJournal, steps, crisis] = await Promise.all([
+    const [
+        periodSymptoms,
+        periodJournal,
+        steps,
+        crisis,
+        meds,
+        pathway,
+    ] = await Promise.all([
         db
             .select()
             .from(symptoms)
@@ -147,10 +282,41 @@ reportRoutes.post("/send-email", async (c) => {
             .from(crisisItems)
             .where(eq(crisisItems.childId, childId))
             .orderBy(asc(crisisItems.position)),
+        db
+            .select()
+            .from(medications)
+            .where(eq(medications.childId, childId))
+            .orderBy(asc(medications.startDate)),
+        db
+            .select()
+            .from(carePathwayProgress)
+            .where(eq(carePathwayProgress.childId, childId)),
     ]);
 
-    // Build HTML report
-    const html = buildReportHtml({
+    // Adherence per medication on the period (taken vs scheduled days), so
+    // the doctor sees observance at a glance without sifting through logs.
+    const medIds = meds.map((m) => m.id);
+    const logsByMed = new Map<string, { taken: number; total: number }>();
+    if (medIds.length > 0) {
+        const logs = await db
+            .select()
+            .from(medicationLogs)
+            .where(
+                and(
+                    inArray(medicationLogs.medicationId, medIds),
+                    gte(medicationLogs.date, sinceDate),
+                    lte(medicationLogs.date, untilDate)
+                )
+            );
+        for (const log of logs) {
+            const cur = logsByMed.get(log.medicationId) ?? { taken: 0, total: 0 };
+            cur.total += 1;
+            if (log.taken) cur.taken += 1;
+            logsByMed.set(log.medicationId, cur);
+        }
+    }
+
+    return {
         child,
         sinceDate,
         untilDate,
@@ -158,37 +324,28 @@ reportRoutes.post("/send-email", async (c) => {
         journal: periodJournal,
         barkleySteps: steps,
         crisisItems: crisis,
+        medications: meds.map((m) => ({
+            name: m.name,
+            dose: m.dose,
+            schedule: m.schedule,
+            startDate: m.startDate,
+            endDate: m.endDate,
+            notes: m.notes,
+            active: m.active,
+            adherence: logsByMed.get(m.id) ?? null,
+        })),
+        carePathway: pathway.map((p) => ({
+            stepId: p.stepId,
+            status: p.status,
+            notes: p.notes,
+            completedAt: p.completedAt,
+        })),
         questions,
-        parentName: user.name ?? "Parent",
-    });
+        parentName,
+    };
+}
 
-    const formatDate = (d: string) =>
-        new Date(d).toLocaleDateString("fr-FR", {
-            day: "numeric",
-            month: "long",
-            year: "numeric",
-        });
-
-    const result = await sendEmail({
-        to: recipientEmail,
-        subject: `Rapport TDAH — ${child.name} (${formatDate(sinceDate)} → ${formatDate(untilDate)})`,
-        html,
-    });
-
-    if (!result.sent) {
-        throw new AppError(
-            "INTERNAL",
-            result.reason === "no-api-key"
-                ? "Service email non configuré"
-                : `Erreur d'envoi: ${result.detail ?? "inconnue"}`,
-            500
-        );
-    }
-
-    return c.json({ sent: true, id: result.id });
-});
-
-// ─── HTML builder ─────────────────────────────────────────
+// ─── Report data shape ────────────────────────────────────
 
 interface ReportData {
     child: { name: string; gender: string | null; ageRange: string | null };
@@ -205,6 +362,22 @@ interface ReportData {
     journal: Array<{ date: string; text: string | null; tags: unknown }>;
     barkleySteps: Array<{ stepNumber: number; completedAt: Date | null }>;
     crisisItems: Array<{ label: string; emoji: string | null; position: number }>;
+    medications: Array<{
+        name: string;
+        dose: string | null;
+        schedule: "morning" | "noon" | "evening" | "bedtime" | "custom";
+        startDate: string;
+        endDate: string | null;
+        notes: string | null;
+        active: boolean;
+        adherence: { taken: number; total: number } | null;
+    }>;
+    carePathway: Array<{
+        stepId: string;
+        status: "todo" | "doing" | "done";
+        notes: string | null;
+        completedAt: Date | null;
+    }>;
     questions?: string;
     parentName: string;
 }
@@ -217,19 +390,58 @@ const SYMPTOM_LABELS: Record<string, string> = {
     sleep: "Sommeil",
 };
 
+const SCHEDULE_LABELS: Record<string, string> = {
+    morning: "Matin",
+    noon: "Midi",
+    evening: "Soir",
+    bedtime: "Coucher",
+    custom: "Personnalisé",
+};
+
+// Mirrors the FR i18n bundle (apps/web/.../locales/fr.json :: carePathway.steps).
+// Kept in sync manually — step ids are stable per care-pathway-data.ts.
+const CARE_PATHWAY_LABELS: Record<string, string> = {
+    school_signal: "Repérage par l'école",
+    gp_consultation: "Consultation chez le médecin traitant ou pédiatre",
+    ent_audition: "Bilan ORL & test auditif",
+    ophtalmo_vision: "Bilan ophtalmologique",
+    sleep_study: "Étude du sommeil (si suspicion)",
+    speech_therapy_assessment: "Bilan orthophonique",
+    psychomotor_assessment: "Bilan psychomoteur",
+    neuropsy_assessment: "Bilan neuropsychologique",
+    specialist_consultation: "Consultation neuropédiatre ou pédopsychiatre",
+    diagnosis_announcement: "Annonce du diagnostic",
+    second_opinion: "Second avis (si besoin)",
+    mdph_application: "Dépôt du dossier MDPH",
+    aeeh_request: "Demande AEEH",
+    pch_request: "PCH (si éligible)",
+    school_pap_pps: "PAP ou PPS à l'école",
+    occupational_therapy: "Suivi pluridisciplinaire",
+    ongoing_followup: "Suivi médical régulier",
+};
+
+const STATUS_LABELS: Record<string, string> = {
+    todo: "À faire",
+    doing: "En cours",
+    done: "Terminé",
+};
+
 function avg(values: number[]): string {
     if (values.length === 0) return "—";
     return (values.reduce((a, b) => a + b, 0) / values.length).toFixed(1);
 }
 
-function buildReportHtml(data: ReportData): string {
-    const formatDate = (d: string | Date) =>
-        new Date(d).toLocaleDateString("fr-FR", {
-            day: "numeric",
-            month: "long",
-            year: "numeric",
-        });
+function formatDateFr(d: string | Date): string {
+    return new Date(d).toLocaleDateString("fr-FR", {
+        day: "numeric",
+        month: "long",
+        year: "numeric",
+    });
+}
 
+// ─── HTML builder ─────────────────────────────────────────
+
+function buildReportHtml(data: ReportData): string {
     const dims = ["mood", "focus", "agitation", "impulse", "sleep"] as const;
 
     // Symptom averages
@@ -252,7 +464,7 @@ function buildReportHtml(data: ReportData): string {
         .map(
             (e) =>
                 `<div style="padding:8px 12px;border-left:3px solid #e5e7eb;margin-bottom:8px">
-          <div style="font-size:12px;color:#6b7280">${formatDate(e.date)}</div>
+          <div style="font-size:12px;color:#6b7280">${formatDateFr(e.date)}</div>
           ${e.text ? `<div style="margin-top:4px;font-size:14px">${escapeHtml(e.text)}</div>` : ""}
         </div>`
         )
@@ -271,7 +483,7 @@ function buildReportHtml(data: ReportData): string {
            <div style="height:100%;width:${(completedSteps.length / 10) * 100}%;background:#6366f1;border-radius:4px"></div>
          </div>
          <ul style="margin-top:8px;padding-left:0;list-style:none">
-           ${completedSteps.map((s) => `<li style="padding:2px 0;font-size:13px">✓ Étape ${s.stepNumber}${s.completedAt ? ` — ${formatDate(s.completedAt)}` : ""}</li>`).join("")}
+           ${completedSteps.map((s) => `<li style="padding:2px 0;font-size:13px">✓ Étape ${s.stepNumber}${s.completedAt ? ` — ${formatDateFr(s.completedAt)}` : ""}</li>`).join("")}
          </ul>`
             : "";
 
@@ -285,6 +497,51 @@ function buildReportHtml(data: ReportData): string {
          </ol>`
             : "";
 
+    // Medications — split active from inactive so the doctor sees the
+    // current treatment first and the history second.
+    const activeMeds = data.medications.filter((m) => m.active);
+    const inactiveMeds = data.medications.filter((m) => !m.active);
+
+    const renderMed = (m: ReportData["medications"][number]) => {
+        const period = m.endDate
+            ? `${formatDateFr(m.startDate)} → ${formatDateFr(m.endDate)}`
+            : `Depuis le ${formatDateFr(m.startDate)}`;
+        const adherence = m.adherence && m.adherence.total > 0
+            ? `<span style="margin-left:8px;font-size:12px;color:#059669">Observance ${Math.round((m.adherence.taken / m.adherence.total) * 100)}% (${m.adherence.taken}/${m.adherence.total})</span>`
+            : "";
+        return `<li style="padding:6px 0;border-bottom:1px solid #f3f4f6">
+          <div style="font-size:14px;font-weight:500">${escapeHtml(m.name)}${m.dose ? ` <span style="color:#6b7280;font-weight:400">— ${escapeHtml(m.dose)}</span>` : ""}</div>
+          <div style="font-size:12px;color:#6b7280;margin-top:2px">${SCHEDULE_LABELS[m.schedule] ?? m.schedule} · ${period}${adherence}</div>
+          ${m.notes ? `<div style="font-size:12px;color:#4b5563;margin-top:4px;font-style:italic">${escapeHtml(m.notes)}</div>` : ""}
+        </li>`;
+    };
+
+    const medicationsSection = data.medications.length > 0
+        ? `<h3 style="margin-top:24px;font-size:14px;text-transform:uppercase;letter-spacing:0.05em;color:#6b7280">Traitements médicamenteux</h3>
+         ${activeMeds.length > 0 ? `<p style="font-size:12px;color:#059669;margin:4px 0 8px">En cours · ${activeMeds.length}</p><ul style="margin:0;padding-left:0;list-style:none">${activeMeds.map(renderMed).join("")}</ul>` : ""}
+         ${inactiveMeds.length > 0 ? `<p style="font-size:12px;color:#6b7280;margin:12px 0 8px">Historique · ${inactiveMeds.length}</p><ul style="margin:0;padding-left:0;list-style:none;opacity:0.75">${inactiveMeds.map(renderMed).join("")}</ul>` : ""}`
+        : "";
+
+    // Care pathway — only show steps the parent has touched (status != todo
+    // by virtue of having a row).
+    const pathwayDone = data.carePathway.filter((p) => p.status === "done");
+    const pathwayDoing = data.carePathway.filter((p) => p.status === "doing");
+    const renderPathway = (p: ReportData["carePathway"][number]) => {
+        const label = CARE_PATHWAY_LABELS[p.stepId] ?? p.stepId;
+        const date = p.completedAt ? ` — ${formatDateFr(p.completedAt)}` : "";
+        return `<li style="padding:4px 0;font-size:13px">
+          <span style="font-weight:500">${escapeHtml(label)}</span>
+          <span style="color:#6b7280">${date}</span>
+          ${p.notes ? `<div style="font-size:12px;color:#4b5563;margin-top:2px;font-style:italic">${escapeHtml(p.notes)}</div>` : ""}
+        </li>`;
+    };
+
+    const carePathwaySection = (pathwayDone.length > 0 || pathwayDoing.length > 0)
+        ? `<h3 style="margin-top:24px;font-size:14px;text-transform:uppercase;letter-spacing:0.05em;color:#6b7280">Parcours de soins</h3>
+         ${pathwayDone.length > 0 ? `<p style="font-size:12px;color:#059669;margin:4px 0 4px">Étapes franchies · ${pathwayDone.length}</p><ul style="margin:0 0 8px;padding-left:20px">${pathwayDone.map(renderPathway).join("")}</ul>` : ""}
+         ${pathwayDoing.length > 0 ? `<p style="font-size:12px;color:#2563eb;margin:8px 0 4px">En cours · ${pathwayDoing.length}</p><ul style="margin:0;padding-left:20px">${pathwayDoing.map(renderPathway).join("")}</ul>` : ""}`
+        : "";
+
     const crisisCount = data.journal.filter(
         (e) => Array.isArray(e.tags) && e.tags.includes("crisis")
     ).length;
@@ -296,7 +553,7 @@ function buildReportHtml(data: ReportData): string {
   <div style="border-bottom:2px solid #6366f1;padding-bottom:16px;margin-bottom:24px">
     <p style="font-size:12px;text-transform:uppercase;letter-spacing:0.1em;color:#6366f1;margin:0">Rapport TDAH · Tokō</p>
     <h1 style="font-size:24px;margin:8px 0 4px">${escapeHtml(data.child.name)}</h1>
-    <p style="font-size:13px;color:#6b7280;margin:0">Période : ${formatDate(data.sinceDate)} → ${formatDate(data.untilDate)} · Généré le ${formatDate(new Date().toISOString())}</p>
+    <p style="font-size:13px;color:#6b7280;margin:0">Période : ${formatDateFr(data.sinceDate)} → ${formatDateFr(data.untilDate)} · Généré le ${formatDateFr(new Date().toISOString())}</p>
   </div>
 
   ${data.questions ? `<div style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:8px;padding:12px 16px;margin-bottom:24px">
@@ -332,6 +589,9 @@ function buildReportHtml(data: ReportData): string {
     <tbody>${symptomRows}</tbody>
   </table>
 
+  ${medicationsSection}
+  ${carePathwaySection}
+
   ${journalEntries ? `<h3 style="font-size:14px;text-transform:uppercase;letter-spacing:0.05em;color:#6b7280">Moments marquants du journal</h3>${journalEntries}` : ""}
 
   ${barkleySection}
@@ -343,6 +603,526 @@ function buildReportHtml(data: ReportData): string {
   </div>
 </body>
 </html>`;
+}
+
+// ─── PDF builder ──────────────────────────────────────────
+
+// Layout constants — shared so sections stay aligned without re-reading the
+// PDFKit cursor on every block.
+const PDF_PAGE_MARGIN = 50;
+const PDF_BRAND = "#6366f1";
+const PDF_TEXT = "#1f2937";
+const PDF_MUTED = "#6b7280";
+const PDF_BORDER = "#e5e7eb";
+
+function buildReportPdf(data: ReportData): Promise<Buffer> {
+    return new Promise((resolve, reject) => {
+        const doc = new PDFDocument({
+            size: "A4",
+            margin: PDF_PAGE_MARGIN,
+            info: {
+                Title: `Rapport TDAH — ${data.child.name}`,
+                Author: data.parentName,
+                Creator: "Tokō",
+                Producer: "Tokō",
+                Subject: `Période ${data.sinceDate} → ${data.untilDate}`,
+            },
+        });
+        const chunks: Buffer[] = [];
+        doc.on("data", (chunk: Buffer) => chunks.push(chunk));
+        doc.on("end", () => resolve(Buffer.concat(chunks)));
+        doc.on("error", reject);
+
+        renderHeader(doc, data);
+        if (data.questions && data.questions.trim()) {
+            renderQuestionsBox(doc, data.questions.trim());
+        }
+        renderSynthesis(doc, data);
+        renderSymptomTable(doc, data);
+        renderMedications(doc, data);
+        renderCarePathway(doc, data);
+        renderJournalHighlights(doc, data);
+        renderBarkley(doc, data);
+        renderCrisisList(doc, data);
+        renderFooterOnEachPage(doc, data);
+
+        doc.end();
+    });
+}
+
+type PDFDoc = InstanceType<typeof PDFDocument>;
+
+function pageWidth(doc: PDFDoc): number {
+    return doc.page.width - PDF_PAGE_MARGIN * 2;
+}
+
+function sectionTitle(doc: PDFDoc, title: string): void {
+    doc.moveDown(0.6);
+    doc
+        .font("Helvetica-Bold")
+        .fontSize(10)
+        .fillColor(PDF_MUTED)
+        .text(title.toUpperCase(), { characterSpacing: 0.5 });
+    doc.moveDown(0.3);
+}
+
+function renderHeader(doc: PDFDoc, data: ReportData): void {
+    doc
+        .font("Helvetica-Bold")
+        .fontSize(9)
+        .fillColor(PDF_BRAND)
+        .text("RAPPORT TDAH · TOKO", { characterSpacing: 1 });
+
+    doc.moveDown(0.3);
+    doc
+        .font("Helvetica-Bold")
+        .fontSize(22)
+        .fillColor(PDF_TEXT)
+        .text(data.child.name);
+
+    const meta: string[] = [];
+    if (data.child.gender) {
+        meta.push(
+            data.child.gender === "male"
+                ? "Garçon"
+                : data.child.gender === "female"
+                    ? "Fille"
+                    : data.child.gender,
+        );
+    }
+    if (data.child.ageRange) meta.push(data.child.ageRange);
+
+    doc.moveDown(0.2);
+    doc
+        .font("Helvetica")
+        .fontSize(10)
+        .fillColor(PDF_MUTED)
+        .text(
+            `Période : ${formatDateFr(data.sinceDate)} → ${formatDateFr(data.untilDate)} · Généré le ${formatDateFr(new Date().toISOString())}`,
+        );
+    if (meta.length > 0) {
+        doc.text(meta.join(" · "));
+    }
+
+    doc.moveDown(0.4);
+    const y = doc.y;
+    doc
+        .strokeColor(PDF_BRAND)
+        .lineWidth(1.5)
+        .moveTo(PDF_PAGE_MARGIN, y)
+        .lineTo(PDF_PAGE_MARGIN + pageWidth(doc), y)
+        .stroke();
+    doc.moveDown(0.5);
+}
+
+function renderQuestionsBox(doc: PDFDoc, questions: string): void {
+    const x = PDF_PAGE_MARGIN;
+    const w = pageWidth(doc);
+    const padding = 10;
+
+    // Pre-measure height so we can draw a background that fits the text.
+    doc.font("Helvetica").fontSize(10).fillColor(PDF_TEXT);
+    const textHeight = doc.heightOfString(questions, { width: w - padding * 2 });
+    const titleHeight = 14;
+    const totalHeight = textHeight + titleHeight + padding * 2;
+
+    const y = doc.y;
+    doc
+        .save()
+        .roundedRect(x, y, w, totalHeight, 6)
+        .fillColor("#eff6ff")
+        .fill()
+        .restore();
+    doc
+        .save()
+        .roundedRect(x, y, w, totalHeight, 6)
+        .strokeColor("#bfdbfe")
+        .lineWidth(1)
+        .stroke()
+        .restore();
+
+    doc
+        .font("Helvetica-Bold")
+        .fontSize(9)
+        .fillColor("#2563eb")
+        .text("QUESTIONS DU PARENT", x + padding, y + padding, {
+            characterSpacing: 0.5,
+        });
+    doc
+        .font("Helvetica")
+        .fontSize(10)
+        .fillColor(PDF_TEXT)
+        .text(questions, x + padding, y + padding + titleHeight, {
+            width: w - padding * 2,
+        });
+
+    doc.y = y + totalHeight;
+    doc.x = x;
+    doc.moveDown(0.5);
+}
+
+function renderSynthesis(doc: PDFDoc, data: ReportData): void {
+    sectionTitle(doc, "Synthèse de la période");
+
+    const crisisCount = data.journal.filter(
+        (e) => Array.isArray(e.tags) && (e.tags as string[]).includes("crisis"),
+    ).length;
+    const activeMedsCount = data.medications.filter((m) => m.active).length;
+
+    const cards = [
+        { value: String(data.journal.length), label: "Entrées journal" },
+        { value: String(data.symptoms.length), label: "Jours suivis" },
+        { value: String(crisisCount), label: "Crises notées" },
+        { value: String(activeMedsCount), label: "Traitements actifs" },
+    ];
+
+    const x = PDF_PAGE_MARGIN;
+    const w = pageWidth(doc);
+    const gap = 8;
+    const cardW = (w - gap * (cards.length - 1)) / cards.length;
+    const cardH = 50;
+    const y = doc.y;
+
+    cards.forEach((card, i) => {
+        const cx = x + i * (cardW + gap);
+        doc
+            .save()
+            .roundedRect(cx, y, cardW, cardH, 6)
+            .strokeColor(PDF_BORDER)
+            .lineWidth(1)
+            .stroke()
+            .restore();
+        doc
+            .font("Helvetica-Bold")
+            .fontSize(18)
+            .fillColor(PDF_TEXT)
+            .text(card.value, cx, y + 8, { width: cardW, align: "center" });
+        doc
+            .font("Helvetica")
+            .fontSize(9)
+            .fillColor(PDF_MUTED)
+            .text(card.label, cx, y + 30, { width: cardW, align: "center" });
+    });
+
+    doc.y = y + cardH;
+    doc.x = x;
+    doc.moveDown(0.5);
+}
+
+function renderSymptomTable(doc: PDFDoc, data: ReportData): void {
+    sectionTitle(doc, "Moyennes par dimension (échelle 1-5)");
+
+    const dims = ["mood", "focus", "agitation", "impulse", "sleep"] as const;
+    const x = PDF_PAGE_MARGIN;
+    const w = pageWidth(doc);
+    const colDimW = w * 0.55;
+    const colAvgW = w * 0.225;
+    const colCountW = w * 0.225;
+    const rowH = 22;
+
+    let y = doc.y;
+    doc
+        .save()
+        .rect(x, y, w, rowH)
+        .fillColor("#f9fafb")
+        .fill()
+        .restore();
+    doc
+        .font("Helvetica-Bold")
+        .fontSize(9)
+        .fillColor(PDF_MUTED)
+        .text("Dimension", x + 10, y + 7, { width: colDimW - 10 });
+    doc.text("Moyenne", x + colDimW, y + 7, {
+        width: colAvgW,
+        align: "center",
+    });
+    doc.text("Relevés", x + colDimW + colAvgW, y + 7, {
+        width: colCountW,
+        align: "center",
+    });
+    y += rowH;
+
+    dims.forEach((key) => {
+        const values = data.symptoms
+            .map((s) => s[key])
+            .filter((v) => typeof v === "number" && v > 0);
+        doc
+            .strokeColor(PDF_BORDER)
+            .lineWidth(0.5)
+            .moveTo(x, y)
+            .lineTo(x + w, y)
+            .stroke();
+
+        doc
+            .font("Helvetica")
+            .fontSize(10)
+            .fillColor(PDF_TEXT)
+            .text(SYMPTOM_LABELS[key] ?? key, x + 10, y + 7, {
+                width: colDimW - 10,
+            });
+        doc.text(avg(values), x + colDimW, y + 7, {
+            width: colAvgW,
+            align: "center",
+        });
+        doc.text(String(values.length), x + colDimW + colAvgW, y + 7, {
+            width: colCountW,
+            align: "center",
+        });
+        y += rowH;
+    });
+
+    doc
+        .strokeColor(PDF_BORDER)
+        .lineWidth(0.5)
+        .moveTo(x, y)
+        .lineTo(x + w, y)
+        .stroke();
+
+    doc.y = y;
+    doc.x = x;
+    doc.moveDown(0.5);
+}
+
+function renderMedications(doc: PDFDoc, data: ReportData): void {
+    if (data.medications.length === 0) return;
+    sectionTitle(doc, "Traitements médicamenteux");
+
+    const active = data.medications.filter((m) => m.active);
+    const inactive = data.medications.filter((m) => !m.active);
+
+    const renderGroup = (
+        label: string,
+        meds: ReportData["medications"],
+        labelColor: string,
+    ) => {
+        doc
+            .font("Helvetica-Bold")
+            .fontSize(9)
+            .fillColor(labelColor)
+            .text(`${label} · ${meds.length}`);
+        doc.moveDown(0.2);
+
+        meds.forEach((m) => {
+            const period = m.endDate
+                ? `${formatDateFr(m.startDate)} → ${formatDateFr(m.endDate)}`
+                : `Depuis le ${formatDateFr(m.startDate)}`;
+            const adherence =
+                m.adherence && m.adherence.total > 0
+                    ? `  ·  Observance ${Math.round(
+                          (m.adherence.taken / m.adherence.total) * 100,
+                      )}% (${m.adherence.taken}/${m.adherence.total})`
+                    : "";
+
+            doc
+                .font("Helvetica-Bold")
+                .fontSize(11)
+                .fillColor(PDF_TEXT)
+                .text(m.dose ? `${m.name} — ${m.dose}` : m.name, {
+                    continued: false,
+                });
+            doc
+                .font("Helvetica")
+                .fontSize(9)
+                .fillColor(PDF_MUTED)
+                .text(
+                    `${SCHEDULE_LABELS[m.schedule] ?? m.schedule} · ${period}${adherence}`,
+                );
+            if (m.notes) {
+                doc
+                    .font("Helvetica-Oblique")
+                    .fontSize(9)
+                    .fillColor("#4b5563")
+                    .text(m.notes);
+            }
+            doc.moveDown(0.3);
+        });
+    };
+
+    if (active.length > 0) renderGroup("EN COURS", active, "#059669");
+    if (inactive.length > 0) {
+        if (active.length > 0) doc.moveDown(0.2);
+        renderGroup("HISTORIQUE", inactive, PDF_MUTED);
+    }
+    doc.moveDown(0.3);
+}
+
+function renderCarePathway(doc: PDFDoc, data: ReportData): void {
+    const done = data.carePathway.filter((p) => p.status === "done");
+    const doing = data.carePathway.filter((p) => p.status === "doing");
+    if (done.length === 0 && doing.length === 0) return;
+
+    sectionTitle(doc, "Parcours de soins");
+
+    const renderStep = (p: ReportData["carePathway"][number]) => {
+        const label = CARE_PATHWAY_LABELS[p.stepId] ?? p.stepId;
+        const date = p.completedAt ? `  ·  ${formatDateFr(p.completedAt)}` : "";
+        doc
+            .font("Helvetica")
+            .fontSize(10)
+            .fillColor(PDF_TEXT)
+            .text(`• ${label}${date}`, {
+                indent: 0,
+            });
+        if (p.notes) {
+            doc
+                .font("Helvetica-Oblique")
+                .fontSize(9)
+                .fillColor("#4b5563")
+                .text(p.notes, { indent: 12 });
+        }
+    };
+
+    if (done.length > 0) {
+        doc
+            .font("Helvetica-Bold")
+            .fontSize(9)
+            .fillColor("#059669")
+            .text(`ÉTAPES FRANCHIES · ${done.length}`);
+        doc.moveDown(0.2);
+        done.forEach(renderStep);
+    }
+    if (doing.length > 0) {
+        doc.moveDown(0.3);
+        doc
+            .font("Helvetica-Bold")
+            .fontSize(9)
+            .fillColor("#2563eb")
+            .text(`EN COURS · ${doing.length}`);
+        doc.moveDown(0.2);
+        doing.forEach(renderStep);
+    }
+    doc.moveDown(0.3);
+}
+
+function renderJournalHighlights(doc: PDFDoc, data: ReportData): void {
+    if (data.journal.length === 0) return;
+    sectionTitle(doc, "Moments marquants du journal");
+
+    const recent = [...data.journal]
+        .sort(
+            (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime(),
+        )
+        .slice(0, 10);
+
+    recent.forEach((entry) => {
+        doc
+            .font("Helvetica-Bold")
+            .fontSize(9)
+            .fillColor(PDF_MUTED)
+            .text(formatDateFr(entry.date));
+        if (entry.text) {
+            doc
+                .font("Helvetica")
+                .fontSize(10)
+                .fillColor(PDF_TEXT)
+                .text(entry.text);
+        }
+        doc.moveDown(0.3);
+    });
+}
+
+function renderBarkley(doc: PDFDoc, data: ReportData): void {
+    const completed = data.barkleySteps
+        .filter((s) => s.completedAt)
+        .sort((a, b) => a.stepNumber - b.stepNumber);
+    if (completed.length === 0) return;
+
+    sectionTitle(doc, "Programme Barkley");
+
+    doc
+        .font("Helvetica-Bold")
+        .fontSize(11)
+        .fillColor(PDF_TEXT)
+        .text(`${completed.length} / 10 étapes complétées`);
+    doc.moveDown(0.3);
+
+    // Progress bar
+    const x = PDF_PAGE_MARGIN;
+    const w = pageWidth(doc);
+    const barH = 6;
+    const y = doc.y;
+    doc
+        .save()
+        .roundedRect(x, y, w, barH, 3)
+        .fillColor("#f3f4f6")
+        .fill()
+        .restore();
+    doc
+        .save()
+        .roundedRect(x, y, (w * completed.length) / 10, barH, 3)
+        .fillColor(PDF_BRAND)
+        .fill()
+        .restore();
+    doc.y = y + barH + 6;
+    doc.x = x;
+
+    completed.forEach((s) => {
+        doc
+            .font("Helvetica")
+            .fontSize(10)
+            .fillColor(PDF_TEXT)
+            .text(
+                `✓ Étape ${s.stepNumber}${s.completedAt ? ` — ${formatDateFr(s.completedAt)}` : ""}`,
+            );
+    });
+    doc.moveDown(0.3);
+}
+
+function renderCrisisList(doc: PDFDoc, data: ReportData): void {
+    if (data.crisisItems.length === 0) return;
+    sectionTitle(doc, "Liste de crise");
+
+    doc
+        .font("Helvetica")
+        .fontSize(9)
+        .fillColor(PDF_MUTED)
+        .text(
+            `${data.crisisItems.length} stratégie${data.crisisItems.length > 1 ? "s" : ""} de régulation`,
+        );
+    doc.moveDown(0.2);
+
+    data.crisisItems.forEach((item, i) => {
+        doc
+            .font("Helvetica")
+            .fontSize(10)
+            .fillColor(PDF_TEXT)
+            .text(`${i + 1}. ${item.label}`);
+    });
+    doc.moveDown(0.3);
+}
+
+function renderFooterOnEachPage(doc: PDFDoc, data: ReportData): void {
+    const range = doc.bufferedPageRange();
+    for (let i = range.start; i < range.start + range.count; i++) {
+        doc.switchToPage(i);
+        const y = doc.page.height - PDF_PAGE_MARGIN + 10;
+        const w = pageWidth(doc);
+        doc
+            .strokeColor(PDF_BORDER)
+            .lineWidth(0.5)
+            .moveTo(PDF_PAGE_MARGIN, y)
+            .lineTo(PDF_PAGE_MARGIN + w, y)
+            .stroke();
+        doc
+            .font("Helvetica")
+            .fontSize(8)
+            .fillColor(PDF_MUTED)
+            .text(
+                `Tokō · toko.app — Rapport généré pour ${data.parentName} · Page ${i - range.start + 1}/${range.count}`,
+                PDF_PAGE_MARGIN,
+                y + 6,
+                { width: w, align: "center" },
+            );
+        doc
+            .fontSize(7)
+            .fillColor("#9ca3af")
+            .text(
+                "Ce rapport est généré à partir des données saisies par le parent. Il ne constitue pas un diagnostic médical.",
+                PDF_PAGE_MARGIN,
+                y + 18,
+                { width: w, align: "center" },
+            );
+    }
 }
 
 function escapeHtml(str: string): string {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -29,10 +29,10 @@ import { Route as AuthenticatedMedicationsIndexRouteImport } from './routes/_aut
 import { Route as AuthenticatedJournalIndexRouteImport } from './routes/_authenticated/journal/index'
 import { Route as AuthenticatedDashboardIndexRouteImport } from './routes/_authenticated/dashboard/index'
 import { Route as AuthenticatedCrisisListIndexRouteImport } from './routes/_authenticated/crisis-list/index'
+import { Route as AuthenticatedConnaissancesIndexRouteImport } from './routes/_authenticated/connaissances/index'
 import { Route as AuthenticatedCarePathwayIndexRouteImport } from './routes/_authenticated/care-pathway/index'
 import { Route as AuthenticatedBarkleyIndexRouteImport } from './routes/_authenticated/barkley/index'
 import { Route as AuthenticatedAdminVaultIndexRouteImport } from './routes/_authenticated/admin-vault/index'
-import { Route as AuthenticatedConnaissancesIndexRouteImport } from './routes/_authenticated/connaissances/index'
 import { Route as AuthenticatedActivityIndexRouteImport } from './routes/_authenticated/activity/index'
 import { Route as AuthenticatedAchievementsIndexRouteImport } from './routes/_authenticated/achievements/index'
 import { Route as AuthenticatedAccountIndexRouteImport } from './routes/_authenticated/account/index'
@@ -147,6 +147,12 @@ const AuthenticatedCrisisListIndexRoute =
     path: '/crisis-list/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedConnaissancesIndexRoute =
+  AuthenticatedConnaissancesIndexRouteImport.update({
+    id: '/connaissances/',
+    path: '/connaissances/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedCarePathwayIndexRoute =
   AuthenticatedCarePathwayIndexRouteImport.update({
     id: '/care-pathway/',
@@ -163,12 +169,6 @@ const AuthenticatedAdminVaultIndexRoute =
   AuthenticatedAdminVaultIndexRouteImport.update({
     id: '/admin-vault/',
     path: '/admin-vault/',
-    getParentRoute: () => AuthenticatedRoute,
-  } as any)
-const AuthenticatedConnaissancesIndexRoute =
-  AuthenticatedConnaissancesIndexRouteImport.update({
-    id: '/connaissances/',
-    path: '/connaissances/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 const AuthenticatedActivityIndexRoute =
@@ -216,10 +216,10 @@ export interface FileRoutesByFullPath {
   '/account/': typeof AuthenticatedAccountIndexRoute
   '/achievements/': typeof AuthenticatedAchievementsIndexRoute
   '/activity/': typeof AuthenticatedActivityIndexRoute
-  '/connaissances/': typeof AuthenticatedConnaissancesIndexRoute
   '/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley/': typeof AuthenticatedBarkleyIndexRoute
   '/care-pathway/': typeof AuthenticatedCarePathwayIndexRoute
+  '/connaissances/': typeof AuthenticatedConnaissancesIndexRoute
   '/crisis-list/': typeof AuthenticatedCrisisListIndexRoute
   '/dashboard/': typeof AuthenticatedDashboardIndexRoute
   '/journal/': typeof AuthenticatedJournalIndexRoute
@@ -246,10 +246,10 @@ export interface FileRoutesByTo {
   '/account': typeof AuthenticatedAccountIndexRoute
   '/achievements': typeof AuthenticatedAchievementsIndexRoute
   '/activity': typeof AuthenticatedActivityIndexRoute
-  '/connaissances': typeof AuthenticatedConnaissancesIndexRoute
   '/admin-vault': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley': typeof AuthenticatedBarkleyIndexRoute
   '/care-pathway': typeof AuthenticatedCarePathwayIndexRoute
+  '/connaissances': typeof AuthenticatedConnaissancesIndexRoute
   '/crisis-list': typeof AuthenticatedCrisisListIndexRoute
   '/dashboard': typeof AuthenticatedDashboardIndexRoute
   '/journal': typeof AuthenticatedJournalIndexRoute
@@ -278,10 +278,10 @@ export interface FileRoutesById {
   '/_authenticated/account/': typeof AuthenticatedAccountIndexRoute
   '/_authenticated/achievements/': typeof AuthenticatedAchievementsIndexRoute
   '/_authenticated/activity/': typeof AuthenticatedActivityIndexRoute
-  '/_authenticated/connaissances/': typeof AuthenticatedConnaissancesIndexRoute
   '/_authenticated/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/_authenticated/barkley/': typeof AuthenticatedBarkleyIndexRoute
   '/_authenticated/care-pathway/': typeof AuthenticatedCarePathwayIndexRoute
+  '/_authenticated/connaissances/': typeof AuthenticatedConnaissancesIndexRoute
   '/_authenticated/crisis-list/': typeof AuthenticatedCrisisListIndexRoute
   '/_authenticated/dashboard/': typeof AuthenticatedDashboardIndexRoute
   '/_authenticated/journal/': typeof AuthenticatedJournalIndexRoute
@@ -310,10 +310,10 @@ export interface FileRouteTypes {
     | '/account/'
     | '/achievements/'
     | '/activity/'
-    | '/connaissances/'
     | '/admin-vault/'
     | '/barkley/'
     | '/care-pathway/'
+    | '/connaissances/'
     | '/crisis-list/'
     | '/dashboard/'
     | '/journal/'
@@ -340,10 +340,10 @@ export interface FileRouteTypes {
     | '/account'
     | '/achievements'
     | '/activity'
-    | '/connaissances'
     | '/admin-vault'
     | '/barkley'
     | '/care-pathway'
+    | '/connaissances'
     | '/crisis-list'
     | '/dashboard'
     | '/journal'
@@ -371,10 +371,10 @@ export interface FileRouteTypes {
     | '/_authenticated/account/'
     | '/_authenticated/achievements/'
     | '/_authenticated/activity/'
-    | '/_authenticated/connaissances/'
     | '/_authenticated/admin-vault/'
     | '/_authenticated/barkley/'
     | '/_authenticated/care-pathway/'
+    | '/_authenticated/connaissances/'
     | '/_authenticated/crisis-list/'
     | '/_authenticated/dashboard/'
     | '/_authenticated/journal/'
@@ -543,6 +543,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedCrisisListIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/connaissances/': {
+      id: '/_authenticated/connaissances/'
+      path: '/connaissances'
+      fullPath: '/connaissances/'
+      preLoaderRoute: typeof AuthenticatedConnaissancesIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/care-pathway/': {
       id: '/_authenticated/care-pathway/'
       path: '/care-pathway'
@@ -562,13 +569,6 @@ declare module '@tanstack/react-router' {
       path: '/admin-vault'
       fullPath: '/admin-vault/'
       preLoaderRoute: typeof AuthenticatedAdminVaultIndexRouteImport
-      parentRoute: typeof AuthenticatedRoute
-    }
-    '/_authenticated/connaissances/': {
-      id: '/_authenticated/connaissances/'
-      path: '/connaissances'
-      fullPath: '/connaissances/'
-      preLoaderRoute: typeof AuthenticatedConnaissancesIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/activity/': {
@@ -614,10 +614,10 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAccountIndexRoute: typeof AuthenticatedAccountIndexRoute
   AuthenticatedAchievementsIndexRoute: typeof AuthenticatedAchievementsIndexRoute
   AuthenticatedActivityIndexRoute: typeof AuthenticatedActivityIndexRoute
-  AuthenticatedConnaissancesIndexRoute: typeof AuthenticatedConnaissancesIndexRoute
   AuthenticatedAdminVaultIndexRoute: typeof AuthenticatedAdminVaultIndexRoute
   AuthenticatedBarkleyIndexRoute: typeof AuthenticatedBarkleyIndexRoute
   AuthenticatedCarePathwayIndexRoute: typeof AuthenticatedCarePathwayIndexRoute
+  AuthenticatedConnaissancesIndexRoute: typeof AuthenticatedConnaissancesIndexRoute
   AuthenticatedCrisisListIndexRoute: typeof AuthenticatedCrisisListIndexRoute
   AuthenticatedDashboardIndexRoute: typeof AuthenticatedDashboardIndexRoute
   AuthenticatedJournalIndexRoute: typeof AuthenticatedJournalIndexRoute
@@ -636,10 +636,10 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAccountIndexRoute: AuthenticatedAccountIndexRoute,
   AuthenticatedAchievementsIndexRoute: AuthenticatedAchievementsIndexRoute,
   AuthenticatedActivityIndexRoute: AuthenticatedActivityIndexRoute,
-  AuthenticatedConnaissancesIndexRoute: AuthenticatedConnaissancesIndexRoute,
   AuthenticatedAdminVaultIndexRoute: AuthenticatedAdminVaultIndexRoute,
   AuthenticatedBarkleyIndexRoute: AuthenticatedBarkleyIndexRoute,
   AuthenticatedCarePathwayIndexRoute: AuthenticatedCarePathwayIndexRoute,
+  AuthenticatedConnaissancesIndexRoute: AuthenticatedConnaissancesIndexRoute,
   AuthenticatedCrisisListIndexRoute: AuthenticatedCrisisListIndexRoute,
   AuthenticatedDashboardIndexRoute: AuthenticatedDashboardIndexRoute,
   AuthenticatedJournalIndexRoute: AuthenticatedJournalIndexRoute,

--- a/apps/web/src/routes/_authenticated/report/index.tsx
+++ b/apps/web/src/routes/_authenticated/report/index.tsx
@@ -284,6 +284,7 @@ function ReportContent({ childId, isActive }: { childId: string; isActive: boole
   const [emailTo, setEmailTo] = useState("");
   const [emailSending, setEmailSending] = useState(false);
   const [emailSent, setEmailSent] = useState(false);
+  const [pdfDownloading, setPdfDownloading] = useState(false);
   const [showLockedHint, setShowLockedHint] = useState(false);
 
   // Persist annotations per-child in localStorage
@@ -382,6 +383,46 @@ function ReportContent({ childId, isActive }: { childId: string; isActive: boole
     return { completed, currentStep: maxCompleted + 1, total: 10 };
   }, [barkleySteps]);
 
+  // Server PDF download. Hits POST /api/report/pdf, streams the response as a
+  // blob, and triggers a browser download. Reserved to Famille (plan check
+  // happens server-side) — free tier falls back to window.print().
+  const handleDownloadPdf = async () => {
+    if (!child) return;
+    setPdfDownloading(true);
+    try {
+      const response = await fetch("/api/report/pdf", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          childId,
+          period: period === "custom" ? undefined : period,
+          from: period === "custom" ? customRange.from : undefined,
+          to: period === "custom" ? customRange.to : undefined,
+          questions: questions.trim() || undefined,
+        }),
+      });
+      if (!response.ok) {
+        // Fallback to native print if the server-side PDF is unavailable.
+        window.print();
+        return;
+      }
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = `toko-rapport-${child.name.replace(/[^a-zA-Z0-9-_]/g, "_")}.pdf`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch {
+      window.print();
+    } finally {
+      setPdfDownloading(false);
+    }
+  };
+
   // Email send handler
   const handleSendEmail = async () => {
     if (!emailTo.trim() || !child) return;
@@ -441,11 +482,12 @@ function ReportContent({ childId, isActive }: { childId: string; isActive: boole
           </div>
           <Button
             size="lg"
-            onClick={() => window.print()}
+            onClick={isActive ? handleDownloadPdf : () => window.print()}
+            disabled={pdfDownloading}
             className="gap-2 shadow-sm self-start sm:self-auto"
           >
             <Printer className="h-4 w-4" />
-            Télécharger en PDF
+            {pdfDownloading ? "Génération…" : "Télécharger en PDF"}
           </Button>
         </div>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       hono:
         specifier: ^4.12.12
         version: 4.12.12
+      pdfkit:
+        specifier: ^0.18.0
+        version: 0.18.0
       stripe:
         specifier: ^20.4.1
         version: 20.4.1(@types/node@25.5.0)
@@ -57,6 +60,9 @@ importers:
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
+      '@types/pdfkit':
+        specifier: ^0.17.6
+        version: 0.17.6
       '@types/web-push':
         specifier: ^3.6.4
         version: 3.6.4
@@ -1778,6 +1784,9 @@ packages:
   '@surma/rollup-plugin-off-main-thread@2.2.3':
     resolution: {integrity: sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==}
 
+  '@swc/helpers@0.5.21':
+    resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
   '@tabby_ai/hijri-converter@1.0.5':
     resolution: {integrity: sha512-r5bClKrcIusDoo049dSL8CawnHR6mRdDwhlQuIgZRNty68q0x8k3Lf1BtPAMxRf/GgnHBnIO4ujd3+GQdLWzxQ==}
     engines: {node: '>=16.0.0'}
@@ -2053,6 +2062,9 @@ packages:
   '@types/node@25.5.0':
     resolution: {integrity: sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==}
 
+  '@types/pdfkit@0.17.6':
+    resolution: {integrity: sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -2234,6 +2246,13 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@0.0.8:
+    resolution: {integrity: sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==}
+    engines: {node: '>= 0.4'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.10:
     resolution: {integrity: sha512-sUoJ3IMxx4AyRqO4MLeHlnGDkyXRoUG0/AI9fjK+vS72ekpV0yWVY7O0BVjmBcRtkNcsAO2QDZ4tdKKGoI6YaQ==}
     engines: {node: '>=6.0.0'}
@@ -2334,6 +2353,12 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  brotli@1.3.3:
+    resolution: {integrity: sha512-oTKjJdShmDuGW94SyyaoQvAjf30dZaHnjJ8uAF+u2/vGJkJbJPJAT1gDiOJP5v1Zb6f9KEyW/1HpuaWIXtGHPg==}
+
+  browserify-zlib@0.2.0:
+    resolution: {integrity: sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -2402,6 +2427,10 @@ packages:
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
+
+  clone@2.1.2:
+    resolution: {integrity: sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==}
+    engines: {node: '>=0.8'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2628,6 +2657,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dfa@1.2.0:
+    resolution: {integrity: sha512-ED3jP8saaweFTjeGX8HQPjeC1YYyZs98jGNZx6IiBvxW7JG5v492kamAQB3m2wop07CvU/RQmzcKr6bgcC5D/Q==}
 
   diff@8.0.3:
     resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
@@ -2950,6 +2982,9 @@ packages:
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
+
+  fontkit@2.0.4:
+    resolution: {integrity: sha512-syetQadaUEDNdxdugga9CpEYVaQIxOwk7GlwZWWZ19//qW4zE5bknOKeMBDYAASwnpaSHKJITRLMF9m1fp3s6g==}
 
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -3413,6 +3448,9 @@ packages:
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
 
+  js-md5@0.8.3:
+    resolution: {integrity: sha512-qR0HB5uP6wCuRMrWPTrkMaev7MJZwJuuw4fnwAzRgP4J4/F8RwtodOKpGp4XpqsLBFzzgqIO42efFAyz2Et6KQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3546,6 +3584,9 @@ packages:
   lightningcss@1.32.0:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
+
+  linebreak@1.1.0:
+    resolution: {integrity: sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -3789,6 +3830,12 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
+  pako@0.2.9:
+    resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
+
+  pako@1.0.11:
+    resolution: {integrity: sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -3835,6 +3882,9 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pdfkit@0.18.0:
+    resolution: {integrity: sha512-NvUwSDZ0eYEzqAiWwVQkRkjYUkZ48kcsHuCO31ykqPPIVkwoSDjDGiwIgHHNtsiwls3z3P/zy4q00hl2chg2Ug==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3859,6 +3909,9 @@ packages:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
     engines: {node: '>=18'}
     hasBin: true
+
+  png-js@1.1.0:
+    resolution: {integrity: sha512-PM/uYGzGdNSzqeOgly68+6wKQDL1SY0a/N+OEa/+br6LnHWOAJB0Npiamnodfq3jd2LS/i2fMeOKSAILjA+m5Q==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -4064,6 +4117,9 @@ packages:
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  restructure@3.0.2:
+    resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
 
   rettime@0.10.1:
     resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
@@ -4378,6 +4434,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
@@ -4500,9 +4559,15 @@ packages:
     resolution: {integrity: sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==}
     engines: {node: '>=4'}
 
+  unicode-properties@1.4.1:
+    resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
+
   unicode-property-aliases-ecmascript@2.2.0:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
+
+  unicode-trie@2.0.0:
+    resolution: {integrity: sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -6242,6 +6307,10 @@ snapshots:
       magic-string: 0.25.9
       string.prototype.matchall: 4.0.12
 
+  '@swc/helpers@0.5.21':
+    dependencies:
+      tslib: 2.8.1
+
   '@tabby_ai/hijri-converter@1.0.5': {}
 
   '@tailwindcss/node@4.2.2':
@@ -6512,6 +6581,10 @@ snapshots:
     dependencies:
       undici-types: 7.18.2
 
+  '@types/pdfkit@0.17.6':
+    dependencies:
+      '@types/node': 25.5.0
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -6713,6 +6786,10 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@0.0.8: {}
+
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.10: {}
 
   better-auth@1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(gel@2.2.0)(kysely@0.28.14)(postgres@3.4.8))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))):
@@ -6787,6 +6864,14 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  brotli@1.3.3:
+    dependencies:
+      base64-js: 1.5.1
+
+  browserify-zlib@0.2.0:
+    dependencies:
+      pako: 1.0.11
+
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.10.10
@@ -6859,6 +6944,8 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
+
+  clone@2.1.2: {}
 
   clsx@2.1.1: {}
 
@@ -7038,6 +7125,8 @@ snapshots:
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
+
+  dfa@1.2.0: {}
 
   diff@8.0.3: {}
 
@@ -7425,6 +7514,18 @@ snapshots:
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
+
+  fontkit@2.0.4:
+    dependencies:
+      '@swc/helpers': 0.5.21
+      brotli: 1.3.3
+      clone: 2.1.2
+      dfa: 1.2.0
+      fast-deep-equal: 3.1.3
+      restructure: 3.0.2
+      tiny-inflate: 1.0.3
+      unicode-properties: 1.4.1
+      unicode-trie: 2.0.0
 
   for-each@0.3.5:
     dependencies:
@@ -7843,6 +7944,8 @@ snapshots:
 
   jose@6.2.2: {}
 
+  js-md5@0.8.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@4.1.1:
@@ -7960,6 +8063,11 @@ snapshots:
       lightningcss-linux-x64-musl: 1.32.0
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
+
+  linebreak@1.1.0:
+    dependencies:
+      base64-js: 0.0.8
+      unicode-trie: 2.0.0
 
   lines-and-columns@1.2.4: {}
 
@@ -8182,6 +8290,10 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  pako@0.2.9: {}
+
+  pako@1.0.11: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -8220,6 +8332,15 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pdfkit@0.18.0:
+    dependencies:
+      '@noble/ciphers': 1.3.0
+      '@noble/hashes': 1.8.0
+      fontkit: 2.0.4
+      js-md5: 0.8.3
+      linebreak: 1.1.0
+      png-js: 1.1.0
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -8235,6 +8356,10 @@ snapshots:
       playwright-core: 1.58.2
     optionalDependencies:
       fsevents: 2.3.2
+
+  png-js@1.1.0:
+    dependencies:
+      browserify-zlib: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -8453,6 +8578,8 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
+
+  restructure@3.0.2: {}
 
   rettime@0.10.1: {}
 
@@ -8852,6 +8979,8 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  tiny-inflate@1.0.3: {}
+
   tiny-invariant@1.3.3: {}
 
   tinybench@2.9.0: {}
@@ -8987,7 +9116,17 @@ snapshots:
 
   unicode-match-property-value-ecmascript@2.2.1: {}
 
+  unicode-properties@1.4.1:
+    dependencies:
+      base64-js: 1.5.1
+      unicode-trie: 2.0.0
+
   unicode-property-aliases-ecmascript@2.2.0: {}
+
+  unicode-trie@2.0.0:
+    dependencies:
+      pako: 0.2.9
+      tiny-inflate: 1.0.3
 
   unicorn-magic@0.3.0: {}
 


### PR DESCRIPTION
Adds POST /api/report/pdf — a Famille-gated endpoint that streams a
pdfkit-generated medical report (synthèse, moyennes par dimension,
traitements en cours + observance, parcours de soins, journal, Barkley,
liste de crise) so doctors get a consistent document regardless of the
parent's browser. The web report page now hits this endpoint for paying
users and falls back to window.print() for free tier.

Refactors report.ts to share data-fetching and date-range resolution
between /send-email and /pdf, and extends both with medications and
care-pathway sections.