### PR TITLE
feat(pwa): render update notification as bottom sheet on mobile

### DIFF
--- a/apps/web/src/components/shared/pwa-update-prompt.tsx
+++ b/apps/web/src/components/shared/pwa-update-prompt.tsx
@@ -2,11 +2,21 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { RefreshCw, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { usePwaUpdate } from "@/hooks/use-pwa-update";
 
 export function PWAUpdatePrompt() {
   const { t } = useTranslation();
   const { needRefresh, update, dismiss } = usePwaUpdate();
+  const isMobile = useIsMobile();
   const [updating, setUpdating] = useState(false);
 
   if (!needRefresh) return null;
@@ -20,12 +30,62 @@ export function PWAUpdatePrompt() {
     }
   };
 
+  if (isMobile) {
+    return (
+      <Sheet
+        open={needRefresh}
+        onOpenChange={(open) => {
+          if (!open && !updating) dismiss();
+        }}
+      >
+        <SheetContent
+          side="bottom"
+          showCloseButton={false}
+          aria-label={t("pwaUpdate.regionLabel")}
+        >
+          <SheetHeader>
+            <div className="flex items-start gap-3">
+              <span
+                aria-hidden="true"
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"
+              >
+                <RefreshCw className="h-4 w-4" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <SheetTitle>{t("pwaUpdate.title")}</SheetTitle>
+                <SheetDescription className="mt-1">
+                  {t("pwaUpdate.body")}
+                </SheetDescription>
+              </div>
+            </div>
+          </SheetHeader>
+          <SheetFooter>
+            <Button
+              onClick={handleUpdate}
+              disabled={updating}
+              aria-busy={updating}
+            >
+              {updating ? t("pwaUpdate.updating") : t("pwaUpdate.cta")}
+            </Button>
+            <Button
+              variant="ghost"
+              onClick={dismiss}
+              disabled={updating}
+            >
+              {t("pwaUpdate.later")}
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    );
+  }
+
   return (
     <div
       role="region"
       aria-live="polite"
       aria-label={t("pwaUpdate.regionLabel")}
-      className="fixed inset-x-0 bottom-0 z-50 px-4 pb-[calc(env(safe-area-inset-bottom)+10rem)] md:bottom-4 md:left-auto md:right-4 md:max-w-sm md:px-0 md:pb-0"
+      className="fixed bottom-4 right-4 z-50 max-w-sm"
     >
       <div className="rounded-xl border border-border/60 bg-background/95 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/85">
         <div className="flex items-start gap-3">


### PR DESCRIPTION
The PWA update prompt was a custom-styled floating card on every
viewport. On mobile this competed with the tab bar and crisis FAB for
attention without giving the user a clear modal focus. Switch to the
shared Sheet panel (side="bottom") on mobile so the update gets a
proper backdrop and predictable dismissal gesture, while desktop keeps
the discreet bottom-right floating card.