### PR TITLE
feat(paywall): add Communication variant + variant resolver (#193)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,9 @@ GOOGLE_CLIENT_SECRET=
 # ─── Frontend ─────────────────────────────────────────
 VITE_API_URL=http://localhost:3001
 VITE_APP_VERSION=0.0.0
+# Paywall copywriting variant: `chargeMentale` (default) or `communication`.
+# See issue #193 — A/B distribution is handled separately (issue #190).
+VITE_PAYWALL_VARIANT=chargeMentale
 
 # ─── Koe feedback widget (optional) ───────────────────
 # Self-hosted koe-server (https://github.com/Wifsimster/koe).

--- a/apps/web/src/components/shared/premium-gate.tsx
+++ b/apps/web/src/components/shared/premium-gate.tsx
@@ -12,6 +12,7 @@ import { Button } from "@/components/ui/button";
 import { useBillingStatus, useCheckout, persistSelectedPlan } from "@/hooks/use-billing";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { PAYWALL_VARIANT } from "@/lib/paywall-variant";
 
 // Reusable gate for premium-only sections. While billing is loading, we
 // render a skeleton so the page doesn't flash the upsell on premium users.
@@ -81,7 +82,7 @@ export function PremiumGate({
           <Sparkles className="h-4 w-4" aria-hidden="true" />
           {checkout.isPending
             ? t("premiumGate.ctaLoading")
-            : t("premiumGate.cta")}
+            : t(`premiumGate.variants.${PAYWALL_VARIANT}.cta`)}
         </Button>
         <p className="mt-2 text-xs text-muted-foreground">
           {t("premiumGate.trialHint")}

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -595,19 +595,29 @@
     "statusRejectedHint": "Votre dernière demande n'a pas pu être validée. Votre situation a peut-être évolué — n'hésitez pas à en soumettre une nouvelle."
   },
   "premiumGate": {
-    "cta": "Alléger ma charge mentale",
     "ctaLoading": "Préparation...",
-    "trialHint": "14 jours d'essai · sans carte bancaire · annulable en 2 clics"
+    "trialHint": "14 jours d'essai · sans carte bancaire · annulable en 2 clics",
+    "dismiss": "Plus tard",
+    "variants": {
+      "chargeMentale": {
+        "title": "Arrêtez de chercher quoi faire. Laissez-vous guider.",
+        "subtitle": "Vous avez déjà lu des dizaines de livres et passé des heures sur les forums. Votre cerveau n'a plus de place.",
+        "body": "En passant Famille, vous n'achetez pas de la lecture. Vous achetez du temps. Accédez à nos protocoles prêts-à-l'emploi et laissez Tokō organiser vos routines. On s'occupe de la logistique. Vous vous occupez de votre enfant.",
+        "cta": "Alléger ma charge mentale"
+      },
+      "communication": {
+        "title": "Changez de disque. Dès ce soir.",
+        "subtitle": "Cela fait des années que les soirées se ressemblent : répétitions, négociations, épuisement.",
+        "body": "Tokō Famille vous donne les mots que vous cherchez : scripts prêts pour quand l'école vous appelle, quand les grands-parents minimisent, quand votre enfant explose. Pour que la conversation cesse d'être un combat.",
+        "cta": "Trouver les mots"
+      }
+    }
   },
   "insights": {
     "title": "Analyses",
     "subtitle": "Les tendances de votre enfant sur 30 et 90 jours, et les patterns qui se dessinent quand on prend du recul.",
     "disclaimer": "Ces analyses sont des grilles de lecture, pas des conclusions médicales. Elles vous aident à préparer vos rendez-vous, pas à vous substituer à un professionnel.",
     "noChild": "Sélectionnez un enfant pour voir ses analyses.",
-    "valueProp": {
-      "title": "Arrêtez de chercher quoi faire. Laissez-vous guider.",
-      "body": "Vous avez déjà lu des dizaines de livres et passé des heures sur les forums. En passant Famille, vous n'achetez pas de la lecture — vous achetez du temps. Tokō fait le travail d'analyse à votre place : repérer les patterns, suggérer le bon protocole."
-    },
     "monthlyTrends": {
       "title": "Tendances sur 30 jours",
       "body": "L'évolution des dimensions principales (humeur, attention, agitation, sommeil) jour après jour.",

--- a/apps/web/src/lib/paywall-variant.ts
+++ b/apps/web/src/lib/paywall-variant.ts
@@ -1,0 +1,14 @@
+// Paywall copywriting variant. Two angles validated in the strategy
+// review (GitHub issue #193): `chargeMentale` is principal, `communication`
+// is secondary. The variant is selected at build time via
+// VITE_PAYWALL_VARIANT and resolved once here so consumers stay in sync.
+//
+// Runtime A/B distribution is tracked separately (issue #190) and is
+// intentionally out of scope.
+export const PAYWALL_VARIANTS = ["chargeMentale", "communication"] as const;
+export type PaywallVariant = (typeof PAYWALL_VARIANTS)[number];
+
+const envValue = import.meta.env.VITE_PAYWALL_VARIANT;
+
+export const PAYWALL_VARIANT: PaywallVariant =
+  envValue === "communication" ? "communication" : "chargeMentale";

--- a/apps/web/src/routes/_authenticated/insights/index.tsx
+++ b/apps/web/src/routes/_authenticated/insights/index.tsx
@@ -13,6 +13,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/layout/page-header";
 import { PageLoader } from "@/components/ui/page-loader";
 import { PremiumGate } from "@/components/shared/premium-gate";
+import { PAYWALL_VARIANT } from "@/lib/paywall-variant";
 import { useUiStore } from "@/stores/ui-store";
 import { useChildren } from "@/hooks/use-children";
 import { useBillingStatus } from "@/hooks/use-billing";
@@ -67,12 +68,15 @@ function InsightsPage() {
 
       {showValueProp && (
         <Card className="border-primary/30 bg-primary/5">
-          <CardContent className="py-4 space-y-1">
+          <CardContent className="py-4 space-y-2">
             <p className="font-medium text-sm">
-              {t("insights.valueProp.title")}
+              {t(`premiumGate.variants.${PAYWALL_VARIANT}.title`)}
+            </p>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {t(`premiumGate.variants.${PAYWALL_VARIANT}.subtitle`)}
             </p>
             <p className="text-sm leading-relaxed text-foreground/90">
-              {t("insights.valueProp.body")}
+              {t(`premiumGate.variants.${PAYWALL_VARIANT}.body`)}
             </p>
           </CardContent>
         </Card>


### PR DESCRIPTION
Adds the secondary "Communication" copywriting angle alongside the
existing "Charge Mentale" angle and wires PremiumGate + the /insights
value-prop banner to read whichever variant is selected via the new
VITE_PAYWALL_VARIANT build flag (default: chargeMentale).

Both variants share the trial hint and refusal label, and the
Communication body deliberately avoids co-regulation / crise wording
per the ethics policy. Runtime A/B distribution stays out of scope and
is tracked in #190.