### PR TITLE
fix(web): re-enable pointer events on SOS overlay

### DIFF
--- a/apps/web/src/components/shared/sos-crisis-button.tsx
+++ b/apps/web/src/components/shared/sos-crisis-button.tsx
@@ -90,7 +90,7 @@ function SOSOverlay({
       role="dialog"
       aria-modal="true"
       aria-label={t("sos.dialogLabel")}
-      className="fixed inset-0 z-50 flex flex-col bg-gradient-to-b from-sage-50 via-background to-accent-50 pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)] dark:from-sage-900/30 dark:via-background dark:to-accent-900/30"
+      className="pointer-events-auto fixed inset-0 z-50 flex flex-col bg-gradient-to-b from-sage-50 via-background to-accent-50 pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)] dark:from-sage-900/30 dark:via-background dark:to-accent-900/30"
     >
       <div className="flex items-center justify-between px-4 pt-4 sm:px-6">
         {technique ? (


### PR DESCRIPTION
The overlay is rendered inside the floating-button container
which sets pointer-events-none, so taps on the dialog (including
the X close button) were falling through to the header's theme
toggle behind it.

https://claude.ai/code/session_01CBSA8QkVyp2R6wqwNvAqCt