### PR TITLE
fix(web): hide header separator on mobile

### DIFF
--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -326,7 +326,7 @@ function AppHeader() {
           <Separator
             orientation="vertical"
             aria-hidden="true"
-            className="h-4"
+            className="hidden h-4 md:block"
           />
           <Breadcrumbs className="min-w-0 flex-1" />
         </>


### PR DESCRIPTION
The vertical Separator between SidebarTrigger and Breadcrumbs stayed
visible on mobile even though the trigger itself is hidden, leaving a
stray little bar in the top-left corner of the header. Match the
separator's visibility to the trigger.