### PR TITLE
feat(billing): scope portal sessions to this app's Stripe configuration

### DIFF
--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -12,6 +12,12 @@ const envSchema = z
     CORS_ORIGIN: z.string().optional(),
     STRIPE_SECRET_KEY: z.string().min(1, "STRIPE_SECRET_KEY is required"),
     STRIPE_WEBHOOK_SECRET: z.string().min(1, "STRIPE_WEBHOOK_SECRET is required"),
+    // Stripe Billing Portal configuration ID (bpc_…). When set, portal
+    // sessions are created with this configuration so the customer can
+    // only switch between Tokō Premium prices, not toward products of
+    // other apps sharing the same Stripe account. Empty falls back to
+    // the account's default configuration.
+    STRIPE_PORTAL_CONFIG_ID: z.string().optional(),
     GOOGLE_CLIENT_ID: z.string().default("placeholder"),
     GOOGLE_CLIENT_SECRET: z.string().default("placeholder"),
     NODE_ENV: z

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -243,6 +243,12 @@ billingRoutes.post("/portal", authMiddleware, portalLimiter, async (c) => {
   const session = await getStripe().billingPortal.sessions.create({
     customer: sub.stripeCustomerId,
     return_url: `${env.CORS_ORIGIN || "http://localhost:5173"}/account`,
+    // Restricts the portal to Tokō Premium products. Without a config
+    // a customer would see WAWPTN / The Box / CoproPilot prices in the
+    // "switch plan" picker — they share the same Stripe account.
+    ...(env.STRIPE_PORTAL_CONFIG_ID
+      ? { configuration: env.STRIPE_PORTAL_CONFIG_ID }
+      : {}),
   });
 
   return c.json({ url: session.url });


### PR DESCRIPTION
## Context

The four apps (Tokō, WAWPTN, The Box, CoproPilot) share a single Stripe account. Before this PR, `stripe.billingPortal.sessions.create()` was called without a `configuration` parameter, so the portal fell back to the account default — which lists every active product on the account. A logged-in customer could open "Manage subscription" and see prices for the three other apps in the "switch plan" picker.

Worst case: a WAWPTN customer (3€/mo) accidentally switches to CoproPilot Entreprise (749€/year), the webhook receives a `customer.subscription.updated` for an unrelated product, and the user state in DB ends up inconsistent.

## What this PR does

- Adds a `STRIPE_PORTAL_CONFIG_ID` env var.
- When set, it is passed as the `configuration` argument to every `billingPortal.sessions.create()` call → the portal only lists this app's products.
- When empty, behaviour is unchanged (falls back to the account default), so the change is back-compat safe.

## Stripe-side state

The four portal configurations have already been provisioned in Stripe live via the API and are pinned to each app's products only. The matching `bpc_…` IDs are already set in the prod `.env` of each app.

## Test plan

- [ ] Verify backend builds and existing tests still pass
- [ ] After deploy: open Manage Subscription as a customer, confirm only this app's prices appear in the picker
- [ ] Confirm cancellation / payment method update still work
- [ ] Confirm no regression for customers that have no active subscription (route still 400s cleanly)