### PR TITLE
Wire #193 Charge Mentale copy on /insights + PremiumGate

### DIFF
--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -594,7 +594,7 @@
     "statusRejectedHint": "Votre dernière demande n'a pas pu être validée. Votre situation a peut-être évolué — n'hésitez pas à en soumettre une nouvelle."
   },
   "premiumGate": {
-    "cta": "Essayer 14 jours",
+    "cta": "Alléger ma charge mentale",
     "ctaLoading": "Préparation...",
     "trialHint": "14 jours d'essai · sans carte bancaire · annulable en 2 clics"
   },
@@ -603,6 +603,10 @@
     "subtitle": "Les tendances de votre enfant sur 30 et 90 jours, et les patterns qui se dessinent quand on prend du recul.",
     "disclaimer": "Ces analyses sont des grilles de lecture, pas des conclusions médicales. Elles vous aident à préparer vos rendez-vous, pas à vous substituer à un professionnel.",
     "noChild": "Sélectionnez un enfant pour voir ses analyses.",
+    "valueProp": {
+      "title": "Arrêtez de chercher quoi faire. Laissez-vous guider.",
+      "body": "Vous avez déjà lu des dizaines de livres et passé des heures sur les forums. En passant Famille, vous n'achetez pas de la lecture — vous achetez du temps. Tokō fait le travail d'analyse à votre place : repérer les patterns, suggérer le bon protocole."
+    },
     "monthlyTrends": {
       "title": "Tendances sur 30 jours",
       "body": "L'évolution des dimensions principales (humeur, attention, agitation, sommeil) jour après jour.",

--- a/apps/web/src/routes/_authenticated/insights/index.tsx
+++ b/apps/web/src/routes/_authenticated/insights/index.tsx
@@ -15,6 +15,7 @@ import { PageLoader } from "@/components/ui/page-loader";
 import { PremiumGate } from "@/components/shared/premium-gate";
 import { useUiStore } from "@/stores/ui-store";
 import { useChildren } from "@/hooks/use-children";
+import { useBillingStatus } from "@/hooks/use-billing";
 import {
   useStats,
   useCorrelations,
@@ -36,6 +37,8 @@ function InsightsPage() {
   const { t } = useTranslation();
   const activeChildId = useUiStore((s) => s.activeChildId);
   const { data: children, isLoading } = useChildren();
+  const billing = useBillingStatus();
+  const showValueProp = !billing.isLoading && !billing.data?.active;
 
   if (isLoading) return <PageLoader />;
 
@@ -61,6 +64,19 @@ function InsightsPage() {
         title={t("insights.title")}
         description={t("insights.subtitle")}
       />
+
+      {showValueProp && (
+        <Card className="border-primary/30 bg-primary/5">
+          <CardContent className="py-4 space-y-1">
+            <p className="font-medium text-sm">
+              {t("insights.valueProp.title")}
+            </p>
+            <p className="text-sm leading-relaxed text-foreground/90">
+              {t("insights.valueProp.body")}
+            </p>
+          </CardContent>
+        </Card>
+      )}
 
       <Card className="border-info-border bg-info-surface/40">
         <CardContent className="py-4 text-sm leading-relaxed text-foreground/90">


### PR DESCRIPTION
## Contexte

Active la copy "Charge Mentale" validée dans #193 sur les surfaces de monétisation existantes :

- **#197** a livré le PricingCatalogue en onboarding
- **#210** a livré /insights + PremiumGate
- **#213** a fait la transition month/quarter du dashboard vers /insights

Cette PR remplit ces surfaces avec la copy persona-alignée pour la persona "parent qui cherche des solutions depuis des années".

## Changements

### 1. Bannière value-prop sur /insights (free users only)
Au-dessus du disclaimer médical, pour les utilisateurs non-actifs uniquement (`!billing.data?.active`) :

> **Arrêtez de chercher quoi faire. Laissez-vous guider.**
>
> *Vous avez déjà lu des dizaines de livres et passé des heures sur les forums. En passant Famille, vous n'achetez pas de la lecture — vous achetez du temps. Tokō fait le travail d'analyse à votre place : repérer les patterns, suggérer le bon protocole.*

Bannière cachée pour les utilisateurs Famille (rien à vendre).

### 2. CTA PremiumGate
`Essayer 14 jours` → `Alléger ma charge mentale`

Verbe d'action concret aligné avec le brief #193 (priorité au bénéfice ressenti, pas à la mécanique de l'offre). Le hint sous le CTA reste : *"14 jours d'essai · sans carte bancaire · annulable en 2 clics"* — répond à la méfiance des parents échaudés par les SaaS.

## Hors scope
- Variante "Communication" (#193) reste documentée pour un futur A/B test (`#190`).
- Pas de paywall hard sur cette PR — tout reste en preview honnête comme avant.

## Vérifications
- Typecheck ✓
- 23 web tests / 75 api tests ✓
- `lint:copy` ✓
- `lint:trackers` ✓

Refs #193.

---
_Generated by [Claude Code](https://claude.ai/code/session_014P65UHLHivCgRKr9hivriX)_