### PR TITLE
Increase PWA cache size limit to 5MB

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig({
       includeAssets: ["favicon.svg", "icon.svg"],
       workbox: {
         globPatterns: ["**/*.{js,css,html,svg,png,woff2}"],
+        maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
         navigateFallback: "/index.html",
         navigateFallbackDenylist: [/^\/api\//],
         runtimeCaching: [


### PR DESCRIPTION
## Summary
Increased the maximum file size limit for PWA caching in the Workbox configuration to allow larger assets to be cached offline.

## Changes
- Set `maximumFileSizeToCacheInBytes` to 5MB (5 * 1024 * 1024 bytes) in the Workbox configuration
  - This allows the service worker to cache files up to 5MB in size, previously using Workbox's default limit of 2MB
  - Enables larger assets (images, fonts, bundles) to be included in the offline cache

## Details
This change improves the offline experience by allowing more substantial assets to be cached with the service worker, reducing the need for network requests when the app is accessed offline or on slow connections.

https://claude.ai/code/session_01KXABkoDZo6sfVH9FER6NZP