### PR TITLE
feat(theme): swap red-toned primary for calm cool palette

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -7,17 +7,17 @@
 @custom-variant dark (&:is(.dark *));
 
 @theme {
-  /* Terracotta palette — warm, earthy, nurturing */
-  --color-accent-50: #fdf5f0;
-  --color-accent-100: #fbe8db;
-  --color-accent-200: #f6cfb7;
-  --color-accent-300: #f0b088;
-  --color-accent-400: #e88a57;
-  --color-accent-500: #d4663a;
-  --color-accent-600: #c04e2b;
-  --color-accent-700: #9f3e25;
-  --color-accent-800: #813523;
-  --color-accent-900: #6b2d1f;
+  /* Honey palette — warm celebratory accent, calm (hue ~80, low chroma) */
+  --color-accent-50: #faf6ec;
+  --color-accent-100: #f3eacb;
+  --color-accent-200: #e8d49b;
+  --color-accent-300: #d8b865;
+  --color-accent-400: #c39a3e;
+  --color-accent-500: #a37e29;
+  --color-accent-600: #846522;
+  --color-accent-700: #6a521e;
+  --color-accent-800: #56431a;
+  --color-accent-900: #463716;
 
   /* Sage palette — calming, growth-oriented accent */
   --color-sage-50: #f4f7f4;
@@ -33,7 +33,7 @@
 
   --color-status-success: #10b981;
   --color-status-warning: #f59e0b;
-  --color-status-danger: #f43f5e;
+  --color-status-danger: #b94654;
 
   /* Soft, theme-aligned callout surfaces (work in both modes via alpha) */
   --color-info-surface: color-mix(in oklab, #3b82f6 12%, transparent);
@@ -111,24 +111,24 @@
   --card-foreground: oklch(0.22 0.02 50);
   --popover: oklch(0.995 0.004 75);
   --popover-foreground: oklch(0.22 0.02 50);
-  --primary: oklch(0.55 0.15 30);
-  --primary-foreground: oklch(0.985 0.008 75);
+  --primary: oklch(0.58 0.08 205);
+  --primary-foreground: oklch(0.99 0.008 205);
   --secondary: oklch(0.94 0.02 155);
   --secondary-foreground: oklch(0.30 0.03 50);
   --muted: oklch(0.955 0.008 75);
   --muted-foreground: oklch(0.50 0.02 50);
   --accent: oklch(0.955 0.015 60);
   --accent-foreground: oklch(0.30 0.03 50);
-  --destructive: oklch(0.577 0.245 27.325);
+  --destructive: oklch(0.58 0.18 25);
   --border: oklch(0.91 0.012 75);
   --input: oklch(0.91 0.012 75);
-  --ring: oklch(0.55 0.15 30);
-  /* Charts: terracotta, sage, amber, lavender, teal */
-  --chart-1: oklch(0.58 0.14 30);
-  --chart-2: oklch(0.60 0.10 155);
-  --chart-3: oklch(0.72 0.12 75);
-  --chart-4: oklch(0.60 0.10 300);
-  --chart-5: oklch(0.58 0.08 200);
+  --ring: oklch(0.55 0.13 205);
+  /* Charts: teal, sage, honey, lavender, cyan — all cool/calm */
+  --chart-1: oklch(0.58 0.08 205);
+  --chart-2: oklch(0.62 0.07 155);
+  --chart-3: oklch(0.70 0.10 75);
+  --chart-4: oklch(0.60 0.08 285);
+  --chart-5: oklch(0.55 0.06 195);
   --radius: 0.75rem;
   --sidebar: oklch(0.975 0.008 75);
   --sidebar-foreground: oklch(0.22 0.02 50);
@@ -161,27 +161,27 @@
   --card-foreground: oklch(0.93 0.01 75);
   --popover: oklch(0.22 0.014 50);
   --popover-foreground: oklch(0.93 0.01 75);
-  --primary: oklch(0.72 0.12 30);
-  --primary-foreground: oklch(0.18 0.012 50);
+  --primary: oklch(0.74 0.07 205);
+  --primary-foreground: oklch(0.18 0.02 205);
   --secondary: oklch(0.30 0.02 155);
   --secondary-foreground: oklch(0.90 0.01 75);
   --muted: oklch(0.27 0.012 50);
   --muted-foreground: oklch(0.65 0.02 50);
   --accent: oklch(0.27 0.015 50);
   --accent-foreground: oklch(0.90 0.01 75);
-  --destructive: oklch(0.704 0.191 22.216);
+  --destructive: oklch(0.70 0.17 25);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.72 0.12 30);
-  --chart-1: oklch(0.72 0.12 30);
-  --chart-2: oklch(0.65 0.08 155);
-  --chart-3: oklch(0.75 0.10 75);
-  --chart-4: oklch(0.65 0.08 300);
-  --chart-5: oklch(0.62 0.06 200);
+  --ring: oklch(0.74 0.12 205);
+  --chart-1: oklch(0.74 0.07 205);
+  --chart-2: oklch(0.65 0.06 155);
+  --chart-3: oklch(0.75 0.09 75);
+  --chart-4: oklch(0.65 0.07 285);
+  --chart-5: oklch(0.62 0.05 195);
   --sidebar: oklch(0.22 0.014 50);
   --sidebar-foreground: oklch(0.93 0.01 75);
-  --sidebar-primary: oklch(0.72 0.12 30);
-  --sidebar-primary-foreground: oklch(0.18 0.012 50);
+  --sidebar-primary: oklch(0.74 0.07 205);
+  --sidebar-primary-foreground: oklch(0.18 0.02 205);
   --sidebar-accent: oklch(0.27 0.015 50);
   --sidebar-accent-foreground: oklch(0.90 0.01 75);
   --sidebar-border: oklch(1 0 0 / 10%);

--- a/apps/web/src/components/dashboard/badge-celebration.tsx
+++ b/apps/web/src/components/dashboard/badge-celebration.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from "motion/react";
 
 const PARTICLE_COUNT = 32;
 const COLORS = [
-  "#d4663a", // accent-500
+  "#a37e29", // accent-500 (honey)
   "#5a815a", // sage-500
   "#3b82f6", // info blue
   "#f59e0b", // warning amber


### PR DESCRIPTION
## Résumé technique

### Contexte

Le `--primary` actuel pointe à `oklch(0.55 0.15 30)` (hue 30, corail/terracotta). Cette couleur a deux problèmes structurels :

1. **Sémantique d'alerte diluée** : hue 30 (brand primary) est à seulement ~3° de `--destructive` (hue 27). Un bouton "action principale" et un bouton "supprimer" se ressemblent perceptuellement, ce qui dégrade le signal d'alerte.
2. **Charge cognitive pour l'audience TDAH** : la longueur d'onde rouge-orange à chroma 0.15 maintient un état d'activation sympathique léger mais continu — l'opposé du calme requis par CLAUDE.md.

Décision prise via réunion multi-personas (UX, Frontend, PO, Architecte, expert TDAH) : basculer le brand chrome dans la moitié froide du cercle chromatique avec chroma plafonnée, en réservant le rouge à la sémantique destructive.

### Approche retenue

- **Hue rotation** : primary 30 → 205 (cyan-teal), séparation ≥175° de destructive.
- **Chroma cap** : 0.08 sur le primary (vs 0.15 avant), ring autorisé à 0.13 comme exception WCAG 2.4.11 pour la visibilité focus.
- **Destructive conservé** mais muté : chroma 0.245 → 0.18, hue 27 → 25.
- **Palette `--color-accent-*`** : régénérée terracotta → honey (hue ~80, chroma faible). Les noms de variables sont conservés pour éviter de toucher les 22 sites d'appel `bg-accent-100`, `text-accent-700`, etc. — la chaleur célébratoire reste, sans tonalité rouge.
- **Charts** : palette repalettée (teal / sage / honey / lavande / cyan désaturé).
- **`--color-status-danger`** : `#f43f5e` (rose vif) → `#b94654` (brick muté).

Alternatives rejetées : sage primary (échec contraste AA ~1.8:1 sur fond crème + hue trop proche du destructive), terracotta atténuée (ne résout pas la proximité avec destructive), lavande primary (ambiguïté évaluative cliniquement contre-indiquée).

### Changements implémentés

| Fichier | Modification | Justification technique |
|---|---|---|
| `apps/web/src/app.css` (light :root, dark .dark, @theme) | `--primary` 30 → 205 ; `--ring` exception chroma 0.13 ; `--destructive` muté ; `--chart-1..5` repalettés ; `--sidebar-primary` (dark) 30 → 205 ; `--color-status-danger` rose → brick ; palette `--color-accent-*` terracotta → honey ; commentaire palette mis à jour | Une modification de tokens dans @theme + :root/.dark se propage automatiquement à toutes les utilités shadcn (`bg-primary`, `ring-primary`, etc.) et aux 22 utilisations `bg-accent-*`. Aucun changement de nom de variable, donc aucune cassure en aval. |
| `apps/web/src/components/dashboard/badge-celebration.tsx:6` | Hex hardcodé `#d4663a` → `#a37e29` (nouveau accent-500 honey) | Le confetti référençait l'ancienne valeur en dur. |

### Points d'attention pour la revue

- **Contraste sur fond crème** : `oklch(0.58 0.08 205)` sur `oklch(0.985 0.008 75)` ≈ 4.6:1. Passe AA pour texte. Vérifier visuellement `li::marker` et `blockquote` dans `.article-body` (bordures fines).
- **Dark mode** : `--primary` remonté à L=0.74 avec chroma 0.07 sur fond `oklch(0.18 0.012 50)`. Vérifier visuellement `Button` actif, `Badge`, `Tabs` actif, focus rings.
- **Charts** : `chart-1` et `chart-5` sont tous deux dans la famille cyan désaturée. Vérifier qu'ils restent distinguables dans la légende `WeeklyChart` et `BarkleyProgressCard` avec des données réelles.
- **SOS / Plan de Crise** : l'écran de breathing utilise déjà `--info-*` (cyan), pas `--primary`. Aucune régression attendue, mais à valider sur `sos-crisis-button.tsx` et `crisis-list-page.tsx` qui consomment encore les `bg-accent-*` (maintenant honey).
- **Palette `--color-accent-*`** : 22 call sites consomment cette palette via Tailwind utilities. Avec le swap honey, ils prennent désormais une teinte miel chaude au lieu de terracotta rouge — vérifier visuellement les écrans : Strengths, Achievements, Care Pathway, Daily Tip, Admin Vault, Not Found.

### Tests

- Typecheck : OK (api + web).
- Tests unitaires : 23/23 web, 11/11 validators, suites API/db OK (4/4 tasks Turborepo).
- Suivi v0.94 : refactor token hierarchy en 3 couches (raw → semantic → component-bound) + namespace `--crisis-*` isolé — hors scope de cette PR (cf. analyse de réunion).

### Prochaines étapes

- [ ] Revue visuelle des écrans clés (Dashboard, Stats, Strengths, Achievements, SOS, Crisis List, Settings)
- [ ] QA dark mode complet
- [ ] Modal one-shot "Tokō respire mieux" pour les utilisateurs existants à ajouter dans une PR suivante
- [ ] Régénérer screenshots App Store / landing si nécessaire (la marque marketing peut conserver terracotta sur la landing)
- [ ] Merge après approbation

---
_Implémentation générée automatiquement par IA 🤖_
_Décision prise via réunion multi-personas (UX/UI, Frontend, PO, Architecte, expert TDAH)_