### PR TITLE
Add admin badge to user menu

### DIFF
--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -14,6 +14,18 @@ export const auth = betterAuth({
     ...devWebOrigins,
     ...(env.CORS_ORIGIN ? [env.CORS_ORIGIN] : []),
   ],
+  user: {
+    additionalFields: {
+      // Surfaced on the session so the client can show an "Admin" badge.
+      // input: false — admin elevation is never user-provided at signup.
+      isAdmin: {
+        type: "boolean",
+        required: false,
+        defaultValue: false,
+        input: false,
+      },
+    },
+  },
   emailAndPassword: {
     enabled: true,
     // Better Auth appends ?token=... and uses this URL as the redirect target

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -259,6 +259,7 @@
     "support": "Help & support",
     "tour": "Guided tour",
     "userMenu": "User menu",
+    "admin": "Admin",
     "buildAt": "Built on {{date}} at {{time}}",
     "skipToContent": "Skip to main content",
     "toggleSidebar": "Toggle sidebar",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -263,6 +263,7 @@
     "support": "Aide & support",
     "tour": "Visite guidée",
     "userMenu": "Menu utilisateur",
+    "admin": "Admin",
     "buildAt": "Build du {{date}} à {{time}}",
     "skipToContent": "Aller au contenu principal",
     "toggleSidebar": "Afficher la navigation",

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { Heart, LogOut, LifeBuoy, ChevronDown, Menu, Lock, UserCog, Compass } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import {
@@ -233,10 +234,16 @@ function UserMenu() {
   const session = useSession();
   const { openKoe, available: koeAvailable } = useKoeTrigger();
 
-  const user = session.data?.user;
+  // Better Auth's React client is cast to a generic `ReturnType<typeof createAuthClient>`
+  // in auth-client.ts, which drops the inferred additionalFields. Re-narrow here so we
+  // can read `isAdmin` (surfaced via `user.additionalFields` on the server).
+  const user = session.data?.user as
+    | { name: string; email?: string | null; isAdmin?: boolean }
+    | undefined;
   if (!user) return null;
 
   const userInitial = user.name?.trim().charAt(0).toUpperCase() ?? "?";
+  const isAdmin = user.isAdmin === true;
 
   const handleSignOut = () => {
     invalidateSessionCache();
@@ -265,8 +272,15 @@ function UserMenu() {
           {userInitial}
         </span>
         <span className="flex min-w-0 flex-1 flex-col group-data-[collapsible=icon]:hidden">
-          <span className="truncate text-sm font-medium text-sidebar-foreground">
-            {user.name}
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate text-sm font-medium text-sidebar-foreground">
+              {user.name}
+            </span>
+            {isAdmin && (
+              <Badge variant="secondary" className="shrink-0">
+                {t("nav.admin")}
+              </Badge>
+            )}
           </span>
           {user.email && (
             <span className="truncate text-xs text-muted-foreground">
@@ -278,8 +292,15 @@ function UserMenu() {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" side="top" className="w-60">
         <DropdownMenuLabel>
-          <span className="truncate text-sm font-medium text-foreground">
-            {user.name}
+          <span className="flex min-w-0 items-center gap-1.5">
+            <span className="truncate text-sm font-medium text-foreground">
+              {user.name}
+            </span>
+            {isAdmin && (
+              <Badge variant="secondary" className="shrink-0">
+                {t("nav.admin")}
+              </Badge>
+            )}
           </span>
           {user.email && (
             <span className="truncate text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
This PR adds an "Admin" badge to the user menu, allowing admins to be visually identified in the UI. The implementation includes backend support for an `isAdmin` field and frontend display logic.

## Key Changes
- **Backend (auth.ts)**: Added `isAdmin` as an additional user field in Better Auth configuration
  - Set as a boolean field with `defaultValue: false`
  - Marked as `input: false` to prevent user-provided elevation at signup
  - Surfaced on the session for client-side access

- **Frontend (user menu)**: Updated the user menu component to display an admin badge
  - Added type narrowing for the user object to properly access the `isAdmin` field
  - Displayed badge in both the sidebar trigger and dropdown menu label
  - Used existing `Badge` component with `secondary` variant
  - Badge is shrink-proof to prevent layout issues with long usernames

- **Internationalization**: Added "Admin" label translations
  - English: "Admin"
  - French: "Admin"

## Implementation Details
- The `isAdmin` field is cast explicitly in the component since Better Auth's React client type inference doesn't preserve `additionalFields`
- The badge appears next to the user's name in both collapsed and expanded sidebar states
- Flexbox layout with `gap-1.5` ensures proper spacing between name and badge

https://claude.ai/code/session_01HzU7xAwGwia7s3Zjode1rz