### PR TITLE
fix(ui): make AlertDialog mobile-friendly with bottom-sheet pattern

### DIFF
--- a/apps/web/src/components/ui/alert-dialog.tsx
+++ b/apps/web/src/components/ui/alert-dialog.tsx
@@ -47,7 +47,14 @@ function AlertDialogContent({
       <DialogPrimitive.Popup
         data-slot="alert-dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] max-h-[calc(100dvh-2rem)] overflow-y-auto -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-background p-4 text-sm ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          "fixed z-50 grid gap-4 overflow-y-auto bg-background text-sm ring-1 ring-foreground/10 outline-none duration-100",
+          // Mobile: bottom sheet
+          "inset-x-0 bottom-0 top-auto w-full max-w-full max-h-[90dvh] rounded-t-2xl rounded-b-none p-4 pb-[max(1rem,env(safe-area-inset-bottom))]",
+          "data-open:animate-in data-open:fade-in-0 data-open:slide-in-from-bottom-8 data-closed:animate-out data-closed:fade-out-0 data-closed:slide-out-to-bottom-8",
+          // Desktop (sm+): centered modal (margin-auto centering avoids
+          // conflicts with animate-in transforms like zoom-in / slide-in)
+          "sm:inset-0 sm:m-auto sm:h-fit sm:w-full sm:max-w-sm sm:max-h-[calc(100dvh-2rem)] sm:rounded-xl sm:pb-4",
+          "sm:data-open:slide-in-from-bottom-0 sm:data-open:zoom-in-95 sm:data-closed:slide-out-to-bottom-0 sm:data-closed:zoom-out-95",
           className
         )}
         {...props}
@@ -79,7 +86,7 @@ function AlertDialogFooter({
     <div
       data-slot="alert-dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        "-mx-4 -mb-[max(1rem,env(safe-area-inset-bottom))] flex flex-col-reverse gap-2 border-t bg-muted/50 p-4 pb-[max(1rem,env(safe-area-inset-bottom))] sm:-mb-4 sm:flex-row sm:justify-end sm:rounded-b-xl sm:pb-4",
         className
       )}
       {...props}


### PR DESCRIPTION
The AlertDialog used transform-based centering (-translate-x/y-1/2) which
conflicted with the data-open:zoom-in-95 animation transform, causing the
dialog to render off-center on small viewports (cut off on the right).

Mirror the pattern from dialog.tsx: bottom-sheet on mobile, inset-0 m-auto
centering on sm+ (which avoids transform conflicts). Also adopt the same
safe-area-aware footer treatment for consistency with other dialogs.

https://claude.ai/code/session_01NmM2kibj2FjxStJZgnBMm9