### PR TITLE
feat(auth): add forgot password flow

### DIFF
--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -2,6 +2,8 @@ import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "@focusflow/db";
 import { env } from "./env";
+import { sendEmail } from "./email";
+import { resetPasswordEmail } from "./email-templates";
 
 const devWebOrigins = ["http://localhost:5173", "http://localhost:5176"] as const
 
@@ -14,6 +16,17 @@ export const auth = betterAuth({
   ],
   emailAndPassword: {
     enabled: true,
+    // Better Auth appends ?token=... and uses this URL as the redirect target
+    // emailed to the user. Pointed at the SPA route so the reset form opens
+    // directly without a server round-trip.
+    resetPasswordTokenExpiresIn: 60 * 60, // 1h
+    sendResetPassword: async ({ user, token }) => {
+      // Email link must hit the SPA, not the API host (Better Auth baseURL).
+      const resetUrl = new URL("/reset-password", env.APP_URL);
+      resetUrl.searchParams.set("token", token);
+      const { subject, html } = resetPasswordEmail({ url: resetUrl.toString() });
+      await sendEmail({ to: user.email, subject, html });
+    },
   },
   socialProviders: {
     google: {

--- a/apps/api/src/lib/email-templates.ts
+++ b/apps/api/src/lib/email-templates.ts
@@ -211,6 +211,38 @@ export function trialEndingReminderTemplate(parentName: string): {
   };
 }
 
+export function resetPasswordEmail({ url }: { url: string }): {
+  subject: string;
+  html: string;
+} {
+  return {
+    subject: "Tokō — Réinitialise ton mot de passe",
+    html: layout(`
+      <p style="color: #44403c; font-size: 16px;">Bonjour,</p>
+      <p style="color: #57534e;">
+        Quelqu'un (toi, on l'espère) a demandé à réinitialiser le mot de passe
+        de ton compte Tokō. Clique sur le bouton ci-dessous pour en choisir un
+        nouveau. Ce lien est valable 1&nbsp;heure.
+      </p>
+      <p style="margin: 24px 0;">
+        <a href="${url}" style="display: inline-block; background: #7c6a58; color: #fff; text-decoration: none; padding: 12px 20px; border-radius: 8px; font-weight: 500;">
+          Choisir un nouveau mot de passe
+        </a>
+      </p>
+      <p style="color: #78716c; font-size: 13px;">
+        Si le bouton ne fonctionne pas, copie ce lien dans ton navigateur&nbsp;:
+      </p>
+      <p style="color: #78716c; font-size: 13px; word-break: break-all;">
+        ${url}
+      </p>
+      <p style="color: #78716c; font-size: 14px; margin-top: 20px;">
+        Si tu n'as rien demandé, ignore simplement ce message — ton mot de
+        passe ne changera pas.
+      </p>
+    `),
+  };
+}
+
 function escapeHtml(s: string): string {
   return s
     .replace(/&/g, "&amp;")

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -10,6 +10,21 @@ export const authClient = createAuthClient({
 
 export const { useSession, signIn, signUp, signOut } = authClient;
 
+// Better Auth's React client exposes these helpers when emailAndPassword is
+// enabled on the server, but `ReturnType<typeof createAuthClient>` collapses
+// the generic so they don't surface on the cast type. Re-export through a
+// loose-typed wrapper.
+type ResetPasswordResult = { error?: { message?: string } | null };
+export const forgetPassword = (args: { email: string; redirectTo?: string }) =>
+  (authClient as unknown as {
+    forgetPassword: (a: typeof args) => Promise<ResetPasswordResult>;
+  }).forgetPassword(args);
+
+export const resetPassword = (args: { newPassword: string; token: string }) =>
+  (authClient as unknown as {
+    resetPassword: (a: typeof args) => Promise<ResetPasswordResult>;
+  }).resetPassword(args);
+
 // Deduplicates getSession calls during rapid navigation (beforeLoad fires on every route change).
 // Returns cached result if fetched within the last 5 seconds.
 let _sessionCache: { data: unknown; ts: number } | null = null;

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -208,7 +208,25 @@
     "googleLoading": "Signing in...",
     "errorInvalid": "Invalid credentials",
     "errorRegister": "Registration error",
-    "backToHome": "Home"
+    "backToHome": "Home",
+    "forgotPassword": "Forgot password?"
+  },
+  "forgotPassword": {
+    "title": "Forgot password",
+    "intro": "Enter your email and we'll send you a link to choose a new password.",
+    "submit": "Send link",
+    "submitting": "Sending…",
+    "confirmation": "If an account exists for this address, an email is on its way. Check your inbox (and spam folder).",
+    "backToLogin": "Back to sign in"
+  },
+  "resetPassword": {
+    "title": "New password",
+    "newPassword": "Password",
+    "submit": "Save",
+    "submitting": "Saving…",
+    "success": "Done. Sign in with your new password.",
+    "goToLogin": "Sign in",
+    "errorInvalid": "Link expired or invalid. Request a new one."
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -208,7 +208,25 @@
     "googleLoading": "Connexion...",
     "errorInvalid": "Identifiants incorrects",
     "errorRegister": "Erreur lors de l'inscription",
-    "backToHome": "Accueil"
+    "backToHome": "Accueil",
+    "forgotPassword": "Mot de passe oublié ?"
+  },
+  "forgotPassword": {
+    "title": "Mot de passe oublié",
+    "intro": "Entre ton email, on t'envoie un lien pour en choisir un nouveau.",
+    "submit": "Envoyer le lien",
+    "submitting": "Envoi…",
+    "confirmation": "Si un compte existe pour cette adresse, un email est parti. Vérifie ta boîte (et les spams).",
+    "backToLogin": "Retour à la connexion"
+  },
+  "resetPassword": {
+    "title": "Nouveau mot de passe",
+    "newPassword": "Mot de passe",
+    "submit": "Enregistrer",
+    "submitting": "Enregistrement…",
+    "success": "C'est fait. Connecte-toi avec ton nouveau mot de passe.",
+    "goToLogin": "Se connecter",
+    "errorInvalid": "Lien expiré ou invalide. Demande un nouveau lien."
   },
   "nav": {
     "dashboard": "Tableau de bord",

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -9,8 +9,10 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as MentionsLegalesRouteImport } from './routes/mentions-legales'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as ContactRouteImport } from './routes/contact'
 import { Route as ConfidentialiteRouteImport } from './routes/confidentialite'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
@@ -39,6 +41,11 @@ import { Route as AuthenticatedAccountIndexRouteImport } from './routes/_authent
 import { Route as AuthenticatedConnaissancesSlugRouteImport } from './routes/_authenticated/connaissances/$slug'
 import { Route as AuthenticatedBarkleyFormationStepNumberRouteImport } from './routes/_authenticated/barkley/formation/$stepNumber'
 
+const ResetPasswordRoute = ResetPasswordRouteImport.update({
+  id: '/reset-password',
+  path: '/reset-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const MentionsLegalesRoute = MentionsLegalesRouteImport.update({
   id: '/mentions-legales',
   path: '/mentions-legales',
@@ -47,6 +54,11 @@ const MentionsLegalesRoute = MentionsLegalesRouteImport.update({
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
+  id: '/forgot-password',
+  path: '/forgot-password',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ContactRoute = ContactRouteImport.update({
@@ -206,8 +218,10 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/confidentialite': typeof ConfidentialiteRoute
   '/contact': typeof ContactRoute
+  '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/mentions-legales': typeof MentionsLegalesRoute
+  '/reset-password': typeof ResetPasswordRoute
   '/invite/$token': typeof InviteTokenRoute
   '/ressources/$slug': typeof RessourcesSlugRoute
   '/ressources/plan-de-crise': typeof RessourcesPlanDeCriseRoute
@@ -236,8 +250,10 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/confidentialite': typeof ConfidentialiteRoute
   '/contact': typeof ContactRoute
+  '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/mentions-legales': typeof MentionsLegalesRoute
+  '/reset-password': typeof ResetPasswordRoute
   '/invite/$token': typeof InviteTokenRoute
   '/ressources/$slug': typeof RessourcesSlugRoute
   '/ressources/plan-de-crise': typeof RessourcesPlanDeCriseRoute
@@ -268,8 +284,10 @@ export interface FileRoutesById {
   '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/confidentialite': typeof ConfidentialiteRoute
   '/contact': typeof ContactRoute
+  '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/mentions-legales': typeof MentionsLegalesRoute
+  '/reset-password': typeof ResetPasswordRoute
   '/invite/$token': typeof InviteTokenRoute
   '/ressources/$slug': typeof RessourcesSlugRoute
   '/ressources/plan-de-crise': typeof RessourcesPlanDeCriseRoute
@@ -300,8 +318,10 @@ export interface FileRouteTypes {
     | '/'
     | '/confidentialite'
     | '/contact'
+    | '/forgot-password'
     | '/login'
     | '/mentions-legales'
+    | '/reset-password'
     | '/invite/$token'
     | '/ressources/$slug'
     | '/ressources/plan-de-crise'
@@ -330,8 +350,10 @@ export interface FileRouteTypes {
     | '/'
     | '/confidentialite'
     | '/contact'
+    | '/forgot-password'
     | '/login'
     | '/mentions-legales'
+    | '/reset-password'
     | '/invite/$token'
     | '/ressources/$slug'
     | '/ressources/plan-de-crise'
@@ -361,8 +383,10 @@ export interface FileRouteTypes {
     | '/_authenticated'
     | '/confidentialite'
     | '/contact'
+    | '/forgot-password'
     | '/login'
     | '/mentions-legales'
+    | '/reset-password'
     | '/invite/$token'
     | '/ressources/$slug'
     | '/ressources/plan-de-crise'
@@ -393,8 +417,10 @@ export interface RootRouteChildren {
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   ConfidentialiteRoute: typeof ConfidentialiteRoute
   ContactRoute: typeof ContactRoute
+  ForgotPasswordRoute: typeof ForgotPasswordRoute
   LoginRoute: typeof LoginRoute
   MentionsLegalesRoute: typeof MentionsLegalesRoute
+  ResetPasswordRoute: typeof ResetPasswordRoute
   InviteTokenRoute: typeof InviteTokenRoute
   RessourcesSlugRoute: typeof RessourcesSlugRoute
   RessourcesPlanDeCriseRoute: typeof RessourcesPlanDeCriseRoute
@@ -403,6 +429,13 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/reset-password': {
+      id: '/reset-password'
+      path: '/reset-password'
+      fullPath: '/reset-password'
+      preLoaderRoute: typeof ResetPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/mentions-legales': {
       id: '/mentions-legales'
       path: '/mentions-legales'
@@ -415,6 +448,13 @@ declare module '@tanstack/react-router' {
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/forgot-password': {
+      id: '/forgot-password'
+      path: '/forgot-password'
+      fullPath: '/forgot-password'
+      preLoaderRoute: typeof ForgotPasswordRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/contact': {
@@ -663,8 +703,10 @@ const rootRouteChildren: RootRouteChildren = {
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
   ConfidentialiteRoute: ConfidentialiteRoute,
   ContactRoute: ContactRoute,
+  ForgotPasswordRoute: ForgotPasswordRoute,
   LoginRoute: LoginRoute,
   MentionsLegalesRoute: MentionsLegalesRoute,
+  ResetPasswordRoute: ResetPasswordRoute,
   InviteTokenRoute: InviteTokenRoute,
   RessourcesSlugRoute: RessourcesSlugRoute,
   RessourcesPlanDeCriseRoute: RessourcesPlanDeCriseRoute,

--- a/apps/web/src/routes/forgot-password.tsx
+++ b/apps/web/src/routes/forgot-password.tsx
@@ -1,0 +1,110 @@
+import { useState } from "react";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { ArrowLeft, Heart } from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { forgetPassword } from "@/lib/auth-client";
+
+export const Route = createFileRoute("/forgot-password")({
+  component: ForgotPasswordPage,
+});
+
+function ForgotPasswordPage() {
+  const { t } = useTranslation();
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    // Better Auth always returns the same response whether the account
+    // exists or not (anti-enumeration), so we don't surface the result.
+    await forgetPassword({ email, redirectTo: "/reset-password" });
+    setSent(true);
+    setLoading(false);
+  };
+
+  return (
+    <div className="relative flex min-h-dvh items-center justify-center bg-background px-4">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_60%_40%_at_50%_40%,oklch(0.85_0.08_30_/_0.08),transparent)]" />
+
+      <Link
+        to="/login"
+        className="absolute left-4 top-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {t("forgotPassword.backToLogin")}
+      </Link>
+
+      <div className="relative w-full max-w-md space-y-8">
+        <div className="text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-md shadow-primary/20">
+            <Heart className="h-6 w-6" />
+          </div>
+          <h1 className="font-heading text-3xl font-semibold tracking-tight text-foreground">
+            Toko
+          </h1>
+        </div>
+
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle className="font-heading text-lg font-semibold">
+              {t("forgotPassword.title")}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {sent ? (
+              <div className="space-y-4">
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  {t("forgotPassword.confirmation")}
+                </p>
+                <Link
+                  to="/login"
+                  className={buttonVariants({
+                    variant: "outline",
+                    className: "w-full",
+                  })}
+                >
+                  {t("forgotPassword.backToLogin")}
+                </Link>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  {t("forgotPassword.intro")}
+                </p>
+                <div className="space-y-2">
+                  <Label htmlFor="forgot-email">{t("login.email")}</Label>
+                  <Input
+                    id="forgot-email"
+                    type="email"
+                    inputMode="email"
+                    autoComplete="email"
+                    autoFocus
+                    placeholder="parent@example.com"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                  />
+                </div>
+                <Button
+                  type="submit"
+                  className="w-full shadow-sm shadow-primary/20"
+                  disabled={loading}
+                >
+                  {loading
+                    ? t("forgotPassword.submitting")
+                    : t("forgotPassword.submit")}
+                </Button>
+              </form>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -115,7 +115,15 @@ function LoginForm() {
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="login-password">{t("login.password")}</Label>
+            <div className="flex items-baseline justify-between gap-2">
+              <Label htmlFor="login-password">{t("login.password")}</Label>
+              <Link
+                to="/forgot-password"
+                className="text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+              >
+                {t("login.forgotPassword")}
+              </Link>
+            </div>
             <Input
               id="login-password"
               type="password"

--- a/apps/web/src/routes/reset-password.tsx
+++ b/apps/web/src/routes/reset-password.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+import { createFileRoute, Link, redirect } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { ArrowLeft, Heart } from "lucide-react";
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { resetPassword } from "@/lib/auth-client";
+
+type ResetPasswordSearch = { token: string };
+
+export const Route = createFileRoute("/reset-password")({
+  validateSearch: (search: Record<string, unknown>): ResetPasswordSearch => {
+    const token = typeof search.token === "string" ? search.token : "";
+    return { token };
+  },
+  beforeLoad: ({ search }) => {
+    if (!search.token) {
+      throw redirect({ to: "/login" });
+    }
+  },
+  component: ResetPasswordPage,
+});
+
+function ResetPasswordPage() {
+  const { t } = useTranslation();
+  const { token } = Route.useSearch();
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [done, setDone] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token) return;
+    setError("");
+    setLoading(true);
+
+    const result = await resetPassword({ newPassword: password, token });
+
+    if (result.error) {
+      setError(result.error.message ?? t("resetPassword.errorInvalid"));
+      setLoading(false);
+      return;
+    }
+
+    setDone(true);
+    setLoading(false);
+  };
+
+  return (
+    <div className="relative flex min-h-dvh items-center justify-center bg-background px-4">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_60%_40%_at_50%_40%,oklch(0.85_0.08_30_/_0.08),transparent)]" />
+
+      <Link
+        to="/login"
+        className="absolute left-4 top-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {t("forgotPassword.backToLogin")}
+      </Link>
+
+      <div className="relative w-full max-w-md space-y-8">
+        <div className="text-center">
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-2xl bg-primary text-primary-foreground shadow-md shadow-primary/20">
+            <Heart className="h-6 w-6" />
+          </div>
+          <h1 className="font-heading text-3xl font-semibold tracking-tight text-foreground">
+            Toko
+          </h1>
+        </div>
+
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle className="font-heading text-lg font-semibold">
+              {t("resetPassword.title")}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {done ? (
+              <div className="space-y-4">
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  {t("resetPassword.success")}
+                </p>
+                <Link
+                  to="/login"
+                  className={buttonVariants({
+                    className: "w-full shadow-sm shadow-primary/20",
+                  })}
+                >
+                  {t("resetPassword.goToLogin")}
+                </Link>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="reset-password">
+                    {t("resetPassword.newPassword")}
+                  </Label>
+                  <Input
+                    id="reset-password"
+                    type="password"
+                    autoComplete="new-password"
+                    autoFocus
+                    placeholder={t("login.passwordPlaceholder")}
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    minLength={8}
+                    required
+                  />
+                </div>
+                {error && (
+                  <p className="text-sm text-destructive">{error}</p>
+                )}
+                <Button
+                  type="submit"
+                  className="w-full shadow-sm shadow-primary/20"
+                  disabled={loading}
+                >
+                  {loading
+                    ? t("resetPassword.submitting")
+                    : t("resetPassword.submit")}
+                </Button>
+              </form>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/packages/validators/src/account.ts
+++ b/packages/validators/src/account.ts
@@ -5,3 +5,16 @@ export const deleteAccountSchema = z.object({
 });
 
 export type DeleteAccount = z.infer<typeof deleteAccountSchema>;
+
+export const forgotPasswordSchema = z.object({
+  email: z.string().email(),
+});
+
+export type ForgotPassword = z.infer<typeof forgotPasswordSchema>;
+
+export const resetPasswordSchema = z.object({
+  token: z.string().min(1),
+  password: z.string().min(8),
+});
+
+export type ResetPassword = z.infer<typeof resetPasswordSchema>;


### PR DESCRIPTION
Wire Better Auth's sendResetPassword callback to send a Resend email
pointing at a new /reset-password SPA route, and surface "Mot de passe
oublié ?" on the login screen. Anti-enumeration is handled by Better
Auth (identical response whether the account exists or not); rate limit
on /forget-password was already configured (5/60s).

- API: emailAndPassword.sendResetPassword + resetPasswordEmail template
  (1h token expiry, link built against APP_URL so it hits the SPA).
- Web: /forgot-password and /reset-password public routes, forgetPassword
  and resetPassword helpers re-exported from auth-client.
- Validators: forgotPasswordSchema, resetPasswordSchema.
- i18n: French + English keys for both screens.

https://claude.ai/code/session_01YK4Td9QeAtJuD9AaXxkL5M