### PR TITLE
feat(install-prompt): show as bottom sheet on mobile

### DIFF
--- a/apps/web/src/components/shared/install-prompt.tsx
+++ b/apps/web/src/components/shared/install-prompt.tsx
@@ -1,19 +1,91 @@
 import { useTranslation } from "react-i18next";
 import { Download, Share, Plus, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { useIsMobile } from "@/hooks/use-mobile";
 import { useInstallPrompt } from "@/hooks/use-install-prompt";
 
 export function InstallPrompt() {
   const { t } = useTranslation();
   const { canPrompt, mode, install, dismiss } = useInstallPrompt();
+  const isMobile = useIsMobile();
 
   if (!canPrompt) return null;
+
+  const bodyText = mode === "ios" ? t("install.iosBody") : t("install.body");
+  const secondaryLabel =
+    mode === "ios" ? t("install.gotIt") : t("install.later");
+
+  const iosSteps = mode === "ios" && (
+    <ol className="mt-2 space-y-1 text-xs text-muted-foreground">
+      <li className="flex items-center gap-1.5">
+        <Share className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span>{t("install.iosStep1")}</span>
+      </li>
+      <li className="flex items-center gap-1.5">
+        <Plus className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        <span>{t("install.iosStep2")}</span>
+      </li>
+    </ol>
+  );
+
+  if (isMobile) {
+    return (
+      <Sheet
+        open={canPrompt}
+        onOpenChange={(open) => {
+          if (!open) dismiss();
+        }}
+      >
+        <SheetContent
+          side="bottom"
+          showCloseButton={false}
+          aria-label={t("install.regionLabel")}
+        >
+          <SheetHeader>
+            <div className="flex items-start gap-3">
+              <span
+                aria-hidden="true"
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary"
+              >
+                <Download className="h-4 w-4" />
+              </span>
+              <div className="min-w-0 flex-1">
+                <SheetTitle>{t("install.title")}</SheetTitle>
+                <SheetDescription className="mt-1">
+                  {bodyText}
+                </SheetDescription>
+                {iosSteps}
+              </div>
+            </div>
+          </SheetHeader>
+          <SheetFooter>
+            {mode === "native" && (
+              <Button onClick={() => void install()}>
+                {t("install.cta")}
+              </Button>
+            )}
+            <Button variant="ghost" onClick={dismiss}>
+              {secondaryLabel}
+            </Button>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+    );
+  }
 
   return (
     <div
       role="region"
       aria-label={t("install.regionLabel")}
-      className="fixed inset-x-0 bottom-0 z-50 px-4 pb-[calc(env(safe-area-inset-bottom)+5.5rem)] md:bottom-4 md:left-auto md:right-4 md:max-w-sm md:px-0 md:pb-0"
+      className="fixed bottom-4 right-4 z-50 max-w-sm"
     >
       <div className="rounded-xl border border-border/60 bg-background/95 p-4 shadow-lg backdrop-blur supports-[backdrop-filter]:bg-background/85">
         <div className="flex items-start gap-3">
@@ -27,22 +99,9 @@ export function InstallPrompt() {
             <p className="font-heading text-sm font-medium">
               {t("install.title")}
             </p>
-            <p className="mt-1 text-xs text-muted-foreground">
-              {mode === "ios" ? t("install.iosBody") : t("install.body")}
-            </p>
+            <p className="mt-1 text-xs text-muted-foreground">{bodyText}</p>
 
-            {mode === "ios" && (
-              <ol className="mt-2 space-y-1 text-xs text-muted-foreground">
-                <li className="flex items-center gap-1.5">
-                  <Share className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-                  <span>{t("install.iosStep1")}</span>
-                </li>
-                <li className="flex items-center gap-1.5">
-                  <Plus className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-                  <span>{t("install.iosStep2")}</span>
-                </li>
-              </ol>
-            )}
+            {iosSteps}
 
             <div className="mt-3 flex items-center gap-2">
               {mode === "native" && (
@@ -51,7 +110,7 @@ export function InstallPrompt() {
                 </Button>
               )}
               <Button size="sm" variant="ghost" onClick={dismiss}>
-                {mode === "ios" ? t("install.gotIt") : t("install.later")}
+                {secondaryLabel}
               </Button>
             </div>
           </div>


### PR DESCRIPTION
Mirrors the pattern used by PWAUpdatePrompt: a Sheet (side="bottom")
on mobile, floating card on desktop. The 30-day dismissal TTL from
useInstallPrompt is preserved — closing the sheet (backdrop tap,
"Plus tard", or "J'ai compris") counts as a dismissal.

https://claude.ai/code/session_01Fu2hT95XRFWxJ6yPkEV7np