### PR TITLE
Fix sidebar tooltip visibility logic and prevent stuck tooltips

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -520,6 +520,12 @@ function SidebarMenuButton({
     tooltip?: string | React.ComponentProps<typeof TooltipContent>
   } & VariantProps<typeof sidebarMenuButtonVariants>) {
   const { isMobile, state } = useSidebar()
+  // Only attach Base UI Tooltip when the sidebar is in collapsed (icon) mode on
+  // desktop. Otherwise the Root keeps tracking hover state on every nav item
+  // while expanded, and any tooltip whose internal "open" state was left true
+  // pops out the moment the sidebar collapses — causing tooltips to appear
+  // stuck open.
+  const showTooltip = !!tooltip && state === "collapsed" && !isMobile
   const comp = useRender({
     defaultTagName: "button",
     props: mergeProps<"button">(
@@ -528,7 +534,7 @@ function SidebarMenuButton({
       },
       props
     ),
-    render: !tooltip ? render : <TooltipTrigger render={render} />,
+    render: showTooltip ? <TooltipTrigger render={render} /> : render,
     state: {
       slot: "sidebar-menu-button",
       sidebar: "menu-button",
@@ -537,25 +543,17 @@ function SidebarMenuButton({
     },
   })
 
-  if (!tooltip) {
+  if (!showTooltip) {
     return comp
   }
 
-  if (typeof tooltip === "string") {
-    tooltip = {
-      children: tooltip,
-    }
-  }
+  const tooltipProps: React.ComponentProps<typeof TooltipContent> =
+    typeof tooltip === "string" ? { children: tooltip } : tooltip!
 
   return (
     <Tooltip>
       {comp}
-      <TooltipContent
-        side="right"
-        align="center"
-        hidden={state !== "collapsed" || isMobile}
-        {...tooltip}
-      />
+      <TooltipContent side="right" align="center" {...tooltipProps} />
     </Tooltip>
   )
 }


### PR DESCRIPTION
## Summary
Refactored the sidebar menu button tooltip logic to prevent tooltips from appearing stuck open when the sidebar collapses. The tooltip visibility is now determined upfront based on sidebar state, rather than being conditionally rendered with a `hidden` prop.

## Key Changes
- Introduced `showTooltip` variable that only enables tooltips when: tooltip content exists AND sidebar is in collapsed state AND user is on desktop (not mobile)
- Moved tooltip visibility logic from conditional rendering (`hidden` prop) to conditional component mounting, preventing tooltip internal state from persisting across sidebar state changes
- Simplified tooltip content prop handling by normalizing string tooltips to object format upfront
- Removed the `hidden` prop from `TooltipContent` since visibility is now controlled at the component level

## Implementation Details
The core issue was that Base UI Tooltip components were tracking hover state on every nav item while the sidebar was expanded. When the sidebar collapsed, any tooltip that had its internal "open" state left as true would immediately pop out, appearing stuck open. By only mounting the `TooltipTrigger` wrapper when tooltips should actually be visible, we prevent this state tracking from occurring in the first place.

https://claude.ai/code/session_01NnCrZ9NnvMjrBEYgTDY5pg