### PR TITLE
fix(web): reposition SOS button to bottom-right corner

### DIFF
--- a/apps/web/src/components/shared/floating-tip-button.tsx
+++ b/apps/web/src/components/shared/floating-tip-button.tsx
@@ -54,7 +54,7 @@ export function FloatingTipButton() {
   const showNext = available.length > 1;
 
   return (
-    <div className="pointer-events-none fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 z-40 lg:bottom-6 lg:right-6">
+    <div className="pointer-events-none fixed bottom-[calc(8.75rem+env(safe-area-inset-bottom))] right-4 z-40 lg:bottom-[5.5rem] lg:right-6">
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger
           render={

--- a/apps/web/src/components/shared/sos-crisis-button.tsx
+++ b/apps/web/src/components/shared/sos-crisis-button.tsx
@@ -51,7 +51,7 @@ export function SOSCrisisButton() {
         type="button"
         onClick={() => setOpen(true)}
         aria-label={t("sos.openLabel")}
-        className="fixed bottom-[calc(8.75rem+env(safe-area-inset-bottom))] right-4 z-40 flex h-14 items-center gap-2 rounded-full bg-destructive px-4 text-sm font-semibold text-white shadow-lg ring-2 ring-destructive/20 transition-transform duration-200 hover:scale-105 focus-visible:scale-105 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring active:scale-95 lg:bottom-[5rem] lg:right-6"
+        className="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 z-40 flex h-14 items-center gap-2 rounded-full bg-destructive px-4 text-sm font-semibold text-white shadow-lg ring-2 ring-destructive/20 transition-transform duration-200 hover:scale-105 focus-visible:scale-105 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring active:scale-95 lg:bottom-6 lg:right-6"
       >
         <span
           aria-hidden="true"

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -959,7 +959,7 @@
   },
   "sos": {
     "openLabel": "Ouvrir le mode SOS Crise",
-    "buttonLabel": "SOS Crise",
+    "buttonLabel": "SOS",
     "dialogLabel": "Techniques de désamorçage de crise",
     "title": "Respirez. Vous êtes au bon endroit.",
     "subtitle": "Choisissez une technique pour désamorcer la crise. Personne ne juge — vous gérez déjà beaucoup.",


### PR DESCRIPTION
Move the SOS button down to sit just above the mobile bottom nav (and
flush to the corner on desktop), and bump the floating tip button up so
they no longer overlap. Shorten the button label from "SOS Crise" to
"SOS".

https://claude.ai/code/session_01RnKareRnYqdYPLQQjjGWzz