### PR TITLE
fix(web): use active child's name in crisis list subtitle

### DIFF
--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -1017,7 +1017,8 @@
   },
   "crisis": {
     "title": "Crisis list",
-    "subtitle": "The things that help me when I'm not okay",
+    "subtitle": "The things that help your child when they're not okay",
+    "subtitleWithName": "The things that help {{name}} when they're not okay",
     "crisisMode": "Crisis mode",
     "addButton": "Add",
     "editTitle": "Edit",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -1017,7 +1017,8 @@
   },
   "crisis": {
     "title": "Liste de la crise",
-    "subtitle": "Les choses qui me font du bien quand ça ne va pas",
+    "subtitle": "Les choses qui font du bien à votre enfant quand ça ne va pas",
+    "subtitleWithName": "Les choses qui font du bien à {{name}} quand ça ne va pas",
     "crisisMode": "Mode crise",
     "addButton": "Ajouter",
     "editTitle": "Modifier",

--- a/apps/web/src/routes/_authenticated/crisis-list/crisis-list-page.tsx
+++ b/apps/web/src/routes/_authenticated/crisis-list/crisis-list-page.tsx
@@ -67,6 +67,7 @@ import {
   useDeleteCrisisItem,
   useReorderCrisisItems,
 } from "@/hooks/use-crisis-list";
+import { useChildren } from "@/hooks/use-children";
 import { useUiStore } from "@/stores/ui-store";
 import type { CrisisItem } from "@focusflow/validators";
 export default function CrisisListPage() {
@@ -76,6 +77,8 @@ export default function CrisisListPage() {
   const [crisisMode, setCrisisMode] = useState(false);
   const activeChildId = useUiStore((s) => s.activeChildId);
   const { data: items, isLoading } = useCrisisItems(activeChildId ?? "");
+  const { data: children } = useChildren();
+  const activeChild = children?.find((c) => c.id === activeChildId);
   const reorder = useReorderCrisisItems();
 
   const sensors = useSensors(
@@ -128,7 +131,11 @@ export default function CrisisListPage() {
     <div className="space-y-6">
       <PageHeader
         title={t("crisis.title")}
-        description={t("crisis.subtitle")}
+        description={
+          activeChild?.name
+            ? t("crisis.subtitleWithName", { name: activeChild.name })
+            : t("crisis.subtitle")
+        }
         actions={
           <>
             {items && items.length > 0 && (


### PR DESCRIPTION
The subtitle was written in first person ("me font du bien"), implying
the child was speaking, but the page is shown to parents. Use the active
child's first name so the subtitle reads as parent-facing copy.

https://claude.ai/code/session_01Wzj5ee4PwDpKQdsZKQ2ePC