### PR TITLE
fix(sos): make crisis overlay opaque in dark mode

### DIFF
--- a/apps/web/src/components/shared/sos-crisis-button.tsx
+++ b/apps/web/src/components/shared/sos-crisis-button.tsx
@@ -90,7 +90,7 @@ function SOSOverlay({
       role="dialog"
       aria-modal="true"
       aria-label={t("sos.dialogLabel")}
-      className="pointer-events-auto fixed inset-0 z-50 flex flex-col bg-gradient-to-b from-sage-50 via-background to-accent-50 pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)] dark:from-sage-900/30 dark:via-background dark:to-accent-900/30"
+      className="pointer-events-auto fixed inset-0 z-50 flex flex-col bg-background bg-gradient-to-b from-sage-50 via-background to-accent-50 pb-[env(safe-area-inset-bottom)] pt-[env(safe-area-inset-top)] dark:from-sage-900 dark:via-background dark:to-accent-900"
     >
       <div className="flex items-center justify-between px-4 pt-4 sm:px-6">
         {technique ? (


### PR DESCRIPTION
The SOS overlay used 30%-opacity gradient stops on top and bottom in
dark mode with no solid background, so the underlying page bled
through. Drop the opacity on the gradient stops and add a solid
bg-background base so the overlay fully covers the page.