### PR TITLE
Add admin notification for solidarity pricing requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,9 @@ STRIPE_WEBHOOK_SECRET=whsec_...
 # Without this key, reminder + digest emails silently no-op.
 RESEND_API_KEY=
 EMAIL_FROM="Tokō <no-reply@toko.app>"
+# Where "Tarif solidaire" requests are emailed for manual review.
+# Temporary single-inbox routing until proper admin tooling exists.
+SOLIDARITY_NOTIFY_EMAIL=battistella@proton.me
 # Public app URL used in email links (defaults to http://localhost:5173)
 APP_URL=http://localhost:5173
 

--- a/apps/api/src/lib/email-templates.ts
+++ b/apps/api/src/lib/email-templates.ts
@@ -211,6 +211,40 @@ export function trialEndingReminderTemplate(parentName: string): {
   };
 }
 
+export function solidarityRequestAdminNotificationTemplate(data: {
+  parentName: string;
+  parentEmail: string;
+  message: string | null;
+  requestId: string;
+}): { subject: string; html: string } {
+  const messageBlock = data.message
+    ? `
+      <p style="color: #78716c; font-size: 13px; margin: 20px 0 6px;">Message du parent</p>
+      <blockquote style="border-left: 3px solid #e7e5e4; padding: 8px 14px; margin: 0; color: #57534e; white-space: pre-wrap;">${escapeHtml(data.message)}</blockquote>
+    `
+    : `
+      <p style="color: #a8a29e; font-size: 13px; margin: 20px 0 0;">Aucun message fourni.</p>
+    `;
+
+  return {
+    subject: `Tokō — Nouvelle demande de tarif solidaire de ${data.parentName}`,
+    html: layout(`
+      <p style="color: #44403c; font-size: 16px;">Nouvelle demande de tarif solidaire</p>
+      <table role="presentation" width="100%" cellspacing="0" cellpadding="0" style="margin: 16px 0;">
+        <tr><td style="padding: 6px 0; color: #78716c;">Parent</td><td style="padding: 6px 0; text-align: right;"><strong>${escapeHtml(data.parentName)}</strong></td></tr>
+        <tr><td style="padding: 6px 0; color: #78716c;">Email</td><td style="padding: 6px 0; text-align: right;"><a href="mailto:${escapeHtml(data.parentEmail)}" style="color: #7c6a58;">${escapeHtml(data.parentEmail)}</a></td></tr>
+        <tr><td style="padding: 6px 0; color: #78716c;">Référence</td><td style="padding: 6px 0; text-align: right; font-family: monospace; font-size: 12px;">${escapeHtml(data.requestId)}</td></tr>
+      </table>
+      ${messageBlock}
+      <p style="color: #78716c; font-size: 13px; margin-top: 24px;">
+        Pour répondre, écrivez directement au parent à l'adresse ci-dessus.
+        La demande reste en statut <em>pending</em> en base tant qu'elle n'a
+        pas été revue.
+      </p>
+    `),
+  };
+}
+
 export function resetPasswordEmail({ url }: { url: string }): {
   subject: string;
   html: string;

--- a/apps/api/src/lib/env.ts
+++ b/apps/api/src/lib/env.ts
@@ -27,6 +27,9 @@ const envSchema = z
     // Email + cron (all optional; emails gracefully no-op without RESEND_API_KEY)
     RESEND_API_KEY: z.string().optional(),
     EMAIL_FROM: z.string().default("Tokō <no-reply@toko.app>"),
+    // Recipient for new "Tarif solidaire" requests. Temporary single-inbox
+    // routing until proper admin tooling exists.
+    SOLIDARITY_NOTIFY_EMAIL: z.string().email().default("battistella@proton.me"),
     APP_URL: z.string().default("http://localhost:5173"),
     CRON_SECRET: z.string().optional(),
     // When true, the API runs an in-process node-cron scheduler that

--- a/apps/api/src/routes/solidarity.ts
+++ b/apps/api/src/routes/solidarity.ts
@@ -4,6 +4,9 @@ import type { AppEnv } from "../types";
 import { db, solidarityRequests } from "@focusflow/db";
 import { solidarityRequestInputSchema } from "@focusflow/validators";
 import { authMiddleware } from "../middleware/auth";
+import { sendEmail } from "../lib/email";
+import { solidarityRequestAdminNotificationTemplate } from "../lib/email-templates";
+import { env } from "../lib/env";
 
 export const solidarityRoutes = new Hono<AppEnv>();
 
@@ -86,5 +89,33 @@ solidarityRoutes.post("/", async (c) => {
     return c.json({ error: "Création impossible" }, 500);
   }
 
+  // Fire-and-forget admin notification. The request is already persisted,
+  // so an email delivery failure must not surface to the parent — they'd
+  // retry and get a SOLIDARITY_REQUEST_PENDING conflict.
+  void notifyAdminOfRequest({
+    parentName: user.name ?? user.email,
+    parentEmail: user.email,
+    message: created.message,
+    requestId: created.id,
+  });
+
   return c.json(sanitize(created), 201);
 });
+
+async function notifyAdminOfRequest(data: {
+  parentName: string;
+  parentEmail: string;
+  message: string | null;
+  requestId: string;
+}) {
+  try {
+    const { subject, html } = solidarityRequestAdminNotificationTemplate(data);
+    await sendEmail({
+      to: env.SOLIDARITY_NOTIFY_EMAIL,
+      subject,
+      html,
+    });
+  } catch (err) {
+    console.error("solidarity_request_notify_failed", err);
+  }
+}


### PR DESCRIPTION
## Summary
Adds email notification to admins when users submit solidarity pricing ("Tarif solidaire") requests, enabling manual review and response workflows.

## Key Changes
- **New email template** (`solidarityRequestAdminNotificationTemplate`): Formats solidarity request details including parent name, email, optional message, and request ID for admin review
- **Admin notification flow**: Sends fire-and-forget email notification after request creation, ensuring failures don't surface to the user (who would retry and encounter a conflict error)
- **Environment configuration**: Added `SOLIDARITY_NOTIFY_EMAIL` config variable to specify the admin inbox for request notifications (defaults to `battistella@proton.me`)
- **Error handling**: Admin notification failures are logged but don't block the user's request submission

## Implementation Details
- The notification is sent asynchronously via `void` to prevent email delivery failures from affecting the API response
- Email delivery errors are caught and logged to console, maintaining the fire-and-forget pattern
- The template includes a blockquote-styled message section (when provided) and instructions for admins to respond directly to the parent
- Request reference ID is included in monospace font for easy tracking

https://claude.ai/code/session_01PzDMPA1xRKYZmcrYmKzyry