### PR TITLE
fix(web): cluster SOS and tip buttons into a horizontal FAB group

### DIFF
--- a/apps/web/src/components/shared/floating-tip-button.tsx
+++ b/apps/web/src/components/shared/floating-tip-button.tsx
@@ -54,67 +54,65 @@ export function FloatingTipButton() {
   const showNext = available.length > 1;
 
   return (
-    <div className="pointer-events-none fixed bottom-[calc(8.75rem+env(safe-area-inset-bottom))] right-4 z-40 lg:bottom-[5.5rem] lg:right-6">
-      <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger
-          render={
-            <button
-              type="button"
-              aria-label={t("featureTip.open")}
-              className="pointer-events-auto relative flex h-11 w-11 items-center justify-center rounded-full bg-info-surface text-info-foreground shadow-md ring-1 ring-info-border transition-transform duration-200 hover:scale-110 focus-visible:scale-110 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring active:scale-95"
-            >
-              {!open && (
-                <span
-                  aria-hidden="true"
-                  className="absolute inset-0 rounded-full bg-info-foreground/30 animate-tip-halo"
-                />
-              )}
-              <Lightbulb
-                className={`relative h-[1.125rem] w-[1.125rem] ${
-                  open ? "" : "animate-tip-wiggle"
-                }`}
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger
+        render={
+          <button
+            type="button"
+            aria-label={t("featureTip.open")}
+            className="pointer-events-auto relative flex h-11 w-11 items-center justify-center rounded-full bg-info-surface text-info-foreground shadow-md ring-1 ring-info-border transition-transform duration-200 hover:scale-110 focus-visible:scale-110 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring active:scale-95"
+          >
+            {!open && (
+              <span
+                aria-hidden="true"
+                className="absolute inset-0 rounded-full bg-info-foreground/30 animate-tip-halo"
               />
-            </button>
-          }
-        />
-        <PopoverContent
-          side="top"
-          align="end"
-          sideOffset={8}
-          className="pointer-events-auto w-[min(20rem,calc(100vw-2rem))] border border-info-border bg-[color-mix(in_oklab,#3b82f6_14%,var(--color-popover))] text-info-foreground shadow-md dark:bg-[color-mix(in_oklab,#3b82f6_22%,var(--color-popover))]"
-        >
-          <div className="flex items-start gap-2">
-            <Lightbulb className="mt-0.5 h-4 w-4 shrink-0" />
-            <p className="flex-1 text-xs leading-relaxed">
-              {t(`tips.${tip.id}`)}
-            </p>
-          </div>
-          <div className="flex items-center justify-end gap-1 pt-1">
-            {showNext && (
-              <button
-                type="button"
-                onClick={() => setOffset((o) => o + 1)}
-                aria-label={t("featureTip.next")}
-                className="flex h-7 items-center gap-1 rounded px-2 text-xs text-info-foreground/80 hover:text-info-foreground focus-visible:text-info-foreground focus-visible:outline-2 focus-visible:outline-ring"
-              >
-                <span>{t("featureTip.next")}</span>
-                <ChevronRight className="h-3.5 w-3.5" />
-              </button>
             )}
+            <Lightbulb
+              className={`relative h-[1.125rem] w-[1.125rem] ${
+                open ? "" : "animate-tip-wiggle"
+              }`}
+            />
+          </button>
+        }
+      />
+      <PopoverContent
+        side="top"
+        align="end"
+        sideOffset={12}
+        className="pointer-events-auto w-[min(20rem,calc(100vw-2rem))] border border-info-border bg-[color-mix(in_oklab,#3b82f6_14%,var(--color-popover))] text-info-foreground shadow-md dark:bg-[color-mix(in_oklab,#3b82f6_22%,var(--color-popover))]"
+      >
+        <div className="flex items-start gap-2">
+          <Lightbulb className="mt-0.5 h-4 w-4 shrink-0" />
+          <p className="flex-1 text-xs leading-relaxed">
+            {t(`tips.${tip.id}`)}
+          </p>
+        </div>
+        <div className="flex items-center justify-end gap-1 pt-1">
+          {showNext && (
             <button
               type="button"
-              onClick={() => {
-                dismissTip(tip.id);
-                setOffset(0);
-              }}
-              aria-label={t("featureTip.dismiss")}
-              className="flex h-7 w-7 items-center justify-center rounded text-info-foreground/70 hover:text-info-foreground focus-visible:text-info-foreground focus-visible:outline-2 focus-visible:outline-ring"
+              onClick={() => setOffset((o) => o + 1)}
+              aria-label={t("featureTip.next")}
+              className="flex h-7 items-center gap-1 rounded px-2 text-xs text-info-foreground/80 hover:text-info-foreground focus-visible:text-info-foreground focus-visible:outline-2 focus-visible:outline-ring"
             >
-              <X className="h-3.5 w-3.5" />
+              <span>{t("featureTip.next")}</span>
+              <ChevronRight className="h-3.5 w-3.5" />
             </button>
-          </div>
-        </PopoverContent>
-      </Popover>
-    </div>
+          )}
+          <button
+            type="button"
+            onClick={() => {
+              dismissTip(tip.id);
+              setOffset(0);
+            }}
+            aria-label={t("featureTip.dismiss")}
+            className="flex h-7 w-7 items-center justify-center rounded text-info-foreground/70 hover:text-info-foreground focus-visible:text-info-foreground focus-visible:outline-2 focus-visible:outline-ring"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/apps/web/src/components/shared/sos-crisis-button.tsx
+++ b/apps/web/src/components/shared/sos-crisis-button.tsx
@@ -51,7 +51,7 @@ export function SOSCrisisButton() {
         type="button"
         onClick={() => setOpen(true)}
         aria-label={t("sos.openLabel")}
-        className="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 z-40 flex h-14 items-center gap-2 rounded-full bg-destructive px-4 text-sm font-semibold text-white shadow-lg ring-2 ring-destructive/20 transition-transform duration-200 hover:scale-105 focus-visible:scale-105 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring active:scale-95 lg:bottom-6 lg:right-6"
+        className="pointer-events-auto relative flex h-14 items-center gap-2 rounded-full bg-destructive px-4 text-sm font-semibold text-white shadow-lg ring-2 ring-destructive/20 transition-transform duration-200 hover:scale-105 focus-visible:scale-105 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring active:scale-95"
       >
         <span
           aria-hidden="true"

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -125,8 +125,10 @@ function AuthenticatedShell() {
         {isMobile && <MobileTabBar />}
       </SidebarInset>
 
-      <SOSCrisisButton />
-      <FloatingTipButton />
+      <div className="pointer-events-none fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 z-40 flex items-end gap-3 lg:bottom-6 lg:right-6">
+        <FloatingTipButton />
+        <SOSCrisisButton />
+      </div>
       <KoeWidget />
       <LockOverlay />
       <InstallPrompt />


### PR DESCRIPTION
The lightbulb tip button was stacked vertically above the SOS button
with only ~4px of breathing room on mobile, which felt cramped and
made the tip popover overlap page content. Move both buttons into a
single positioned flex container so they share a baseline as a
horizontal cluster (tip on the left, SOS on the right), and let the
tip popover anchor cleanly above the cluster.