### PR TITLE
Add i18n support to KoeWidget component

### DIFF
--- a/apps/web/src/components/koe-widget.tsx
+++ b/apps/web/src/components/koe-widget.tsx
@@ -1,6 +1,7 @@
 import { KoeWidget as KoeWidgetBase } from "@wifsimster/koe";
 import "@wifsimster/koe/style.css";
 import { create } from "zustand";
+import { useTranslation } from "react-i18next";
 import { useSession } from "@/lib/auth-client";
 import { useKoeHash } from "@/hooks/use-koe-hash";
 
@@ -31,18 +32,20 @@ export function KoeWidget() {
   const user = session.data?.user;
   const { data: hashData } = useKoeHash(Boolean(user && apiUrl && projectKey));
   const openCount = useKoeWidgetStore((s) => s.openCount);
+  const { i18n } = useTranslation();
 
   if (!apiUrl || !projectKey || !user || !hashData?.hash) return null;
 
   return (
     <KoeWidgetBase
-      key={openCount}
+      key={`${i18n.resolvedLanguage ?? "fr"}-${openCount}`}
       projectKey={projectKey}
       apiUrl={apiUrl}
       user={{ id: user.id, name: user.name, email: user.email }}
       userHash={hashData.hash}
       position="bottom-right"
       theme={{ accentColor: "#c2410c", mode: "auto" }}
+      language={i18n.resolvedLanguage ?? "fr"}
       defaultOpen={openCount > 0}
     />
   );


### PR DESCRIPTION
## Summary
Added internationalization (i18n) support to the KoeWidget component to display the widget in the user's current language.

## Key Changes
- Imported `useTranslation` hook from `react-i18next` to access the current language settings
- Updated the widget's `key` prop to include the resolved language, ensuring the component re-renders when the language changes
- Added `language` prop to `KoeWidgetBase` component, passing the current resolved language (defaults to "fr" if not available)

## Implementation Details
- The resolved language is obtained from `i18n.resolvedLanguage` with a fallback to "fr" (French)
- The component key now includes both the language and `openCount` to properly track state changes across language switches
- This ensures the KoeWidget displays content in the correct language and updates appropriately when users change their language preference

https://claude.ai/code/session_01AwXFeNQmh2PtSxYk5Ksxbk