### PR TITLE
feat(routines): add 6 ready-made routine templates for empty state

### DIFF
--- a/apps/api/src/routes/routines.ts
+++ b/apps/api/src/routes/routines.ts
@@ -11,6 +11,8 @@ import {
   updateRoutineSchema,
   upsertRoutineStepsSchema,
   completeRoutineStepSchema,
+  adoptRoutineTemplateSchema,
+  findRoutineTemplate,
 } from "@focusflow/validators";
 import type { AppEnv } from "../types";
 import { authMiddleware } from "../middleware/auth";
@@ -158,6 +160,79 @@ routinesRoutes.post("/", async (c) => {
     entityId: created.id,
     action: "create",
     summary: `Routine « ${created.name} » créée`,
+  });
+
+  const full = await loadRoutineWithSteps(created.id);
+  return c.json(full, 201);
+});
+
+// ─── Adopt a built-in template ─────────────────────────────────────────────
+// One-tap path from the empty state: turns a curated template (matin / devoirs
+// / coucher / …) into a full routine + steps in a single transaction. The
+// template content lives in @focusflow/validators so FE and BE agree.
+routinesRoutes.post("/from-template", async (c) => {
+  const user = c.get("user");
+  const body = await c.req.json();
+  const parsed = adoptRoutineTemplateSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      422,
+    );
+  }
+  await assertChildAccess(user.id, parsed.data.childId);
+
+  const template = findRoutineTemplate(parsed.data.templateKey);
+  if (!template) {
+    throw new AppError("NOT_FOUND", "Modèle introuvable", 404);
+  }
+
+  const [maxPos] = await db
+    .select({ max: sql<number>`coalesce(max(${routines.position}), -1)` })
+    .from(routines)
+    .where(eq(routines.childId, parsed.data.childId));
+  const position = (maxPos?.max ?? -1) + 1;
+
+  const created = await db.transaction(async (tx) => {
+    const [routine] = await tx
+      .insert(routines)
+      .values({
+        childId: parsed.data.childId,
+        name: template.title,
+        emoji: template.emoji,
+        timeOfDay: template.timeOfDay,
+        daysOfWeek: [],
+        position,
+      })
+      .returning();
+
+    if (!routine) {
+      throw new AppError("INTERNAL", "Création échouée", 500);
+    }
+
+    if (template.steps.length > 0) {
+      await tx.insert(routineSteps).values(
+        template.steps.map((s, i) => ({
+          routineId: routine.id,
+          label: s.label,
+          emoji: s.emoji ?? null,
+          durationMinutes: s.durationMinutes ?? null,
+          position: i,
+        })),
+      );
+    }
+
+    return routine;
+  });
+
+  void logAudit({
+    actorId: user.id,
+    actorName: user.name ?? null,
+    childId: created.childId,
+    entityType: "routine",
+    entityId: created.id,
+    action: "create",
+    summary: `Routine « ${created.name} » ajoutée depuis un modèle`,
   });
 
   const full = await loadRoutineWithSteps(created.id);

--- a/apps/web/src/hooks/use-routines.ts
+++ b/apps/web/src/hooks/use-routines.ts
@@ -9,6 +9,7 @@ import type {
   UpdateRoutine,
   UpsertRoutineSteps,
   CompleteRoutineStep,
+  AdoptRoutineTemplate,
 } from "@focusflow/validators";
 
 export const routinesKeys = {
@@ -40,6 +41,19 @@ export function useCreateRoutine() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data: CreateRoutine) => api.post<Routine>("/routines", data),
+    onSuccess: (_, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: routinesKeys.all(variables.childId),
+      }),
+    onError: () => toast.error(i18n.t("toastErrors.addRoutine")),
+  });
+}
+
+export function useAdoptRoutineTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: AdoptRoutineTemplate) =>
+      api.post<Routine>("/routines/from-template", data),
     onSuccess: (_, variables) =>
       queryClient.invalidateQueries({
         queryKey: routinesKeys.all(variables.childId),

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -1094,7 +1094,32 @@
     "removeStep": "Remove step",
     "saveSteps": "Save steps",
     "done": "done",
-    "allDoneCelebration": "Great job, routine complete!"
+    "allDoneCelebration": "Great job, routine complete!",
+    "templates": {
+      "fromTemplateButton": "From a template",
+      "modalTitle": "Add from a template",
+      "modalIntro": "Pick a ready-made routine. You can edit everything afterwards.",
+      "startHereHeading": "Start here",
+      "startHereIntro": "Don't feel like starting from scratch? Routines tested by other parents.",
+      "createFromScratch": "Create from scratch",
+      "metaWithTime": "{{steps}} steps · ~{{minutes}} min",
+      "metaSteps": "{{steps}} steps",
+      "seeAll": "See all templates ({{count}})",
+      "personalize": "Personalize",
+      "adoptedToast": "\"{{name}}\" added to your routines",
+      "gentleHint": "For tough days",
+      "patienceTitle": "Be patient with yourself",
+      "patienceBody": "A routine takes 3 to 6 weeks to settle in. The first days will feel chaotic — that's expected. Try 14 days before changing it.",
+      "patienceDismiss": "Dismiss this message",
+      "items": {
+        "morning-school": { "title": "School morning" },
+        "after-school": { "title": "After school" },
+        "homework": { "title": "Homework" },
+        "bedtime": { "title": "Calm bedtime" },
+        "transition": { "title": "Transition" },
+        "rough-day": { "title": "Tough day" }
+      }
+    }
   },
   "barkley": {
     "title": "Barkley program",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -1094,7 +1094,32 @@
     "removeStep": "Retirer l'étape",
     "saveSteps": "Enregistrer les étapes",
     "done": "fait",
-    "allDoneCelebration": "Bravo, routine terminée !"
+    "allDoneCelebration": "Bravo, routine terminée !",
+    "templates": {
+      "fromTemplateButton": "Depuis un modèle",
+      "modalTitle": "Ajouter depuis un modèle",
+      "modalIntro": "Choisissez une routine prête à l'emploi. Vous pourrez tout modifier ensuite.",
+      "startHereHeading": "Pour commencer",
+      "startHereIntro": "Pas envie de partir de zéro ? Voici des routines testées par d'autres parents.",
+      "createFromScratch": "Créer depuis zéro",
+      "metaWithTime": "{{steps}} étapes · ~{{minutes}} min",
+      "metaSteps": "{{steps}} étapes",
+      "seeAll": "Voir tous les modèles ({{count}})",
+      "personalize": "Personnaliser",
+      "adoptedToast": "« {{name}} » ajoutée à vos routines",
+      "gentleHint": "Pour les jours difficiles",
+      "patienceTitle": "Soyez patients avec vous-même",
+      "patienceBody": "Une routine met 3 à 6 semaines à s'installer. Les premiers jours seront chaotiques — c'est normal. Essayez 14 jours avant de modifier.",
+      "patienceDismiss": "Masquer ce message",
+      "items": {
+        "morning-school": { "title": "Matin d'école" },
+        "after-school": { "title": "Retour d'école" },
+        "homework": { "title": "Devoirs" },
+        "bedtime": { "title": "Coucher sans cris" },
+        "transition": { "title": "Transition" },
+        "rough-day": { "title": "Journée pourrie" }
+      }
+    }
   },
   "barkley": {
     "title": "Programme Barkley",

--- a/apps/web/src/routes/_authenticated/routines/routines-page.tsx
+++ b/apps/web/src/routes/_authenticated/routines/routines-page.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 
 import {
   Plus,
@@ -14,6 +15,8 @@ import {
   Check,
   Timer,
   ChevronDown,
+  Heart,
+  X,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -52,13 +55,22 @@ import {
   useRoutines,
   useRoutineCompletions,
   useCreateRoutine,
+  useAdoptRoutineTemplate,
   useUpdateRoutine,
   useUpsertRoutineSteps,
   useDeleteRoutine,
   useCompleteStep,
   useUncompleteStep,
 } from "@/hooks/use-routines";
-import type { Routine, TimeOfDay } from "@focusflow/validators";
+import {
+  ROUTINE_TEMPLATES,
+  type Routine,
+  type RoutineTemplate,
+  type TimeOfDay,
+} from "@focusflow/validators";
+
+const PATIENCE_DISMISSED_KEY = "toko.routines.patience-dismissed";
+const TEMPLATES_INITIAL_VISIBLE = 5;
 
 const TIME_SLOTS: { value: TimeOfDay; iconKey: string }[] = [
   { value: "morning", iconKey: "morning" },
@@ -106,12 +118,50 @@ export default function RoutinesPage() {
     activeChildId ?? "",
     today,
   );
+  const adoptTemplate = useAdoptRoutineTemplate();
 
   const [routineDialogOpen, setRoutineDialogOpen] = useState(false);
   const [editingRoutine, setEditingRoutine] = useState<Routine | null>(null);
   const [stepEditorRoutine, setStepEditorRoutine] = useState<Routine | null>(
     null,
   );
+  const [templatesOpen, setTemplatesOpen] = useState(false);
+  const [patienceVisible, setPatienceVisible] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const dismissed = window.localStorage.getItem(PATIENCE_DISMISSED_KEY);
+    if (dismissed === "1") return;
+    if ((routines?.length ?? 0) > 0) setPatienceVisible(true);
+  }, [routines?.length]);
+
+  const dismissPatience = () => {
+    setPatienceVisible(false);
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(PATIENCE_DISMISSED_KEY, "1");
+    }
+  };
+
+  const handleAdoptTemplate = (template: RoutineTemplate) => {
+    if (!activeChildId) return;
+    adoptTemplate.mutate(
+      { childId: activeChildId, templateKey: template.key },
+      {
+        onSuccess: (created) => {
+          setTemplatesOpen(false);
+          toast.success(
+            t("routines.templates.adoptedToast", { name: template.title }),
+            {
+              action: {
+                label: t("routines.templates.personalize"),
+                onClick: () => setStepEditorRoutine(created),
+              },
+            },
+          );
+        },
+      },
+    );
+  };
 
   const completedStepIds = useMemo(
     () => new Set((completions ?? []).map((c) => c.stepId)),
@@ -150,12 +200,41 @@ export default function RoutinesPage() {
         title={t("routines.title")}
         description={t("routines.subtitle")}
         actions={
-          <Button onClick={openCreate} disabled={!activeChildId}>
-            <Plus className="mr-2 h-4 w-4" />
-            {t("routines.addButton")}
-          </Button>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              variant="outline"
+              onClick={() => setTemplatesOpen(true)}
+              disabled={!activeChildId}
+            >
+              <Sparkles className="mr-2 h-4 w-4" />
+              {t("routines.templates.fromTemplateButton")}
+            </Button>
+            <Button onClick={openCreate} disabled={!activeChildId}>
+              <Plus className="mr-2 h-4 w-4" />
+              {t("routines.addButton")}
+            </Button>
+          </div>
         }
       />
+
+      <Dialog
+        open={templatesOpen}
+        onOpenChange={(open) => setTemplatesOpen(open)}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{t("routines.templates.modalTitle")}</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            {t("routines.templates.modalIntro")}
+          </p>
+          <TemplatesList
+            onPick={handleAdoptTemplate}
+            disabled={adoptTemplate.isPending || !activeChildId}
+            initiallyExpanded
+          />
+        </DialogContent>
+      </Dialog>
 
       <Dialog
         open={routineDialogOpen}
@@ -208,23 +287,55 @@ export default function RoutinesPage() {
       ) : isLoading ? (
         <PageLoader />
       ) : !routines?.length ? (
-        <Card>
-          <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
-            <ListChecks className="h-10 w-10 text-muted-foreground/50" />
-            <p className="font-medium text-muted-foreground">
-              {t("routines.emptyTitle")}
-            </p>
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <h2 className="text-base font-semibold">
+              {t("routines.templates.startHereHeading")}
+            </h2>
             <p className="text-sm text-muted-foreground">
-              {t("routines.emptyBody")}
+              {t("routines.templates.startHereIntro")}
             </p>
-            <Button onClick={openCreate} className="mt-2">
-              <Plus className="mr-2 h-4 w-4" />
-              {t("routines.createFirst")}
-            </Button>
-          </CardContent>
-        </Card>
+          </div>
+          <TemplatesList
+            onPick={handleAdoptTemplate}
+            disabled={adoptTemplate.isPending}
+          />
+          <button
+            type="button"
+            onClick={openCreate}
+            className="block w-full rounded-lg border border-dashed py-4 text-center text-sm text-muted-foreground transition-colors hover:bg-accent"
+          >
+            <Plus className="mr-1 inline h-4 w-4" />
+            {t("routines.templates.createFromScratch")}
+          </button>
+        </div>
       ) : (
         <div className="space-y-6">
+          {patienceVisible && (
+            <div className="flex items-start gap-3 rounded-lg border border-primary/20 bg-primary/5 p-4">
+              <Heart
+                className="mt-0.5 h-5 w-5 shrink-0 text-primary"
+                aria-hidden="true"
+              />
+              <div className="flex-1 space-y-1">
+                <p className="text-sm font-semibold">
+                  {t("routines.templates.patienceTitle")}
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {t("routines.templates.patienceBody")}
+                </p>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={dismissPatience}
+                aria-label={t("routines.templates.patienceDismiss")}
+                className="h-8 w-8 shrink-0"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          )}
           <section className="space-y-3">
             <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
               {t("routines.todaySection")}
@@ -747,5 +858,92 @@ function StepsEditor({
         {upsert.isPending ? t("routines.saving") : t("routines.saveSteps")}
       </Button>
     </form>
+  );
+}
+
+function TemplatesList({
+  onPick,
+  disabled,
+  initiallyExpanded = false,
+}: {
+  onPick: (template: RoutineTemplate) => void;
+  disabled?: boolean;
+  initiallyExpanded?: boolean;
+}) {
+  const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(initiallyExpanded);
+
+  const visible = expanded
+    ? ROUTINE_TEMPLATES
+    : ROUTINE_TEMPLATES.slice(0, TEMPLATES_INITIAL_VISIBLE);
+  const hasMore = ROUTINE_TEMPLATES.length > TEMPLATES_INITIAL_VISIBLE;
+
+  return (
+    <div className="space-y-2">
+      <ul className="space-y-2">
+        {visible.map((template) => {
+          const stepCount = template.steps.length;
+          const totalMinutes = template.steps.reduce(
+            (acc, s) => acc + (s.durationMinutes ?? 0),
+            0,
+          );
+          const gentle = template.tone === "gentle";
+          return (
+            <li key={template.key}>
+              <button
+                type="button"
+                onClick={() => onPick(template)}
+                disabled={disabled}
+                className={`flex w-full items-center gap-3 rounded-xl border p-4 text-left transition-colors min-h-[64px] ${
+                  gentle
+                    ? "border-primary/40 bg-primary/5 hover:bg-primary/10"
+                    : "hover:bg-accent"
+                } disabled:cursor-not-allowed disabled:opacity-60`}
+              >
+                <span
+                  className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-background text-2xl shadow-sm"
+                  aria-hidden="true"
+                >
+                  {template.emoji}
+                </span>
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="font-semibold leading-tight">
+                    {t(`routines.templates.items.${template.key}.title`, {
+                      defaultValue: template.title,
+                    })}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {totalMinutes > 0
+                      ? t("routines.templates.metaWithTime", {
+                          steps: stepCount,
+                          minutes: totalMinutes,
+                        })
+                      : t("routines.templates.metaSteps", {
+                          steps: stepCount,
+                        })}
+                  </span>
+                  {gentle && (
+                    <span className="mt-1 text-xs text-primary">
+                      {t("routines.templates.gentleHint")}
+                    </span>
+                  )}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      {hasMore && !expanded && (
+        <button
+          type="button"
+          onClick={() => setExpanded(true)}
+          className="w-full text-center text-sm text-muted-foreground underline-offset-4 hover:underline"
+        >
+          {t("routines.templates.seeAll", {
+            count: ROUTINE_TEMPLATES.length,
+          })}
+        </button>
+      )}
+    </div>
   );
 }

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -16,6 +16,7 @@ export * from "./child-access";
 export * from "./child-invitation";
 export * from "./strength";
 export * from "./routine";
+export * from "./routine-templates";
 export * from "./care-pathway";
 export * from "./admin-document";
 export * from "./parent-mood";

--- a/packages/validators/src/routine-templates.ts
+++ b/packages/validators/src/routine-templates.ts
@@ -1,0 +1,125 @@
+import { z } from "zod";
+import { TIME_OF_DAY, type TimeOfDay } from "./routine";
+
+// Six ready-made templates surfaced on the Routines empty state so parents
+// don't face a blank page. Curated with a pediatric neurologist + child psy
+// + ADHD parent input — each step is a concrete observable action, sequence
+// is fixed, and counts stay in the 3–7 working-memory window (Barkley).
+//
+// Template content lives client+server side (no DB seed) so adopting a
+// template is a single transactional insert and templates can evolve with
+// app releases without migrations.
+
+export type RoutineTemplateStep = {
+  label: string;
+  emoji?: string;
+  durationMinutes?: number;
+};
+
+export type RoutineTemplate = {
+  key: string;
+  title: string;
+  emoji: string;
+  timeOfDay: TimeOfDay;
+  // Soft tag — surfaces visually so the "survival" template stands apart.
+  tone?: "default" | "gentle";
+  steps: RoutineTemplateStep[];
+};
+
+export const ROUTINE_TEMPLATES: readonly RoutineTemplate[] = [
+  {
+    key: "morning-school",
+    title: "Matin d'école",
+    emoji: "🌞",
+    timeOfDay: "morning",
+    steps: [
+      { label: "Se lever et boire un verre d'eau", emoji: "💧", durationMinutes: 5 },
+      { label: "Aller aux toilettes et se laver le visage", emoji: "🚿", durationMinutes: 5 },
+      { label: "S'habiller (vêtements préparés la veille)", emoji: "👕", durationMinutes: 5 },
+      { label: "Petit-déjeuner", emoji: "🥣", durationMinutes: 10 },
+      { label: "Brosser les dents", emoji: "🪥", durationMinutes: 2 },
+      { label: "Cartable et chaussures", emoji: "🎒", durationMinutes: 3 },
+    ],
+  },
+  {
+    key: "after-school",
+    title: "Retour d'école",
+    emoji: "🎒",
+    timeOfDay: "evening",
+    steps: [
+      { label: "Poser le cartable au même endroit", emoji: "📚", durationMinutes: 1 },
+      { label: "Goûter", emoji: "🍪", durationMinutes: 15 },
+      { label: "20 min de défoulement (bouger, jouer dehors)", emoji: "🤸", durationMinutes: 20 },
+      { label: "Vider le cahier de liaison avec le parent", emoji: "📒", durationMinutes: 5 },
+    ],
+  },
+  {
+    key: "homework",
+    title: "Devoirs",
+    emoji: "✏️",
+    timeOfDay: "evening",
+    steps: [
+      { label: "Sortir le matériel et lire la consigne à voix haute", emoji: "📖", durationMinutes: 3 },
+      { label: "Travail concentré (minuteur visible)", emoji: "⏱️", durationMinutes: 15 },
+      { label: "Pause active", emoji: "🤾", durationMinutes: 5 },
+      { label: "Relecture", emoji: "🔍", durationMinutes: 5 },
+      { label: "Ranger le matériel", emoji: "🗂️", durationMinutes: 2 },
+    ],
+  },
+  {
+    key: "bedtime",
+    title: "Coucher sans cris",
+    emoji: "🌙",
+    timeOfDay: "bedtime",
+    steps: [
+      { label: "Fin des écrans", emoji: "📵", durationMinutes: 1 },
+      { label: "Douche ou bain tiède", emoji: "🛁", durationMinutes: 10 },
+      { label: "Pyjama et brossage des dents", emoji: "🪥", durationMinutes: 5 },
+      { label: "Préparer les affaires du lendemain", emoji: "🎒", durationMinutes: 5 },
+      { label: "Lecture calme ou histoire", emoji: "📕", durationMinutes: 15 },
+      { label: "Câlin et lumière éteinte", emoji: "🤍", durationMinutes: 2 },
+    ],
+  },
+  {
+    key: "transition",
+    title: "Transition",
+    emoji: "🔄",
+    timeOfDay: "anytime",
+    steps: [
+      { label: "Annonce 5 min avant la fin", emoji: "🗣️", durationMinutes: 1 },
+      { label: "Ranger l'activité en cours", emoji: "🧺", durationMinutes: 3 },
+      { label: "Démarrer la suivante avec un signal", emoji: "🔔", durationMinutes: 1 },
+    ],
+  },
+  {
+    key: "rough-day",
+    title: "Journée pourrie",
+    emoji: "🫶",
+    timeOfDay: "anytime",
+    tone: "gentle",
+    steps: [
+      { label: "Médicament (si prescrit)", emoji: "💊" },
+      { label: "Manger quelque chose", emoji: "🍽️" },
+      { label: "Dormir", emoji: "😴" },
+    ],
+  },
+];
+
+export const ROUTINE_TEMPLATE_KEYS = ROUTINE_TEMPLATES.map((t) => t.key) as [
+  string,
+  ...string[],
+];
+
+export const adoptRoutineTemplateSchema = z.object({
+  childId: z.string().uuid(),
+  templateKey: z.enum(ROUTINE_TEMPLATE_KEYS),
+});
+
+export type AdoptRoutineTemplate = z.infer<typeof adoptRoutineTemplateSchema>;
+
+export function findRoutineTemplate(key: string): RoutineTemplate | undefined {
+  return ROUTINE_TEMPLATES.find((t) => t.key === key);
+}
+
+// Re-export for convenience to consumers that want both at once.
+export { TIME_OF_DAY };


### PR DESCRIPTION
Replace the blank-page empty state with curated templates (matin
d'école, retour d'école, devoirs, coucher, transition, journée
pourrie) so TDAH parents have a one-tap launchpad backed by clinical,
behavioural, and parent-experience input.

- Templates live in @focusflow/validators (no DB seed) so adoption is a
  single transactional insert and content can evolve with releases.
- POST /api/routines/from-template adopts a template into a child's
  routines with steps preserved.
- Empty state shows 5 vertical cards + "voir tous les modèles" toggle
  + "créer depuis zéro" link, matching the no-carousel/no-modal,
  cognitive-load-minimal pattern recommended for ADHD parents.
- Tap = instant adoption; toast offers "Personnaliser" which opens
  the existing steps editor — no upfront edit gate.
- Patience banner shown once after first routine warns that routines
  take 3–6 weeks to settle in (dismissable, persisted in localStorage).
- "Depuis un modèle" header button surfaces the same picker once the
  child already has routines.