### PR TITLE
Admin analytics dashboard — event counts + daily chart (#187)

### DIFF
--- a/apps/api/src/__tests__/admin-analytics.routes.test.ts
+++ b/apps/api/src/__tests__/admin-analytics.routes.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { app } from "../app";
+
+// Smoke tests on the admin auth gate. We don't fabricate a session here
+// (Better Auth integration is covered by other suites); the goal is to
+// prove that an anonymous caller cannot reach the aggregation queries.
+
+describe("GET /api/admin/analytics/events", () => {
+  it("returns 401 without a session", async () => {
+    const res = await app.request("/api/admin/analytics/events");
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when querying with a days parameter without auth", async () => {
+    const res = await app.request("/api/admin/analytics/events?days=7");
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -34,6 +34,7 @@ import { adminVaultRoutes } from "./routes/admin-vault";
 import { parentMoodRoutes } from "./routes/parent-mood";
 import { solidarityRoutes } from "./routes/solidarity";
 import { eventsRoutes } from "./routes/events";
+import { adminAnalyticsRoutes } from "./routes/admin-analytics";
 import { auth } from "./lib/auth";
 
 const app = new Hono();
@@ -143,5 +144,6 @@ app.route("/api/care-pathway", carePathwayRoutes);
 app.route("/api/parent-mood", parentMoodRoutes);
 app.route("/api/solidarity", solidarityRoutes);
 app.route("/api/events", eventsRoutes);
+app.route("/api/admin/analytics", adminAnalyticsRoutes);
 
 export { app };

--- a/apps/api/src/routes/admin-analytics.ts
+++ b/apps/api/src/routes/admin-analytics.ts
@@ -1,0 +1,79 @@
+import { Hono } from "hono";
+import { eq, gte, sql } from "drizzle-orm";
+import type { AppEnv } from "../types";
+import { authMiddleware } from "../middleware/auth";
+import { AppError } from "../middleware/error-handler";
+import { db, user, events } from "@focusflow/db";
+
+export const adminAnalyticsRoutes = new Hono<AppEnv>();
+
+adminAnalyticsRoutes.use("*", authMiddleware);
+
+async function assertAdmin(userId: string) {
+  const [row] = await db
+    .select({ isAdmin: user.isAdmin })
+    .from(user)
+    .where(eq(user.id, userId))
+    .limit(1);
+  if (!row?.isAdmin) {
+    throw new AppError("FORBIDDEN", "Action réservée aux admins", 403);
+  }
+}
+
+function daysAgo(n: number): Date {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() - n);
+  d.setUTCHours(0, 0, 0, 0);
+  return d;
+}
+
+// GET /api/admin/analytics/events?days=30
+//
+// Returns per-day event counts over the requested window plus headline
+// totals (7d, 30d). The dashboard (#187) renders these directly — no
+// north-star derivation here yet. That formula needs an
+// `sos_helpful_rating` event that isn't instrumented (follow-up).
+adminAnalyticsRoutes.get("/events", async (c) => {
+  const me = c.get("user");
+  await assertAdmin(me.id);
+
+  const days = Math.min(Math.max(Number(c.req.query("days")) || 30, 1), 90);
+  const since = daysAgo(days - 1);
+  const since7d = daysAgo(6);
+
+  const byDay = await db
+    .select({
+      date: sql<string>`to_char(${events.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD')`,
+      eventName: events.eventName,
+      count: sql<number>`cast(count(*) as int)`,
+    })
+    .from(events)
+    .where(gte(events.createdAt, since))
+    .groupBy(
+      sql`to_char(${events.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD')`,
+      events.eventName,
+    )
+    .orderBy(
+      sql`to_char(${events.createdAt} AT TIME ZONE 'UTC', 'YYYY-MM-DD')`,
+    );
+
+  const totals7d = await db
+    .select({
+      eventName: events.eventName,
+      count: sql<number>`cast(count(*) as int)`,
+    })
+    .from(events)
+    .where(gte(events.createdAt, since7d))
+    .groupBy(events.eventName);
+
+  const totalsRange = await db
+    .select({
+      eventName: events.eventName,
+      count: sql<number>`cast(count(*) as int)`,
+    })
+    .from(events)
+    .where(gte(events.createdAt, since))
+    .groupBy(events.eventName);
+
+  return c.json({ days, byDay, totals7d, totalsRange });
+});

--- a/apps/web/src/hooks/use-admin-analytics.ts
+++ b/apps/web/src/hooks/use-admin-analytics.ts
@@ -1,0 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+
+export type EventDailyRow = {
+  date: string;
+  eventName: string;
+  count: number;
+};
+
+export type EventTotalRow = {
+  eventName: string;
+  count: number;
+};
+
+export type AnalyticsEventsResponse = {
+  days: number;
+  byDay: EventDailyRow[];
+  totals7d: EventTotalRow[];
+  totalsRange: EventTotalRow[];
+};
+
+export const adminAnalyticsKeys = {
+  events: (days: number) => ["admin-analytics", "events", days] as const,
+};
+
+export function useAdminAnalyticsEvents(days: number = 30) {
+  return useQuery({
+    queryKey: adminAnalyticsKeys.events(days),
+    queryFn: () =>
+      api.get<AnalyticsEventsResponse>(`/admin/analytics/events?days=${days}`),
+    retry: false,
+  });
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -26,7 +26,7 @@ async function confirmAndRedirect() {
   }
 }
 
-class ApiError extends Error {
+export class ApiError extends Error {
   constructor(
     public status: number,
     public code: string,

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -39,6 +39,7 @@ import { Route as AuthenticatedCarePathwayIndexRouteImport } from './routes/_aut
 import { Route as AuthenticatedBurnoutIndexRouteImport } from './routes/_authenticated/burnout/index'
 import { Route as AuthenticatedBarkleyIndexRouteImport } from './routes/_authenticated/barkley/index'
 import { Route as AuthenticatedAdminVaultIndexRouteImport } from './routes/_authenticated/admin-vault/index'
+import { Route as AuthenticatedAdminAnalyticsIndexRouteImport } from './routes/_authenticated/admin-analytics/index'
 import { Route as AuthenticatedActivityIndexRouteImport } from './routes/_authenticated/activity/index'
 import { Route as AuthenticatedAchievementsIndexRouteImport } from './routes/_authenticated/achievements/index'
 import { Route as AuthenticatedAccountIndexRouteImport } from './routes/_authenticated/account/index'
@@ -211,6 +212,12 @@ const AuthenticatedAdminVaultIndexRoute =
     path: '/admin-vault/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedAdminAnalyticsIndexRoute =
+  AuthenticatedAdminAnalyticsIndexRouteImport.update({
+    id: '/admin-analytics/',
+    path: '/admin-analytics/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedActivityIndexRoute =
   AuthenticatedActivityIndexRouteImport.update({
     id: '/activity/',
@@ -258,6 +265,7 @@ export interface FileRoutesByFullPath {
   '/account/': typeof AuthenticatedAccountIndexRoute
   '/achievements/': typeof AuthenticatedAchievementsIndexRoute
   '/activity/': typeof AuthenticatedActivityIndexRoute
+  '/admin-analytics/': typeof AuthenticatedAdminAnalyticsIndexRoute
   '/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley/': typeof AuthenticatedBarkleyIndexRoute
   '/burnout/': typeof AuthenticatedBurnoutIndexRoute
@@ -294,6 +302,7 @@ export interface FileRoutesByTo {
   '/account': typeof AuthenticatedAccountIndexRoute
   '/achievements': typeof AuthenticatedAchievementsIndexRoute
   '/activity': typeof AuthenticatedActivityIndexRoute
+  '/admin-analytics': typeof AuthenticatedAdminAnalyticsIndexRoute
   '/admin-vault': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley': typeof AuthenticatedBarkleyIndexRoute
   '/burnout': typeof AuthenticatedBurnoutIndexRoute
@@ -332,6 +341,7 @@ export interface FileRoutesById {
   '/_authenticated/account/': typeof AuthenticatedAccountIndexRoute
   '/_authenticated/achievements/': typeof AuthenticatedAchievementsIndexRoute
   '/_authenticated/activity/': typeof AuthenticatedActivityIndexRoute
+  '/_authenticated/admin-analytics/': typeof AuthenticatedAdminAnalyticsIndexRoute
   '/_authenticated/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/_authenticated/barkley/': typeof AuthenticatedBarkleyIndexRoute
   '/_authenticated/burnout/': typeof AuthenticatedBurnoutIndexRoute
@@ -370,6 +380,7 @@ export interface FileRouteTypes {
     | '/account/'
     | '/achievements/'
     | '/activity/'
+    | '/admin-analytics/'
     | '/admin-vault/'
     | '/barkley/'
     | '/burnout/'
@@ -406,6 +417,7 @@ export interface FileRouteTypes {
     | '/account'
     | '/achievements'
     | '/activity'
+    | '/admin-analytics'
     | '/admin-vault'
     | '/barkley'
     | '/burnout'
@@ -443,6 +455,7 @@ export interface FileRouteTypes {
     | '/_authenticated/account/'
     | '/_authenticated/achievements/'
     | '/_authenticated/activity/'
+    | '/_authenticated/admin-analytics/'
     | '/_authenticated/admin-vault/'
     | '/_authenticated/barkley/'
     | '/_authenticated/burnout/'
@@ -691,6 +704,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminVaultIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/admin-analytics/': {
+      id: '/_authenticated/admin-analytics/'
+      path: '/admin-analytics'
+      fullPath: '/admin-analytics/'
+      preLoaderRoute: typeof AuthenticatedAdminAnalyticsIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/activity/': {
       id: '/_authenticated/activity/'
       path: '/activity'
@@ -734,6 +754,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAccountIndexRoute: typeof AuthenticatedAccountIndexRoute
   AuthenticatedAchievementsIndexRoute: typeof AuthenticatedAchievementsIndexRoute
   AuthenticatedActivityIndexRoute: typeof AuthenticatedActivityIndexRoute
+  AuthenticatedAdminAnalyticsIndexRoute: typeof AuthenticatedAdminAnalyticsIndexRoute
   AuthenticatedAdminVaultIndexRoute: typeof AuthenticatedAdminVaultIndexRoute
   AuthenticatedBarkleyIndexRoute: typeof AuthenticatedBarkleyIndexRoute
   AuthenticatedBurnoutIndexRoute: typeof AuthenticatedBurnoutIndexRoute
@@ -760,6 +781,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAccountIndexRoute: AuthenticatedAccountIndexRoute,
   AuthenticatedAchievementsIndexRoute: AuthenticatedAchievementsIndexRoute,
   AuthenticatedActivityIndexRoute: AuthenticatedActivityIndexRoute,
+  AuthenticatedAdminAnalyticsIndexRoute: AuthenticatedAdminAnalyticsIndexRoute,
   AuthenticatedAdminVaultIndexRoute: AuthenticatedAdminVaultIndexRoute,
   AuthenticatedBarkleyIndexRoute: AuthenticatedBarkleyIndexRoute,
   AuthenticatedBurnoutIndexRoute: AuthenticatedBurnoutIndexRoute,

--- a/apps/web/src/routes/_authenticated/admin-analytics/index.tsx
+++ b/apps/web/src/routes/_authenticated/admin-analytics/index.tsx
@@ -1,0 +1,142 @@
+import { createFileRoute } from "@tanstack/react-router";
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { PageLoader } from "@/components/ui/page-loader";
+import { PageHeader } from "@/components/layout/page-header";
+import {
+  useAdminAnalyticsEvents,
+  type EventDailyRow,
+  type EventTotalRow,
+} from "@/hooks/use-admin-analytics";
+import { ApiError } from "@/lib/api-client";
+
+export const Route = createFileRoute("/_authenticated/admin-analytics/")({
+  component: AdminAnalyticsPage,
+});
+
+const EVENT_LABELS: Record<string, string> = {
+  signup_completed: "Inscriptions",
+  paywall_viewed: "Paywall vu",
+  sos_completed: "S.O.S. terminé",
+};
+
+const EVENT_COLORS: Record<string, string> = {
+  signup_completed: "#16a34a",
+  paywall_viewed: "#f59e0b",
+  sos_completed: "#3b82f6",
+};
+
+function pivotByDay(rows: EventDailyRow[]) {
+  const map = new Map<string, Record<string, number | string>>();
+  for (const row of rows) {
+    let entry = map.get(row.date);
+    if (!entry) {
+      entry = { date: row.date };
+      map.set(row.date, entry);
+    }
+    entry[row.eventName] = row.count;
+  }
+  return Array.from(map.values()).sort((a, b) =>
+    String(a.date).localeCompare(String(b.date)),
+  );
+}
+
+function totalsToMap(rows: EventTotalRow[]): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const row of rows) out[row.eventName] = row.count;
+  return out;
+}
+
+function AdminAnalyticsPage() {
+  const { data, isLoading, error } = useAdminAnalyticsEvents(30);
+
+  if (isLoading) return <PageLoader />;
+
+  if (error) {
+    const forbidden = error instanceof ApiError && error.status === 403;
+    return (
+      <div className="space-y-4">
+        <PageHeader title="Analyses internes" description="" />
+        <Card>
+          <CardContent className="py-8 text-sm text-muted-foreground">
+            {forbidden
+              ? "Cette page est réservée aux administrateurs."
+              : "Impossible de charger les analyses pour le moment."}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const totals7d = totalsToMap(data.totals7d);
+  const totalsRange = totalsToMap(data.totalsRange);
+  const series = pivotByDay(data.byDay);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Analyses internes"
+        description={`Événements collectés sur les ${data.days} derniers jours.`}
+      />
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        {Object.entries(EVENT_LABELS).map(([key, label]) => (
+          <Card key={key}>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">{label}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">{totals7d[key] ?? 0}</div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                7 derniers jours · {totalsRange[key] ?? 0} sur {data.days} jours
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Évolution quotidienne</CardTitle>
+        </CardHeader>
+        <CardContent className="h-72">
+          {series.length === 0 ? (
+            <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+              Aucun événement sur la période.
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={series}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis allowDecimals={false} />
+                <Tooltip />
+                <Legend />
+                {Object.entries(EVENT_LABELS).map(([key, label]) => (
+                  <Bar
+                    key={key}
+                    dataKey={key}
+                    name={label}
+                    fill={EVENT_COLORS[key]}
+                    stackId="a"
+                  />
+                ))}
+              </BarChart>
+            </ResponsiveContainer>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `GET /api/admin/analytics/events?days=N` — admin-only (existing `user.isAdmin`), returns per-day event counts plus 7d / range totals over a 1–90 day window.
- Adds `/admin-analytics` page rendering three stat cards (one per instrumented event) and a stacked Recharts bar chart of daily counts.
- Exports `ApiError` from `api-client.ts` so the page can surface a clean "réservée aux administrateurs" message on 403 instead of the generic 401 redirect path.

Closes the read side of #187 (analytics MVP). The North Star formula ("crises désamorcées par parent actif par semaine") is **not** derived here — it requires an `sos_helpful_rating` event that isn't instrumented yet.

## Out of scope (deferred)

- North Star Metric calculation — needs a 1-tap "ça a aidé" rating after S.O.S. closure
- Alerts on threshold crossings (#187 acceptance criteria item)
- Funnel views (paywall → trial → paid) — `trial_started` / `subscription_started` events not instrumented
- Per-metric documentation page

## Test plan

- [x] `pnpm --filter @focusflow/api test` — 81 passed, 12 skipped (2 new tests for the admin gate)
- [x] `pnpm --filter @focusflow/validators test` — 14/14 pass
- [x] `pnpm typecheck` — 4/4 packages green
- [ ] Smoke in dev: log in as an admin → navigate to `/admin-analytics` → expect the three cards and the bar chart
- [ ] Smoke in dev: log in as a non-admin → navigate to `/admin-analytics` → expect "Cette page est réservée aux administrateurs"

https://claude.ai/code/session_012vy1xTVzFuMz6hmUTojRqM

---
_Generated by [Claude Code](https://claude.ai/code/session_012vy1xTVzFuMz6hmUTojRqM)_