### PR TITLE
Reorganize navigation items by logical grouping and priority

### DIFF
--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -33,25 +33,32 @@ export type NavItem = {
 };
 
 export const navItems: readonly NavItem[] = [
+  // Ressources — apprentissage et outils de référence
   { to: "/connaissances", labelKey: "nav.knowledgeBase", icon: Library, group: "knowledge" },
+  { to: "/barkley", labelKey: "nav.barkley", shortLabelKey: "nav.barkleyShort", icon: ClipboardList, group: "knowledge" },
   { to: "/decodeur", labelKey: "nav.behaviorDecoder", icon: Brain, group: "knowledge" },
   { to: "/scripts", labelKey: "nav.communicationScripts", icon: MessageSquareText, group: "knowledge" },
+
+  // Suivi — vue d'ensemble, saisies quotidiennes, puis revue des tendances
   { to: "/dashboard", labelKey: "nav.dashboard", shortLabelKey: "nav.home", icon: BarChart3, primary: true, group: "tracking" },
-  { to: "/insights", labelKey: "nav.insights", icon: TrendingUp, group: "tracking" },
   { to: "/journal", labelKey: "nav.journal", icon: BookOpen, primary: true, group: "tracking" },
   { to: "/symptoms", labelKey: "nav.symptoms", icon: Activity, primary: true, group: "tracking" },
-  { to: "/strengths", labelKey: "nav.strengths", icon: Sparkles, group: "tracking" },
   { to: "/routines", labelKey: "nav.routines", shortLabelKey: "nav.routinesShort", icon: ListChecks, primary: true, group: "tracking" },
+  { to: "/strengths", labelKey: "nav.strengths", icon: Sparkles, group: "tracking" },
   { to: "/rewards", labelKey: "nav.rewards", shortLabelKey: "nav.rewardsShort", icon: Trophy, group: "tracking" },
+  { to: "/insights", labelKey: "nav.insights", icon: TrendingUp, group: "tracking" },
+
+  // Soins — urgence d'abord, puis routines médicales, dossier et bien-être parental
   { to: "/crisis-list", labelKey: "nav.crisisList", shortLabelKey: "nav.crisis", icon: HandHeart, group: "care" },
   { to: "/medications", labelKey: "nav.medications", icon: Pill, group: "care" },
   { to: "/timer", labelKey: "nav.timer", icon: Timer, group: "care" },
   { to: "/care-pathway", labelKey: "nav.carePathway", icon: Stethoscope, group: "care" },
   { to: "/admin-vault", labelKey: "nav.adminVault", icon: Vault, group: "care" },
   { to: "/burnout", labelKey: "nav.burnout", icon: HeartPulse, group: "care" },
-  { to: "/barkley", labelKey: "nav.barkley", shortLabelKey: "nav.barkleyShort", icon: ClipboardList, group: "care" },
-  { to: "/activity", labelKey: "nav.activity", icon: History, group: "account" },
+
+  // Compte — motivation, historique, paramètres
   { to: "/achievements", labelKey: "nav.achievements", icon: Award, group: "account" },
+  { to: "/activity", labelKey: "nav.activity", icon: History, group: "account" },
   { to: "/account", labelKey: "nav.account", icon: UserCog, group: "account" },
 ] as const;
 


### PR DESCRIPTION
## Summary
Restructured the navigation menu to improve information architecture by organizing items into four logical groups with clear hierarchies and adding descriptive comments for each section.

## Key Changes
- **Reorganized navigation groups** with French section headers:
  - "Ressources" (Resources): Knowledge base, Barkley assessment, behavior decoder, communication scripts
  - "Suivi" (Tracking): Dashboard, journal, symptoms, routines, strengths, rewards, and insights
  - "Soins" (Care): Crisis management, medications, timer, care pathway, admin vault, and burnout support
  - "Compte" (Account): Achievements, activity history, and account settings

- **Moved Barkley assessment** from "care" group to "knowledge" group, as it's a reference tool rather than a care action
- **Reordered tracking items** to follow a logical flow: overview (dashboard) → daily entries (journal, symptoms, routines) → analysis (strengths, rewards, insights)
- **Reordered account items** to prioritize achievements before activity history
- **Added section comments** in French to clarify the purpose of each navigation group

## Implementation Details
- No functional changes to navigation behavior or routing
- All items retain their original `to`, `labelKey`, `icon`, and `primary` properties
- Reorganization improves UX by grouping related features and establishing clear mental models for users

https://claude.ai/code/session_011qmvsrBqQ4upTMaUndcmA7