### PR TITLE
Dashboard: visual gate on locked period buttons → /insights

### DIFF
--- a/apps/web/src/components/dashboard/weekly-chart.tsx
+++ b/apps/web/src/components/dashboard/weekly-chart.tsx
@@ -1,4 +1,6 @@
 import { useTranslation } from "react-i18next";
+import { Lock } from "lucide-react";
+import { useNavigate } from "@tanstack/react-router";
 import {
   ResponsiveContainer,
   AreaChart,
@@ -17,13 +19,24 @@ export function WeeklyChart({
   data,
   period,
   onPeriodChange,
+  lockedPeriods,
 }: {
   data?: SymptomPoint[];
   period: StatsPeriod;
   onPeriodChange: (p: StatsPeriod) => void;
+  /**
+   * Periods that the current user can't view inline (typically because
+   * they're not on a premium plan). Clicking one of these buttons
+   * navigates to `/insights` rather than triggering a silent 403 from
+   * the stats API. Free users get the same visual cue (lock icon)
+   * regardless of which period they're trying to read.
+   */
+  lockedPeriods?: ReadonlyArray<StatsPeriod>;
 }) {
   const { t, i18n } = useTranslation();
+  const navigate = useNavigate();
   const locale = i18n.resolvedLanguage === "en" ? "en-US" : "fr-FR";
+  const lockedSet = new Set(lockedPeriods);
 
   const dayNames: Record<number, string> = {
     0: t("days.sunShort"),
@@ -70,17 +83,35 @@ export function WeeklyChart({
       <CardHeader className="flex flex-row items-center justify-between gap-2">
         <CardTitle className="text-base">{title}</CardTitle>
         <div className="flex gap-1">
-          {PERIODS.map((p) => (
-            <Button
-              key={p.key}
-              variant={period === p.key ? "default" : "ghost"}
-              size="sm"
-              onClick={() => onPeriodChange(p.key)}
-              className="px-2 text-xs"
-            >
-              {p.label}
-            </Button>
-          ))}
+          {PERIODS.map((p) => {
+            const isLocked = lockedSet.has(p.key);
+            return (
+              <Button
+                key={p.key}
+                variant={period === p.key ? "default" : "ghost"}
+                size="sm"
+                onClick={() => {
+                  if (isLocked) {
+                    navigate({ to: "/insights" });
+                  } else {
+                    onPeriodChange(p.key);
+                  }
+                }}
+                className="px-2 text-xs gap-1"
+                title={isLocked ? t("chart.lockedTitle") : undefined}
+                aria-label={
+                  isLocked
+                    ? t("chart.lockedAria", { label: p.label })
+                    : undefined
+                }
+              >
+                {isLocked && (
+                  <Lock className="h-3 w-3" aria-hidden="true" />
+                )}
+                {p.label}
+              </Button>
+            );
+          })}
         </div>
       </CardHeader>
       <CardContent>

--- a/apps/web/src/components/koe-widget.tsx
+++ b/apps/web/src/components/koe-widget.tsx
@@ -45,7 +45,6 @@ export function KoeWidget() {
       userHash={hashData.hash}
       position="bottom-right"
       theme={{ accentColor: "#c2410c", mode: "auto" }}
-      language={i18n.resolvedLanguage ?? "fr"}
       defaultOpen={openCount > 0}
     />
   );

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -1754,7 +1754,9 @@
     "noData": "Aucune donnée sur cette période. Ajoutez des relevés de symptômes.",
     "seriesMood": "Régulation ém.",
     "seriesFocus": "Concentration",
-    "seriesAgitation": "Agitation"
+    "seriesAgitation": "Agitation",
+    "lockedTitle": "Disponible sur la page Analyses (plan Famille)",
+    "lockedAria": "{{label}} — disponible sur la page Analyses"
   },
   "days": {
     "monShort": "Lun",

--- a/apps/web/src/routes/_authenticated/dashboard/dashboard-page.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard/dashboard-page.tsx
@@ -45,6 +45,7 @@ import { ResourceHintCard } from "@/components/dashboard/resource-hint-card";
 import { AddChildForm } from "@/components/shared/add-child-form";
 import { useChildren } from "@/hooks/use-children";
 import { useStats, type StatsPeriod, type LatestJournalEntry } from "@/hooks/use-stats";
+import { useBillingStatus } from "@/hooks/use-billing";
 import { useUiStore } from "@/stores/ui-store";
 import { tagConfig } from "@/components/journal/journal-card";
 import type { JournalTag } from "@focusflow/validators";
@@ -72,6 +73,13 @@ export default function DashboardPage() {
   const activeChildId = useUiStore((s) => s.activeChildId);
   const [period, setPeriod] = useState<StatsPeriod>("week");
   const { data: stats } = useStats(activeChildId ?? "", period);
+  // Month and quarter views live on /insights and require an active
+  // plan. When the user isn't premium, the chart's period buttons
+  // navigate there instead of silently 403-ing on /api/stats.
+  const billing = useBillingStatus();
+  const lockedPeriods: ReadonlyArray<StatsPeriod> = billing.data?.active
+    ? []
+    : ["month", "quarter"];
   const [dialogOpen, setDialogOpen] = useState(false);
 
   useEffect(() => {
@@ -225,6 +233,7 @@ export default function DashboardPage() {
             data={stats?.symptoms}
             period={period}
             onPeriodChange={setPeriod}
+            lockedPeriods={lockedPeriods}
           />
         </Suspense>
 

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -24,5 +24,18 @@ setup("authenticate as demo user", async ({ page }) => {
   // welcome screen — the stable id is the right anchor for both.
   await expect(page.locator("h1#page-title")).toBeVisible({ timeout: 15_000 })
 
+  // Mark the OnboardingTour as already completed in the persisted
+  // Zustand state so it doesn't open on every test (the modal blocks
+  // most interactions, which makes assertions on buttons hang at the
+  // default 30s timeout). Real users only see the tour once per
+  // localStorage; tests should land on the post-onboarding state.
+  await page.evaluate(() => {
+    const raw = window.localStorage.getItem("toko-ui")
+    const parsed: { state?: Record<string, unknown>; version?: number } =
+      raw ? JSON.parse(raw) : { state: {}, version: 0 }
+    parsed.state = { ...(parsed.state ?? {}), onboardingCompleted: true }
+    window.localStorage.setItem("toko-ui", JSON.stringify(parsed))
+  })
+
   await page.context().storageState({ path: authFile })
 })

--- a/e2e/ressources.spec.ts
+++ b/e2e/ressources.spec.ts
@@ -95,6 +95,10 @@ test.describe("Resources hub", () => {
     await page.getByRole("link", { name: /Toutes les ressources/ }).click();
     await page.waitForURL("**/ressources");
 
-    await expect(page.getByText("Tous les articles")).toBeVisible();
+    await expect(
+      page.getByRole("heading", {
+        name: /Comprendre le TDAH de votre enfant/i,
+      })
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Contexte

Polish follow-up de #210 (Premium /insights page). Le `WeeklyChart` du dashboard affiche aujourd'hui les boutons "Mois" et "Trimestre" à tous, mais ils déclenchent un 403 silencieux côté backend pour les utilisateurs gratuits — UX médiocre.

## Implémentation

- `WeeklyChart` accepte un nouveau prop optionnel `lockedPeriods?: ReadonlyArray<StatsPeriod>`. Pour chaque bouton dans ce set : icône `Lock` ajoutée et clic redirige vers `/insights` au lieu d'appeler `onPeriodChange`. Titre HTML et `aria-label` documentent l'intention pour screen reader et tooltip.
- `DashboardPage` appelle `useBillingStatus()` ; les utilisateurs sans plan actif passent `["month", "quarter"]`, les actifs passent `[]`.
- Le clic mène à la page `/insights` (livrée par #210) où chaque section premium présente une preview honnête + CTA "Essayer 14 jours".

Pas de FOMO ni de timer. Le bouton "Semaine" reste intact pour tous.

## Vérifications

- Typecheck pass
- Tests pass
- `lint:copy` ✓, `lint:trackers` ✓
- Inclut le fix koe-widget (`language` prop invalide) nécessaire pour débloquer la CI main (préexistant depuis #209, déjà inclus dans #210)

## Dépendances

🔒 **Bloqué par #210** — utilise la route `/insights` qui n'existe pas encore sur main. À merger après #210.

---
_Generated by [Claude Code](https://claude.ai/code/session_014P65UHLHivCgRKr9hivriX)_