### PR TITLE
Analytics: invisible-churn signals + corrective alerts (#191)

### DIFF
--- a/apps/api/src/routes/admin-analytics.ts
+++ b/apps/api/src/routes/admin-analytics.ts
@@ -216,10 +216,112 @@ adminAnalyticsRoutes.get("/events", async (c) => {
     ltvMonths,
   };
 
+  // Invisible-churn signals (#191). We don't have a session_started
+  // event yet, so "no activity" is approximated by "no event in the
+  // events table for this parentId in the last 14 days". This misses
+  // browsing without a tracked action — acceptable as a first cut.
+  const since14d = daysAgo(13);
+  const eligibleSince = daysAgo(13);
+  const oldestCohort = daysAgo(60);
+
+  const [churnRow] = await db
+    .select({
+      // Signed up >14d ago, ≤60d ago (cohort with enough watch window
+      // but recent enough to be relevant) and no event in last 14d.
+      disengaged: sql<number>`cast(count(*) filter (
+        where ${user.createdAt} < ${eligibleSince}
+          and ${user.createdAt} >= ${oldestCohort}
+          and not exists (
+            select 1 from ${events} e
+            where e.parent_id = ${user.id}
+              and e.created_at >= ${since14d}
+          )
+      ) as int)`,
+      // Same cohort denominator.
+      eligible: sql<number>`cast(count(*) filter (
+        where ${user.createdAt} < ${eligibleSince}
+          and ${user.createdAt} >= ${oldestCohort}
+      ) as int)`,
+    })
+    .from(user);
+
+  // Users who fired sos_completed but never sos_helpful_rating.
+  // Strong signal that the SOS experience didn't land — the user
+  // closed the screen without telling us whether it helped.
+  const [silentSos] = await db.execute<{ silent: number; total: number }>(sql`
+    with sos_users as (
+      select distinct parent_id
+      from events
+      where event_name = 'sos_completed'
+        and parent_id is not null
+    ),
+    rated_users as (
+      select distinct parent_id
+      from events
+      where event_name = 'sos_helpful_rating'
+        and parent_id is not null
+    )
+    select
+      cast(count(*) filter (where rated_users.parent_id is null) as int) as silent,
+      cast(count(*) as int) as total
+    from sos_users
+    left join rated_users on sos_users.parent_id = rated_users.parent_id
+  `);
+
+  // Users who saw the paywall ≥7 days ago but never started a trial.
+  const paywallCutoff = daysAgo(6);
+  const [paywallStall] = await db.execute<{
+    stalled: number;
+    total: number;
+  }>(sql`
+    with paywall_users as (
+      select parent_id, min(created_at) as first_view
+      from events
+      where event_name = 'paywall_viewed'
+        and parent_id is not null
+      group by parent_id
+    ),
+    trial_users as (
+      select distinct parent_id
+      from events
+      where event_name = 'trial_started'
+        and parent_id is not null
+    )
+    select
+      cast(count(*) filter (
+        where trial_users.parent_id is null
+          and paywall_users.first_view < ${paywallCutoff}
+      ) as int) as stalled,
+      cast(count(*) filter (where paywall_users.first_view < ${paywallCutoff}) as int) as total
+    from paywall_users
+    left join trial_users on paywall_users.parent_id = trial_users.parent_id
+  `);
+
+  const disengaged = churnRow?.disengaged ?? 0;
+  const eligibleCohort = churnRow?.eligible ?? 0;
+  const silentSosCount = silentSos?.silent ?? 0;
+  const sosUserTotal = silentSos?.total ?? 0;
+  const paywallStallCount = paywallStall?.stalled ?? 0;
+  const paywallStallTotal = paywallStall?.total ?? 0;
+
+  const churnSignals = {
+    disengaged,
+    eligibleCohort,
+    disengagedRate:
+      eligibleCohort > 0 ? disengaged / eligibleCohort : null,
+    silentSos: silentSosCount,
+    sosUserTotal,
+    silentSosRate: sosUserTotal > 0 ? silentSosCount / sosUserTotal : null,
+    paywallStall: paywallStallCount,
+    paywallStallTotal,
+    paywallStallRate:
+      paywallStallTotal > 0 ? paywallStallCount / paywallStallTotal : null,
+  };
+
   // Threshold alerts. Inline on the dashboard rather than wired to
   // email/Slack: the surface is already admin-only and refreshed
   // manually, so a noisy push channel would add cost without recall.
-  // Targets come straight from #178 / #187 acceptance criteria.
+  // Targets come straight from #178 / #187 / #191 acceptance criteria.
   const alerts: Array<{ level: "warn" | "critical"; message: string }> = [];
   if (timeToAha.medianSeconds !== null && timeToAha.medianSeconds > 7 * 86400) {
     alerts.push({
@@ -245,10 +347,31 @@ adminAnalyticsRoutes.get("/events", async (c) => {
       message: `Churn mensuel payant ${(monthlyChurnRate * 100).toFixed(1)} % — cible < 6 %.`,
     });
   }
+  if (
+    churnSignals.eligibleCohort >= 20 &&
+    churnSignals.disengagedRate !== null &&
+    churnSignals.disengagedRate > 0.5
+  ) {
+    alerts.push({
+      level: "warn",
+      message: `Plus de 50 % des inscrits hors période d'observation sont silencieux depuis 14 j (${disengaged}/${eligibleCohort}). Boucle de réengagement à envisager.`,
+    });
+  }
+  if (
+    churnSignals.sosUserTotal >= 20 &&
+    churnSignals.silentSosRate !== null &&
+    churnSignals.silentSosRate > 0.7
+  ) {
+    alerts.push({
+      level: "warn",
+      message: `${(churnSignals.silentSosRate * 100).toFixed(0)} % des utilisateurs ont déclenché un S.O.S. sans jamais le noter. Le tap "Ça a aidé ?" est peut-être trop discret.`,
+    });
+  }
 
   return c.json({
     days,
     byDay,
+    churnSignals,
     totals7d,
     totalsRange,
     derived7d,

--- a/apps/web/src/hooks/use-admin-analytics.ts
+++ b/apps/web/src/hooks/use-admin-analytics.ts
@@ -45,6 +45,18 @@ export type AnalyticsAlert = {
   message: string;
 };
 
+export type ChurnSignals = {
+  disengaged: number;
+  eligibleCohort: number;
+  disengagedRate: number | null;
+  silentSos: number;
+  sosUserTotal: number;
+  silentSosRate: number | null;
+  paywallStall: number;
+  paywallStallTotal: number;
+  paywallStallRate: number | null;
+};
+
 export type AnalyticsEventsResponse = {
   days: number;
   byDay: EventDailyRow[];
@@ -53,6 +65,7 @@ export type AnalyticsEventsResponse = {
   derived7d: DerivedKpis;
   timeToAha: TimeToAha;
   paid30d: Paid30d;
+  churnSignals: ChurnSignals;
   alerts: AnalyticsAlert[];
 };
 

--- a/apps/web/src/routes/_authenticated/admin-analytics/index.lazy.tsx
+++ b/apps/web/src/routes/_authenticated/admin-analytics/index.lazy.tsx
@@ -120,6 +120,7 @@ function AdminAnalyticsPage() {
   const kpis = data.derived7d;
   const aha = data.timeToAha;
   const paid = data.paid30d;
+  const churn = data.churnSignals;
   const alerts = data.alerts;
 
   return (
@@ -250,6 +251,60 @@ function AdminAnalyticsPage() {
               </div>
               <div className="mt-1 text-xs text-muted-foreground">
                 {aha.reachedD7} sur {aha.cohortSignups} signups · cible 50 %
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </section>
+
+      <section className="space-y-3">
+        <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Signaux de churn invisible
+        </h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">
+                Inscrits silencieux · 14 j
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">
+                {formatPercent(churn.disengagedRate)}
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {churn.disengaged} / {churn.eligibleCohort} dans la cohorte
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">
+                S.O.S. jamais notés
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">
+                {formatPercent(churn.silentSosRate)}
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {churn.silentSos} / {churn.sosUserTotal} utilisateurs
+              </div>
+            </CardContent>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardTitle className="text-sm font-medium">
+                Paywall sans suite
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">
+                {formatPercent(churn.paywallStallRate)}
+              </div>
+              <div className="mt-1 text-xs text-muted-foreground">
+                {churn.paywallStall} / {churn.paywallStallTotal} vus &gt; 7 j
+                sans essai
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary

Adds the three invisible-churn signals from #191, derived from the existing `events` table — no new client instrumentation needed for this slice.

- **Inscrits silencieux 14j** — users who signed up between 14 and 60 days ago with zero events in the last 14 days. Cohort window excludes users who haven't had a chance to be observed yet.
- **S.O.S. jamais notés** — users who fired `sos_completed` at least once but never `sos_helpful_rating`. Signals the 1-tap rating dialog isn't landing.
- **Paywall sans suite** — users who saw the paywall ≥ 7 days ago and never fired `trial_started`.

Plus two new threshold alerts at the top of `/admin-analytics`:
- disengaged-rate > 50 % on cohort ≥ 20 (warn) — réengagement loop suggested
- silent-SOS rate > 70 % on ≥ 20 users (warn) — dialog visibility issue

## Out of scope (still on #191)

- **"Sessions < 1/semaine"** — needs a `session_started` event. Today we only fire on specific actions (signup, paywall view, S.O.S.). Adding it is a separate small slice.
- **Per-acquisition / per-profil segmentation** — needs an acquisition-source field on `user` or an extra event property
- **Email réengagement bienveillant + court sondage** — operational work, not code-only

## Test plan

- [x] `pnpm --filter @focusflow/api test admin-analytics` — 2/2 pass
- [x] `pnpm typecheck` — 4/4 packages green
- [x] `pnpm --filter @focusflow/web build` + bundle budget — 563.4 kB / 570 kB
- [ ] Smoke: open `/admin-analytics` as an admin on a fresh DB → expect "—" on all three signals
- [ ] Smoke: insert ≥ 20 users older than 14 days with zero events → expect the disengaged-rate alert at the top

https://claude.ai/code/session_012vy1xTVzFuMz6hmUTojRqM

---
_Generated by [Claude Code](https://claude.ai/code/session_012vy1xTVzFuMz6hmUTojRqM)_