### PR TITLE
fix(i18n): reword forgot-password copy to satisfy rule B7

### DIFF
--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -209,10 +209,10 @@
     "errorInvalid": "Identifiants incorrects",
     "errorRegister": "Erreur lors de l'inscription",
     "backToHome": "Accueil",
-    "forgotPassword": "Mot de passe oublié ?"
+    "forgotPassword": "Nouveau mot de passe ?"
   },
   "forgotPassword": {
-    "title": "Mot de passe oublié",
+    "title": "Choisir un nouveau mot de passe",
     "intro": "Entre ton email, on t'envoie un lien pour en choisir un nouveau.",
     "submit": "Envoyer le lien",
     "submitting": "Envoi…",


### PR DESCRIPTION
## Summary
`Mot de passe oublié` frames the moment as a failure of memory — exactly what rule B7 (no guilt-inducing language) bans for an ADHD audience. Two strings are reframed as an opportunity:

| Key | Before | After |
|---|---|---|
| `login.forgotPassword` | `Mot de passe oublié ?` | `Nouveau mot de passe ?` |
| `forgotPassword.title` | `Mot de passe oublié` | `Choisir un nouveau mot de passe` |

The page intro (`forgotPassword.intro`) already used opportunity framing (`...un lien pour en choisir un nouveau`), so the new title sits naturally with the existing copy.

## Why now
`pnpm lint:copy` has been failing on `main` since #179 (the forgot-password flow was added before the "oubli" entry landed in `scripts/check-guilt-lexicon.mjs`). Every PR opened against `main` inherits the red CI signal. This unblocks them.

## Test plan
- [x] `pnpm lint:copy` passes locally
- [ ] CI green on this branch

https://claude.ai/code/session_01DB3HyCFsdzsoSv97QYjqbP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DB3HyCFsdzsoSv97QYjqbP)_