### PR TITLE
Communication scripts — ready-to-use phrases for recurring TDAH situations (#215)

### DIFF
--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -17,11 +17,12 @@ import {
   UserCog,
   Brain,
   HeartPulse,
+  MessageSquareText,
   TrendingUp,
 } from "lucide-react";
 
 export type NavItem = {
-  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/timer" | "/care-pathway" | "/admin-vault" | "/achievements" | "/activity" | "/connaissances" | "/account" | "/decodeur" | "/burnout" | "/insights";
+  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/timer" | "/care-pathway" | "/admin-vault" | "/achievements" | "/activity" | "/connaissances" | "/account" | "/decodeur" | "/burnout" | "/insights" | "/scripts";
   labelKey: string;
   shortLabelKey?: string;
   icon: React.ComponentType<{ className?: string }>;
@@ -34,6 +35,7 @@ export type NavItem = {
 export const navItems: readonly NavItem[] = [
   { to: "/connaissances", labelKey: "nav.knowledgeBase", icon: Library, group: "knowledge" },
   { to: "/decodeur", labelKey: "nav.behaviorDecoder", icon: Brain, group: "knowledge" },
+  { to: "/scripts", labelKey: "nav.communicationScripts", icon: MessageSquareText, group: "knowledge" },
   { to: "/dashboard", labelKey: "nav.dashboard", shortLabelKey: "nav.home", icon: BarChart3, primary: true, group: "tracking" },
   { to: "/insights", labelKey: "nav.insights", icon: TrendingUp, group: "tracking" },
   { to: "/journal", labelKey: "nav.journal", icon: BookOpen, primary: true, group: "tracking" },

--- a/apps/web/src/lib/communication-scripts-data.ts
+++ b/apps/web/src/lib/communication-scripts-data.ts
@@ -1,0 +1,33 @@
+// Communication scripts catalogue. Each entry is a recurring social
+// situation the parent of a TDAH child runs into (a teacher calling
+// home, a grandparent minimizing, a "c'est juste un caprice" jab in
+// the family group chat). The script gives them a small set of
+// ready-to-use phrases so they don't have to invent a response under
+// shock.
+//
+// Adapted from popular vulgarisation (Caroline Goldman, HyperSupers,
+// INSERM dossier TDAH). Each script avoids the word "diagnostic" in
+// the user-facing copy where possible (forbidden by
+// `docs/freemium-ethics-policy.md` § 5 outside of legitimate medical
+// contexts).
+
+export type ScriptId =
+  | "schoolCall"
+  | "grandparent"
+  | "caprice"
+  | "pedopsyPrep"
+  | "announceCondition"
+  | "papRequest"
+  | "misplacedRemark"
+  | "presentTreatment";
+
+export const SCRIPT_IDS: readonly ScriptId[] = [
+  "schoolCall",
+  "grandparent",
+  "caprice",
+  "pedopsyPrep",
+  "announceCondition",
+  "papRequest",
+  "misplacedRemark",
+  "presentTreatment",
+];

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -240,6 +240,7 @@
     "timer": "Minuteur",
     "carePathway": "Parcours de soins",
     "behaviorDecoder": "Décodeur de comportements",
+    "communicationScripts": "Scripts de communication",
     "burnout": "Test burn-out parental",
     "adminVault": "Coffre-fort",
     "achievements": "Mes badges",
@@ -631,6 +632,165 @@
       "previewBody": "Quand un comportement précis revient, qu'est-ce qui change dans l'humeur ou le sommeil de votre enfant ? Le pattern le plus net sur 28 jours.",
       "summary": "Quand {{behavior}} est en place, {{dimension}} passe en moyenne de {{offValue}} à {{onValue}}.",
       "insufficient": "Pas encore assez de données pour un pattern fiable. Continuez à enregistrer quelques semaines, on revient vers vous dès que c'est lisible."
+    }
+  },
+  "scripts": {
+    "title": "Scripts de communication",
+    "subtitle": "Des phrases prêtes-à-l'emploi pour les situations sociales qui reviennent et qui épuisent. Copier-coller plutôt que reformuler à chaque fois.",
+    "disclaimer": "Ces scripts sont des points de départ, pas des recettes. Adaptez-les à votre ton, à la personne en face, à votre énergie du jour.",
+    "principlesLabel": "Principes",
+    "phrasesLabel": "Phrases prêtes",
+    "pitfallsLabel": "Pièges à éviter",
+    "copyButton": "Copier",
+    "copyAria": "Copier la phrase",
+    "copied": "Phrase copiée",
+    "copyError": "Impossible de copier — votre navigateur n'autorise pas le presse-papier ici.",
+    "entries": {
+      "schoolCall": {
+        "title": "Quand l'école appelle pour un comportement",
+        "whyHard": "Un mélange de honte et de culpabilité, pas le temps de préparer une réponse posée.",
+        "principles": [
+          "Demander un fait précis (heure, contexte) plutôt qu'accepter un jugement global",
+          "Ne pas s'excuser à la place de l'enfant",
+          "Repositionner sur l'aide à apporter, pas sur la sanction"
+        ],
+        "phrases": [
+          "Merci de m'appeler. Pour bien comprendre, à quel moment précis cela s'est passé ?",
+          "Mon enfant a un TDAH suivi médicalement. Ce que vous décrivez correspond aux moments où il a le plus de difficulté à se réguler. On peut en parler ensemble pour trouver une réponse qui marche pour lui et pour la classe.",
+          "Je vais reprendre cela à la maison avec lui, calmement. De votre côté, qu'est-ce qui pourrait l'aider à l'école dans ce type de moment ?"
+        ],
+        "pitfalls": [
+          "« Excusez-le, on traverse une période difficile » — minimise la situation et porte la culpabilité seul",
+          "« Je vais le punir ce soir » — engage une sanction sans avoir compris ce qui s'est passé"
+        ]
+      },
+      "grandparent": {
+        "title": "Expliquer le TDAH à un grand-parent qui minimise",
+        "whyHard": "On a besoin de soutien familial, et on entend « de mon temps on ne faisait pas tant d'histoires ».",
+        "principles": [
+          "Court-circuiter le débat éducatif, ramener au médical",
+          "Donner une seule info concrète plutôt qu'un cours sur les neurosciences",
+          "Préserver le lien sans céder sur le fond"
+        ],
+        "phrases": [
+          "Le TDAH, c'est un fonctionnement neurologique. Ce n'est pas une question d'éducation.",
+          "On suit un médecin pour ça. On fait ce qu'on peut, et ce que tu vois n'est pas de la mauvaise volonté.",
+          "Tu peux nous aider en l'acceptant tel qu'il est quand on est ensemble. C'est tout ce dont on a besoin pour l'instant."
+        ],
+        "pitfalls": [
+          "Entrer dans le débat sur les neurosciences — épuise et n'aboutit jamais",
+          "« Tu ne comprends rien » — coupe un lien dont on aura besoin un jour"
+        ]
+      },
+      "caprice": {
+        "title": "Répondre à « c'est juste un caprice »",
+        "whyHard": "Cette phrase nie ce qu'on vit au quotidien. Elle vient souvent de gens qui ne voient l'enfant que deux heures le dimanche.",
+        "principles": [
+          "Pas de débat ouvert avec quelqu'un qui n'écoute pas vraiment",
+          "Une phrase de cadrage, puis on change de sujet",
+          "Pas d'argument scientifique en réponse à un jugement émotionnel"
+        ],
+        "phrases": [
+          "Non, c'est un trouble neurologique diagnostiqué. On en parlera plus longuement une autre fois.",
+          "Si tu le voyais 24h/24, tu verrais que ce n'est pas du tout ça.",
+          "Je préfère qu'on ne juge pas mon enfant, surtout en sa présence."
+        ],
+        "pitfalls": [
+          "Justifier en détail — c'est ce que la personne attend pour démonter chaque argument",
+          "Laisser passer en silence devant l'enfant — il enregistre le manque de soutien"
+        ]
+      },
+      "pedopsyPrep": {
+        "title": "Préparer une consultation pédopsy en 10 minutes",
+        "whyHard": "Le rendez-vous est court, on perd l'essentiel sous le stress. On en sort avec l'impression de ne pas avoir tout dit.",
+        "principles": [
+          "Trois sujets maximum, écrits sur papier avant d'entrer",
+          "Faits concrets datés, pas d'interprétation",
+          "Une question prioritaire pour soi (pas pour l'enfant)"
+        ],
+        "phrases": [
+          "Depuis la dernière fois, voici les trois choses qu'on a observées : [liste avec dates].",
+          "Ma question prioritaire aujourd'hui, c'est : [une seule].",
+          "Avant qu'on se quitte, est-ce qu'il y a un point que vous voulez qu'on surveille d'ici la prochaine fois ?"
+        ],
+        "pitfalls": [
+          "Tout dire dans l'ordre où ça vient — dilue le message principal",
+          "Parler uniquement des difficultés — on perd la trace des améliorations"
+        ]
+      },
+      "announceCondition": {
+        "title": "Annoncer le TDAH à votre enfant",
+        "whyHard": "On a peur de l'étiqueter, ou de lui faire croire qu'il est cassé.",
+        "principles": [
+          "Pas le mot « maladie »",
+          "Cadrer comme une explication, pas une fatalité",
+          "Lui demander ce qu'il en pense, ne pas faire un monologue"
+        ],
+        "phrases": [
+          "Tu sais quand tu n'arrives pas à te concentrer ou à rester assis ? Ce n'est pas que tu ne veux pas. Ton cerveau fonctionne différemment, c'est ce qu'on appelle un TDAH.",
+          "Beaucoup d'enfants ont ça. C'est pour ça qu'on va t'aider avec des routines et un suivi médical — pas pour te changer, pour te donner des outils.",
+          "Qu'est-ce que ça te fait, ce que je te dis là ?"
+        ],
+        "pitfalls": [
+          "« Tu es malade » — fausse représentation, qui s'imprime durablement",
+          "En faire un sujet tabou — l'enfant entend le silence"
+        ]
+      },
+      "papRequest": {
+        "title": "Demander un PAP/PPRE à l'école",
+        "whyHard": "L'école n'a pas le temps. On doit pousser sans devenir le « parent pénible ».",
+        "principles": [
+          "Demander un rendez-vous écrit, par mail",
+          "Citer le médecin — c'est lui qui prescrit l'aménagement",
+          "Proposer une réunion de 30 minutes, pas plus"
+        ],
+        "phrases": [
+          "Madame, Monsieur, mon enfant est suivi pour un TDAH. Le médecin recommande un PAP. Je souhaiterais qu'on en parle ensemble. Quand seriez-vous disponible pour une réunion de 30 minutes ?",
+          "Voici les recommandations du médecin (en pièce jointe). Nous sommes ouverts à vos remarques et à vos contraintes.",
+          "Pouvez-vous me confirmer par mail ce qu'on décide ensemble, pour qu'on en garde une trace ?"
+        ],
+        "pitfalls": [
+          "Demander oralement à la sortie de l'école — pas de trace, pas de suite",
+          "Arriver avec une liste d'exigences fermées — ferme le dialogue dès la première minute"
+        ]
+      },
+      "misplacedRemark": {
+        "title": "Gérer une remarque déplacée en famille / au parc",
+        "whyHard": "Sur le moment on est sidéré, on ne sait pas quoi dire, et on s'en veut après.",
+        "principles": [
+          "Une phrase courte, ferme, qu'on apprend par cœur",
+          "Protéger l'enfant qui entend",
+          "Pas de débat, on coupe court"
+        ],
+        "phrases": [
+          "Merci, on gère.",
+          "Ce que tu dis là n'est pas vrai pour mon enfant.",
+          "Je préfère qu'on ne le juge pas, surtout devant lui.",
+          "On en reparlera entre adultes, pas maintenant."
+        ],
+        "pitfalls": [
+          "Se justifier longuement — installe le débat à la place du recadrage",
+          "Rire jaune — l'enfant entend l'acquiescement implicite"
+        ]
+      },
+      "presentTreatment": {
+        "title": "Présenter le traitement à votre enfant",
+        "whyHard": "On veut qu'il accepte le médicament sans en faire un sujet de honte.",
+        "principles": [
+          "Nommer ce que le médicament aide, pas ce qu'il « corrige »",
+          "Comparer à une aide banale (lunettes, asthmateur)",
+          "Lui laisser un mot pour exprimer ce qu'il ressent, à tout moment"
+        ],
+        "phrases": [
+          "Le médicament aide ton cerveau à faire ce qu'il a du mal à faire seul. C'est un coup de pouce, pas un changement de toi.",
+          "Comme des lunettes pour mieux voir : ça ne change pas tes yeux, ça t'aide à voir net.",
+          "Si à un moment tu sens que ça te gêne, tu me le dis et on en parle ensemble au médecin."
+        ],
+        "pitfalls": [
+          "« Tu seras plus sage » ou « tu seras plus calme » — confond effet du médicament et identité de l'enfant",
+          "En cacher l'existence à l'enfant — il découvrira un jour avec un sentiment de trahison"
+        ]
+      }
     }
   },
   "resourceHint": {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as InviteTokenRouteImport } from './routes/invite/$token'
 import { Route as AuthenticatedTimerIndexRouteImport } from './routes/_authenticated/timer/index'
 import { Route as AuthenticatedSymptomsIndexRouteImport } from './routes/_authenticated/symptoms/index'
 import { Route as AuthenticatedStrengthsIndexRouteImport } from './routes/_authenticated/strengths/index'
+import { Route as AuthenticatedScriptsIndexRouteImport } from './routes/_authenticated/scripts/index'
 import { Route as AuthenticatedRoutinesIndexRouteImport } from './routes/_authenticated/routines/index'
 import { Route as AuthenticatedRewardsIndexRouteImport } from './routes/_authenticated/rewards/index'
 import { Route as AuthenticatedReportIndexRouteImport } from './routes/_authenticated/report/index'
@@ -118,6 +119,12 @@ const AuthenticatedStrengthsIndexRoute =
   AuthenticatedStrengthsIndexRouteImport.update({
     id: '/strengths/',
     path: '/strengths/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
+const AuthenticatedScriptsIndexRoute =
+  AuthenticatedScriptsIndexRouteImport.update({
+    id: '/scripts/',
+    path: '/scripts/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
 const AuthenticatedRoutinesIndexRoute =
@@ -265,6 +272,7 @@ export interface FileRoutesByFullPath {
   '/report/': typeof AuthenticatedReportIndexRoute
   '/rewards/': typeof AuthenticatedRewardsIndexRoute
   '/routines/': typeof AuthenticatedRoutinesIndexRoute
+  '/scripts/': typeof AuthenticatedScriptsIndexRoute
   '/strengths/': typeof AuthenticatedStrengthsIndexRoute
   '/symptoms/': typeof AuthenticatedSymptomsIndexRoute
   '/timer/': typeof AuthenticatedTimerIndexRoute
@@ -300,6 +308,7 @@ export interface FileRoutesByTo {
   '/report': typeof AuthenticatedReportIndexRoute
   '/rewards': typeof AuthenticatedRewardsIndexRoute
   '/routines': typeof AuthenticatedRoutinesIndexRoute
+  '/scripts': typeof AuthenticatedScriptsIndexRoute
   '/strengths': typeof AuthenticatedStrengthsIndexRoute
   '/symptoms': typeof AuthenticatedSymptomsIndexRoute
   '/timer': typeof AuthenticatedTimerIndexRoute
@@ -337,6 +346,7 @@ export interface FileRoutesById {
   '/_authenticated/report/': typeof AuthenticatedReportIndexRoute
   '/_authenticated/rewards/': typeof AuthenticatedRewardsIndexRoute
   '/_authenticated/routines/': typeof AuthenticatedRoutinesIndexRoute
+  '/_authenticated/scripts/': typeof AuthenticatedScriptsIndexRoute
   '/_authenticated/strengths/': typeof AuthenticatedStrengthsIndexRoute
   '/_authenticated/symptoms/': typeof AuthenticatedSymptomsIndexRoute
   '/_authenticated/timer/': typeof AuthenticatedTimerIndexRoute
@@ -374,6 +384,7 @@ export interface FileRouteTypes {
     | '/report/'
     | '/rewards/'
     | '/routines/'
+    | '/scripts/'
     | '/strengths/'
     | '/symptoms/'
     | '/timer/'
@@ -409,6 +420,7 @@ export interface FileRouteTypes {
     | '/report'
     | '/rewards'
     | '/routines'
+    | '/scripts'
     | '/strengths'
     | '/symptoms'
     | '/timer'
@@ -445,6 +457,7 @@ export interface FileRouteTypes {
     | '/_authenticated/report/'
     | '/_authenticated/rewards/'
     | '/_authenticated/routines/'
+    | '/_authenticated/scripts/'
     | '/_authenticated/strengths/'
     | '/_authenticated/symptoms/'
     | '/_authenticated/timer/'
@@ -571,6 +584,13 @@ declare module '@tanstack/react-router' {
       path: '/strengths'
       fullPath: '/strengths/'
       preLoaderRoute: typeof AuthenticatedStrengthsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
+    '/_authenticated/scripts/': {
+      id: '/_authenticated/scripts/'
+      path: '/scripts'
+      fullPath: '/scripts/'
+      preLoaderRoute: typeof AuthenticatedScriptsIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
     '/_authenticated/routines/': {
@@ -728,6 +748,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedReportIndexRoute: typeof AuthenticatedReportIndexRoute
   AuthenticatedRewardsIndexRoute: typeof AuthenticatedRewardsIndexRoute
   AuthenticatedRoutinesIndexRoute: typeof AuthenticatedRoutinesIndexRoute
+  AuthenticatedScriptsIndexRoute: typeof AuthenticatedScriptsIndexRoute
   AuthenticatedStrengthsIndexRoute: typeof AuthenticatedStrengthsIndexRoute
   AuthenticatedSymptomsIndexRoute: typeof AuthenticatedSymptomsIndexRoute
   AuthenticatedTimerIndexRoute: typeof AuthenticatedTimerIndexRoute
@@ -753,6 +774,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedReportIndexRoute: AuthenticatedReportIndexRoute,
   AuthenticatedRewardsIndexRoute: AuthenticatedRewardsIndexRoute,
   AuthenticatedRoutinesIndexRoute: AuthenticatedRoutinesIndexRoute,
+  AuthenticatedScriptsIndexRoute: AuthenticatedScriptsIndexRoute,
   AuthenticatedStrengthsIndexRoute: AuthenticatedStrengthsIndexRoute,
   AuthenticatedSymptomsIndexRoute: AuthenticatedSymptomsIndexRoute,
   AuthenticatedTimerIndexRoute: AuthenticatedTimerIndexRoute,

--- a/apps/web/src/routes/_authenticated/scripts/index.tsx
+++ b/apps/web/src/routes/_authenticated/scripts/index.tsx
@@ -1,0 +1,194 @@
+import { useState } from "react";
+import { createFileRoute } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import {
+  MessageSquareText,
+  Copy,
+  Heart,
+  Lightbulb,
+  AlertTriangle,
+  Check,
+} from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/layout/page-header";
+import { cn } from "@/lib/utils";
+import { SCRIPT_IDS, type ScriptId } from "@/lib/communication-scripts-data";
+
+export const Route = createFileRoute("/_authenticated/scripts/")({
+  component: CommunicationScriptsPage,
+  staticData: { crumb: "nav.communicationScripts" },
+});
+
+function CommunicationScriptsPage() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t("scripts.title")}
+        description={t("scripts.subtitle")}
+      />
+
+      <Card className="border-info-border bg-info-surface/40">
+        <CardContent className="py-4 text-sm leading-relaxed text-foreground/90">
+          {t("scripts.disclaimer")}
+        </CardContent>
+      </Card>
+
+      <ul className="grid gap-4">
+        {SCRIPT_IDS.map((id) => (
+          <li key={id}>
+            <ScriptCard id={id} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ScriptCard({ id }: { id: ScriptId }) {
+  const { t } = useTranslation();
+  const principles = t(`scripts.entries.${id}.principles`, {
+    returnObjects: true,
+  }) as string[];
+  const phrases = t(`scripts.entries.${id}.phrases`, {
+    returnObjects: true,
+  }) as string[];
+  const pitfalls = t(`scripts.entries.${id}.pitfalls`, {
+    returnObjects: true,
+  }) as string[];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-start gap-2 text-base">
+          <MessageSquareText
+            className="mt-0.5 h-4 w-4 shrink-0 text-primary"
+            aria-hidden="true"
+          />
+          <span>{t(`scripts.entries.${id}.title`)}</span>
+        </CardTitle>
+        <CardDescription className="ml-6 text-sm">
+          {t(`scripts.entries.${id}.whyHard`)}
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4 text-sm leading-relaxed">
+        <Section
+          icon={
+            <Heart
+              className="mt-0.5 h-4 w-4 shrink-0 text-warning-foreground"
+              aria-hidden="true"
+            />
+          }
+          label={t("scripts.principlesLabel")}
+          items={principles}
+        />
+        <PhrasesSection phrases={phrases} />
+        <Section
+          icon={
+            <AlertTriangle
+              className="mt-0.5 h-4 w-4 shrink-0 text-destructive"
+              aria-hidden="true"
+            />
+          }
+          label={t("scripts.pitfallsLabel")}
+          items={pitfalls}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function Section({
+  icon,
+  label,
+  items,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  items: string[];
+}) {
+  return (
+    <div className="flex items-start gap-2">
+      {icon}
+      <div className="space-y-1">
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          {label}
+        </p>
+        <ul className="space-y-1 list-disc pl-4 marker:text-muted-foreground/50">
+          {items.map((it) => (
+            <li key={it}>{it}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function PhrasesSection({ phrases }: { phrases: string[] }) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex items-start gap-2">
+      <Lightbulb
+        className="mt-0.5 h-4 w-4 shrink-0 text-success-foreground"
+        aria-hidden="true"
+      />
+      <div className="flex-1 space-y-1.5">
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          {t("scripts.phrasesLabel")}
+        </p>
+        <ul className="space-y-2">
+          {phrases.map((phrase) => (
+            <PhraseRow key={phrase} phrase={phrase} />
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function PhraseRow({ phrase }: { phrase: string }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(phrase);
+      setCopied(true);
+      toast.success(t("scripts.copied"));
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error(t("scripts.copyError"));
+    }
+  };
+
+  return (
+    <li className="group flex items-start gap-2 rounded-md bg-muted/40 p-2 transition-colors hover:bg-muted/60">
+      <span className="flex-1">{phrase}</span>
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={handleCopy}
+        aria-label={t("scripts.copyAria")}
+        className={cn(
+          "h-7 w-7 shrink-0 opacity-60 transition-opacity group-hover:opacity-100",
+          copied && "text-success-foreground opacity-100",
+        )}
+      >
+        {copied ? (
+          <Check className="h-3.5 w-3.5" />
+        ) : (
+          <Copy className="h-3.5 w-3.5" />
+        )}
+      </Button>
+    </li>
+  );
+}


### PR DESCRIPTION
## Contexte

Closes #215. Outil gratuit identifié en réunion personas comme "boîte à outils prête-à-emploi" pour la persona parent épuisé : il/elle n'a plus le temps ni l'énergie de formuler une réponse sous shock dans les situations sociales qui reviennent et qui pèsent.

## Contenu

8 scripts pour les moments qui épuisent socialement :

| Script | Quand |
|---|---|
| `schoolCall` | L'école appelle pour un comportement |
| `grandparent` | Grand-parent qui minimise |
| `caprice` | Quelqu'un dit « c'est juste un caprice » |
| `pedopsyPrep` | Préparer une consultation en 10 min |
| `announceCondition` | Annoncer le TDAH à votre enfant |
| `papRequest` | Demander un PAP/PPRE à l'école |
| `misplacedRemark` | Remarque déplacée en famille / au parc |
| `presentTreatment` | Présenter le traitement à votre enfant |

Chaque script a 4 sections :
- **Pourquoi c'est dur** — validation émotionnelle en une ligne
- **Principes** — 2-3 points de cadrage (ex : "ne pas s'excuser à la place de l'enfant", "court-circuiter le débat éducatif")
- **Phrases prêtes** — 3-4 formulations directement utilisables, bouton Copier sur chacune (clipboard API + toast confirmation + icône Check 2s)
- **Pièges à éviter** — 2 erreurs courantes annotées

## Implémentation

- Route `/_authenticated/scripts/` dans la sidebar groupe "knowledge", icône `MessageSquareText`
- Composant page unique : liste de cartes, chaque carte rend les 4 sections
- `PhraseRow` gère le copier-coller : `navigator.clipboard.writeText` + toast + état local 2s, fallback graceful si l'API refuse
- Pas de DB, pas d'API : 100 % i18n statique

## Conformité éthique (`docs/freemium-ethics-policy.md`)

- **§ 1 contenu sécurité gratuit** : ces scripts servent à protéger l'enfant face aux jugements et à outiller le parent dans son rapport au médical et à l'école. C'est de la prévention sociale, donc gratuit et sans cadenas.
- **§ 5 jamais "diagnostic" hors contexte médical légitime** : le mot apparaît uniquement dans des phrases factuelles comme "trouble neurologique diagnostiqué" en réponse à "c'est juste un caprice" — c'est une affirmation médicale recadrante, pas une mise en boîte de l'enfant.
- Lexique de culpabilité ✓ (lint:copy pass)

## Vérifications

- Typecheck ✓
- 23 tests web ✓
- 75 tests api ✓
- lint:copy ✓ (B7), lint:trackers ✓ (C5/F6)
- routeTree.gen.ts régénéré

---
_Generated by [Claude Code](https://claude.ai/code/session_014P65UHLHivCgRKr9hivriX)_