### PR TITLE
feat(web): notify users when a PWA update is available

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -39,6 +39,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^2.6.1",
     "tw-animate-css": "^1.4.0",
+    "workbox-window": "^7.4.1",
     "zustand": "^5.0.0"
   },
   "devDependencies": {

--- a/apps/web/src/components/shared/pwa-update-prompt.tsx
+++ b/apps/web/src/components/shared/pwa-update-prompt.tsx
@@ -1,0 +1,78 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { RefreshCw, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { usePwaUpdate } from "@/hooks/use-pwa-update";
+
+export function PWAUpdatePrompt() {
+  const { t } = useTranslation();
+  const { needRefresh, update, dismiss } = usePwaUpdate();
+  const [updating, setUpdating] = useState(false);
+
+  if (!needRefresh) return null;
+
+  const handleUpdate = async () => {
+    setUpdating(true);
+    try {
+      await update();
+    } catch {
+      setUpdating(false);
+    }
+  };
+
+  return (
+    <div
+      role="region"
+      aria-live="polite"
+      aria-label={t("pwaUpdate.regionLabel")}
+      className="fixed inset-x-0 bottom-0 z-50 px-4 pb-[calc(env(safe-area-inset-bottom)+10rem)] md:bottom-4 md:left-auto md:right-4 md:max-w-sm md:px-0 md:pb-0"
+    >
+      <div className="rounded-xl border border-border/60 bg-background/95 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/85">
+        <div className="flex items-start gap-3">
+          <span
+            aria-hidden="true"
+            className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"
+          >
+            <RefreshCw className="h-4 w-4" />
+          </span>
+          <div className="min-w-0 flex-1">
+            <p className="font-heading text-sm font-medium">
+              {t("pwaUpdate.title")}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {t("pwaUpdate.body")}
+            </p>
+
+            <div className="mt-3 flex items-center gap-2">
+              <Button
+                size="sm"
+                onClick={handleUpdate}
+                disabled={updating}
+                aria-busy={updating}
+              >
+                {updating ? t("pwaUpdate.updating") : t("pwaUpdate.cta")}
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={dismiss}
+                disabled={updating}
+              >
+                {t("pwaUpdate.later")}
+              </Button>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={dismiss}
+            disabled={updating}
+            aria-label={t("pwaUpdate.close")}
+            className="-m-1.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50"
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-pwa-update.ts
+++ b/apps/web/src/hooks/use-pwa-update.ts
@@ -1,0 +1,55 @@
+import { useCallback } from "react";
+import { useRegisterSW } from "virtual:pwa-register/react";
+
+const UPDATE_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+
+export interface UsePwaUpdateResult {
+  needRefresh: boolean;
+  update: () => Promise<void>;
+  dismiss: () => void;
+}
+
+export function usePwaUpdate(): UsePwaUpdateResult {
+  const {
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({
+    onRegisteredSW(swUrl, registration) {
+      if (!registration) return;
+
+      const checkForUpdate = () => {
+        if (!navigator.onLine) return;
+        registration.update().catch(() => {
+          // Network errors are non-fatal — we'll retry on the next tick.
+        });
+      };
+
+      const interval = window.setInterval(
+        checkForUpdate,
+        UPDATE_CHECK_INTERVAL_MS,
+      );
+
+      const onVisibilityChange = () => {
+        if (document.visibilityState === "visible") {
+          checkForUpdate();
+        }
+      };
+      document.addEventListener("visibilitychange", onVisibilityChange);
+
+      return () => {
+        window.clearInterval(interval);
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+      };
+    },
+  });
+
+  const update = useCallback(async () => {
+    await updateServiceWorker(true);
+  }, [updateServiceWorker]);
+
+  const dismiss = useCallback(() => {
+    setNeedRefresh(false);
+  }, [setNeedRefresh]);
+
+  return { needRefresh, update, dismiss };
+}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -1846,5 +1846,14 @@
     "later": "Later",
     "gotIt": "Got it",
     "close": "Dismiss prompt"
+  },
+  "pwaUpdate": {
+    "regionLabel": "Tokō update",
+    "title": "A new version is available",
+    "body": "Reload Tokō to get the latest improvements and fixes.",
+    "cta": "Update",
+    "updating": "Updating…",
+    "later": "Later",
+    "close": "Dismiss update"
   }
 }

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -1846,5 +1846,14 @@
     "later": "Plus tard",
     "gotIt": "J'ai compris",
     "close": "Fermer l'invitation"
+  },
+  "pwaUpdate": {
+    "regionLabel": "Mise à jour de Tokō",
+    "title": "Une nouvelle version est disponible",
+    "body": "Rechargez Tokō pour profiter des dernières améliorations et corrections.",
+    "cta": "Mettre à jour",
+    "updating": "Mise à jour…",
+    "later": "Plus tard",
+    "close": "Ignorer la mise à jour"
   }
 }

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -40,6 +40,7 @@ import { ModeToggle } from "@/components/mode-toggle";
 import { KoeWidget, useKoeTrigger } from "@/components/koe-widget";
 import { FloatingTipButton } from "@/components/shared/floating-tip-button";
 import { InstallPrompt } from "@/components/shared/install-prompt";
+import { PWAUpdatePrompt } from "@/components/shared/pwa-update-prompt";
 import { SOSCrisisButton } from "@/components/shared/sos-crisis-button";
 import { LockOverlay } from "@/components/shared/lock-overlay";
 import { OnboardingTour } from "@/components/shared/onboarding-tour";
@@ -132,6 +133,7 @@ function AuthenticatedShell() {
       <KoeWidget />
       <LockOverlay />
       <InstallPrompt />
+      <PWAUpdatePrompt />
       <OnboardingTour />
     </>
   );

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/react" />
 
 declare const __APP_VERSION__: string;
 declare const __BUILD_DATE__: string;

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -20,8 +20,8 @@ export default defineConfig({
     react(),
     tailwindcss(),
     VitePWA({
-      registerType: "autoUpdate",
-      injectRegister: "auto",
+      registerType: "prompt",
+      injectRegister: null,
       manifest: false,
       includeAssets: ["favicon.svg", "icon.svg"],
       workbox: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
+      workbox-window:
+        specifier: ^7.4.1
+        version: 7.4.1
       zustand:
         specifier: ^5.0.0
         version: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
@@ -198,7 +201,7 @@ importers:
         version: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
       vite-plugin-pwa:
         specifier: ^1.2.0
-        version: 1.2.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0)
+        version: 1.2.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.1)
       vitest:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))
@@ -4793,6 +4796,9 @@ packages:
   workbox-core@7.4.0:
     resolution: {integrity: sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ==}
 
+  workbox-core@7.4.1:
+    resolution: {integrity: sha512-DT+vu46eh/2vRsSHTY4Xmc32Z1rr9PRlQUXr1Dx30ZuXRWwOsvZgGgcwxcasubQLQmbTNYZjv44LkBAQ4tT5tQ==}
+
   workbox-expiration@7.4.0:
     resolution: {integrity: sha512-V50p4BxYhtA80eOvulu8xVfPBgZbkxJ1Jr8UUn0rvqjGhLDqKNtfrDfjJKnLz2U8fO2xGQJTx/SKXNTzHOjnHw==}
 
@@ -4825,6 +4831,9 @@ packages:
 
   workbox-window@7.4.0:
     resolution: {integrity: sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==}
+
+  workbox-window@7.4.1:
+    resolution: {integrity: sha512-notZDH2u8VXaqyuD7xaqIfEFi6SRM4SUSd7ewe9PDsVqADuepxX2ZMY3uvuZGxzY5ZOsGC/vD3A/3smFtJt4/A==}
 
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
@@ -9182,14 +9191,14 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-plugin-pwa@1.2.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.0):
+  vite-plugin-pwa@1.2.0(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))(workbox-build@7.4.0(@types/babel__core@7.20.5))(workbox-window@7.4.1):
     dependencies:
       debug: 4.4.3
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.15
       vite: 6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)
       workbox-build: 7.4.0(@types/babel__core@7.20.5)
-      workbox-window: 7.4.0
+      workbox-window: 7.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -9390,6 +9399,8 @@ snapshots:
 
   workbox-core@7.4.0: {}
 
+  workbox-core@7.4.1: {}
+
   workbox-expiration@7.4.0:
     dependencies:
       idb: 7.1.1
@@ -9444,6 +9455,11 @@ snapshots:
     dependencies:
       '@types/trusted-types': 2.0.7
       workbox-core: 7.4.0
+
+  workbox-window@7.4.1:
+    dependencies:
+      '@types/trusted-types': 2.0.7
+      workbox-core: 7.4.1
 
   wrap-ansi@6.2.0:
     dependencies:


### PR DESCRIPTION
Switch vite-plugin-pwa from autoUpdate to prompt so users can decide when
to apply a new version. A dismissible panel surfaces the update with an
explicit "Mettre à jour" CTA, mirroring the install prompt's UX.