### PR TITLE
Analytics: time-to-aha on admin dashboard (#186)

### DIFF
--- a/apps/api/src/routes/admin-analytics.ts
+++ b/apps/api/src/routes/admin-analytics.ts
@@ -107,5 +107,70 @@ adminAnalyticsRoutes.get("/events", async (c) => {
     northStar: activeParents > 0 ? helpful / activeParents : null,
   };
 
-  return c.json({ days, byDay, totals7d, totalsRange, derived7d });
+  // Time-to-aha over the same window — median + p75 seconds between
+  // signup (user.created_at, the most reliable source) and the first
+  // sos_helpful_rating with helpful=true. Also computes the D7 reach
+  // rate on a stable cohort (signed up at least 7d ago) so a sudden
+  // drop in fresh signups doesn't move the number.
+  const since7dCohort = daysAgo(days - 1);
+  const cohortCutoff = daysAgo(6); // need 7d of observation window
+
+  const ahaRows = await db.execute<{
+    median_seconds: number | null;
+    p75_seconds: number | null;
+    users_reached: number;
+  }>(sql`
+    with first_aha as (
+      select
+        u.id as user_id,
+        u.created_at as signup_at,
+        min(e.created_at) as aha_at
+      from "user" u
+      inner join events e
+        on e.parent_id = u.id
+        and e.event_name = 'sos_helpful_rating'
+        and e.properties ->> 'helpful' = 'true'
+      where u.created_at >= ${since7dCohort}
+      group by u.id, u.created_at
+    )
+    select
+      cast(extract(epoch from percentile_cont(0.5) within group (order by (aha_at - signup_at))) as int) as median_seconds,
+      cast(extract(epoch from percentile_cont(0.75) within group (order by (aha_at - signup_at))) as int) as p75_seconds,
+      cast(count(*) as int) as users_reached
+    from first_aha
+  `);
+
+  const [cohortRow] = await db
+    .select({
+      signups: sql<number>`cast(count(*) as int)`,
+      reachedD7: sql<number>`cast(count(*) filter (
+        where exists (
+          select 1 from ${events} e
+          where e.parent_id = ${user.id}
+            and e.event_name = 'sos_helpful_rating'
+            and e.properties ->> 'helpful' = 'true'
+            and e.created_at <= ${user.createdAt} + interval '7 days'
+        )
+      ) as int)`,
+    })
+    .from(user)
+    .where(
+      sql`${user.createdAt} >= ${since7dCohort} and ${user.createdAt} < ${cohortCutoff}`,
+    );
+
+  // postgres-js returns an array-like RowList; first row holds the aggregate.
+  const ahaStats = ahaRows[0] ?? null;
+  const cohortSignups = cohortRow?.signups ?? 0;
+  const reachedD7 = cohortRow?.reachedD7 ?? 0;
+
+  const timeToAha = {
+    medianSeconds: ahaStats?.median_seconds ?? null,
+    p75Seconds: ahaStats?.p75_seconds ?? null,
+    usersReached: ahaStats?.users_reached ?? 0,
+    cohortSignups,
+    reachedD7,
+    reachRateD7: cohortSignups > 0 ? reachedD7 / cohortSignups : null,
+  };
+
+  return c.json({ days, byDay, totals7d, totalsRange, derived7d, timeToAha });
 });

--- a/apps/web/src/hooks/use-admin-analytics.ts
+++ b/apps/web/src/hooks/use-admin-analytics.ts
@@ -23,12 +23,22 @@ export type DerivedKpis = {
   northStar: number | null;
 };
 
+export type TimeToAha = {
+  medianSeconds: number | null;
+  p75Seconds: number | null;
+  usersReached: number;
+  cohortSignups: number;
+  reachedD7: number;
+  reachRateD7: number | null;
+};
+
 export type AnalyticsEventsResponse = {
   days: number;
   byDay: EventDailyRow[];
   totals7d: EventTotalRow[];
   totalsRange: EventTotalRow[];
   derived7d: DerivedKpis;
+  timeToAha: TimeToAha;
 };
 
 export const adminAnalyticsKeys = {

--- a/apps/web/src/routes/_authenticated/admin-analytics/index.lazy.tsx
+++ b/apps/web/src/routes/_authenticated/admin-analytics/index.lazy.tsx
@@ -52,6 +52,20 @@ function formatNumber(value: number | null, fractionDigits: number): string {
   });
 }
 
+// Humanises a seconds count into "X min", "X h", "X j" — admins read
+// the dashboard quickly and a raw seconds figure is meaningless past
+// a few minutes.
+function formatDuration(seconds: number | null): string {
+  if (seconds === null || seconds < 0) return "—";
+  if (seconds < 60) return `${seconds} s`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes} min`;
+  const hours = Math.round(seconds / 3600);
+  if (hours < 48) return `${hours} h`;
+  const days = Math.round(seconds / 86400);
+  return `${days} j`;
+}
+
 function pivotByDay(rows: EventDailyRow[]) {
   const map = new Map<string, Record<string, number | string>>();
   for (const row of rows) {
@@ -100,6 +114,7 @@ function AdminAnalyticsPage() {
   const totalsRange = totalsToMap(data.totalsRange);
   const series = pivotByDay(data.byDay);
   const kpis = data.derived7d;
+  const aha = data.timeToAha;
 
   return (
     <div className="space-y-6">
@@ -156,6 +171,57 @@ function AdminAnalyticsPage() {
               </div>
               <div className="mt-1 text-xs text-muted-foreground">
                 {kpis.trialsStarted} essais sur {kpis.paywallViews} affichages
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Time-to-aha — signup → 1ʳᵉ crise désamorcée
+        </h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">
+                Médiane (P50)
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">
+                {formatDuration(aha.medianSeconds)}
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {aha.usersReached} utilisateurs ayant atteint l'aha-moment
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">P75</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">
+                {formatDuration(aha.p75Seconds)}
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                75 % des aha-reachers ont mis ce délai ou moins
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">
+                Taux d'aha à J+7
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">
+                {formatPercent(aha.reachRateD7)}
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {aha.reachedD7} sur {aha.cohortSignups} signups · cible 50 %
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary

- Adds a Postgres `PERCENTILE_CONT(0.5/0.75)` aggregation on `(events.created_at - user.created_at)` for users who fired a `sos_helpful_rating` with `helpful=true`.
- Adds a D7 reach-rate on a stable cohort (signed up at least 7 days ago) so a sudden inflow of fresh signups doesn't swing the headline.
- Renders both as a new KPI strip on `/admin-analytics` (P50, P75, reach@D7). `formatDuration` humanises the seconds to min/h/j so the number stays readable past a few hours.

Closes the **time-to-aha** instrumentation item on #186. The remaining acceptance criteria on #186 are onboarding curation (UX decision) and the 50% D7 target (operational, not code).

## Out of scope

- Onboarding curation that pushes users toward the 3 free guides + 1 protocol — needs UX decisions on which exact content to surface and how
- Per-week cohort breakdown — single rolled-up number is enough to start; cohort table can come once we have real traffic
- LTV / CAC + threshold alerts — separate slice (needs Stripe webhook events)

## Test plan

- [x] `pnpm --filter @focusflow/api test admin-analytics` — 2/2 pass (auth gate)
- [x] `pnpm typecheck` — 4/4 packages green
- [x] `pnpm --filter @focusflow/web build` + bundle budget — 560.6 kB / 570 kB
- [ ] Smoke: open `/admin-analytics` as an admin → expect the Time-to-aha strip to render with "—" on a fresh DB and real durations once events accumulate

https://claude.ai/code/session_012vy1xTVzFuMz6hmUTojRqM

---
_Generated by [Claude Code](https://claude.ai/code/session_012vy1xTVzFuMz6hmUTojRqM)_