### PR TITLE
Add responsive padding utility to search inputs

### DIFF
--- a/apps/web/src/routes/_authenticated/decodeur/index.tsx
+++ b/apps/web/src/routes/_authenticated/decodeur/index.tsx
@@ -65,7 +65,7 @@ function BehaviorDecoderPage() {
           onChange={(e) => setQuery(e.target.value)}
           placeholder={t("decoder.searchPlaceholder")}
           aria-label={t("decoder.searchLabel")}
-          className="pl-9"
+          className="pl-9 md:pl-9"
         />
       </div>
 

--- a/apps/web/src/routes/_authenticated/journal/index.tsx
+++ b/apps/web/src/routes/_authenticated/journal/index.tsx
@@ -132,7 +132,7 @@ function JournalPage() {
               placeholder={t("journal.searchPlaceholder")}
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="pl-9"
+              className="pl-9 md:pl-9"
             />
           </div>
           <div className="flex flex-wrap items-center gap-1.5">


### PR DESCRIPTION
## Summary
Added explicit responsive padding utility classes to search input fields across multiple pages to ensure consistent styling behavior on medium-sized screens and above.

## Key Changes
- Updated search input in Behavior Decoder page to include `md:pl-9` responsive class alongside `pl-9`
- Updated search input in Journal page to include `md:pl-9` responsive class alongside `pl-9`

## Implementation Details
These changes ensure that the left padding (`pl-9`) is explicitly maintained at the `md` breakpoint and above, providing consistent spacing for the search input icons across different screen sizes. This prevents any potential responsive style conflicts or unintended padding changes on medium and larger viewports.

https://claude.ai/code/session_01VJkdeqKiH5K3HycLmShLB1