### PR TITLE
Move achievements and activity to user menu dropdown

### DIFF
--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -66,7 +66,6 @@ export const navGroups: { key: NavItem["group"]; labelKey: string }[] = [
   { key: "knowledge", labelKey: "nav.groupKnowledge" },
   { key: "tracking", labelKey: "nav.groupTracking" },
   { key: "care", labelKey: "nav.groupCare" },
-  { key: "account", labelKey: "nav.groupAccount" },
 ];
 
 export const primaryNavItems = navItems.filter((i) => i.primary);

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -268,7 +268,6 @@
     "groupKnowledge": "Resources",
     "groupTracking": "Tracking",
     "groupCare": "Care",
-    "groupAccount": "Account",
     "breadcrumbHome": "Home"
   },
   "contact": {

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -272,7 +272,6 @@
     "groupKnowledge": "Ressources",
     "groupTracking": "Suivi",
     "groupCare": "Soins",
-    "groupAccount": "Compte",
     "breadcrumbHome": "Accueil"
   },
   "contact": {

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -6,7 +6,7 @@ import {
   useRouterState,
 } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { Heart, LogOut, LifeBuoy, ChevronDown, Menu, Lock, UserCog, Compass } from "lucide-react";
+import { Heart, LogOut, LifeBuoy, ChevronDown, Menu, Lock, UserCog, Compass, Award, History } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -309,6 +309,14 @@ function UserMenu() {
           )}
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
+        <DropdownMenuItem render={<Link to="/achievements" />}>
+          <Award className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          {t("nav.achievements")}
+        </DropdownMenuItem>
+        <DropdownMenuItem render={<Link to="/activity" />}>
+          <History className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          {t("nav.activity")}
+        </DropdownMenuItem>
         <DropdownMenuItem render={<Link to="/account" />}>
           <UserCog className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
           {t("nav.account")}


### PR DESCRIPTION
## Summary
Reorganized navigation by moving the Achievements and Activity pages from the main navigation sidebar to the user menu dropdown in the authenticated layout. This declutters the main navigation while keeping these user-specific features easily accessible.

## Key Changes
- Added `Award` and `History` icons from lucide-react to the authenticated layout imports
- Added two new menu items to the UserMenu dropdown:
  - Achievements (with Award icon)
  - Activity (with History icon)
- Removed the "Account" navigation group from the nav configuration and i18n files (en.json and fr.json)

## Implementation Details
- The new menu items are positioned before the existing Account settings item in the dropdown
- Both items use the same styling pattern as other dropdown menu items with icons and translation keys
- The changes maintain consistency with the existing UI patterns and internationalization setup

https://claude.ai/code/session_01FEd9WkN9gcNKnqRDv7vVJa