### PR TITLE
Add admin analytics page with role-based access control

### DIFF
--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -19,17 +19,20 @@ import {
   HeartPulse,
   MessageSquareText,
   TrendingUp,
+  ShieldCheck,
 } from "lucide-react";
 
 export type NavItem = {
-  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/timer" | "/care-pathway" | "/admin-vault" | "/achievements" | "/activity" | "/connaissances" | "/account" | "/decodeur" | "/burnout" | "/insights" | "/scripts";
+  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/timer" | "/care-pathway" | "/admin-vault" | "/admin-analytics" | "/achievements" | "/activity" | "/connaissances" | "/account" | "/decodeur" | "/burnout" | "/insights" | "/scripts";
   labelKey: string;
   shortLabelKey?: string;
   icon: React.ComponentType<{ className?: string }>;
   /** Surfaced in the mobile bottom tab bar (max 4). */
   primary?: boolean;
   /** Section grouping in the desktop sidebar. */
-  group: "knowledge" | "tracking" | "care" | "account";
+  group: "knowledge" | "tracking" | "care" | "account" | "admin";
+  /** Restricts the item to users with `isAdmin === true`. */
+  requiresAdmin?: boolean;
 };
 
 export const navItems: readonly NavItem[] = [
@@ -60,12 +63,16 @@ export const navItems: readonly NavItem[] = [
   { to: "/achievements", labelKey: "nav.achievements", icon: Award, group: "account" },
   { to: "/activity", labelKey: "nav.activity", icon: History, group: "account" },
   { to: "/account", labelKey: "nav.account", icon: UserCog, group: "account" },
+
+  // Admin — réservé aux utilisateurs avec isAdmin === true
+  { to: "/admin-analytics", labelKey: "nav.adminAnalytics", icon: ShieldCheck, group: "admin", requiresAdmin: true },
 ] as const;
 
 export const navGroups: { key: NavItem["group"]; labelKey: string }[] = [
   { key: "knowledge", labelKey: "nav.groupKnowledge" },
   { key: "tracking", labelKey: "nav.groupTracking" },
   { key: "care", labelKey: "nav.groupCare" },
+  { key: "admin", labelKey: "nav.groupAdmin" },
 ];
 
 export const primaryNavItems = navItems.filter((i) => i.primary);

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -239,6 +239,7 @@
     "timer": "Timer",
     "carePathway": "Care pathway",
     "adminVault": "Vault",
+    "adminAnalytics": "Internal analytics",
     "achievements": "My badges",
     "activity": "Activity",
     "barkley": "Barkley program",
@@ -268,6 +269,7 @@
     "groupKnowledge": "Resources",
     "groupTracking": "Tracking",
     "groupCare": "Care",
+    "groupAdmin": "Admin",
     "breadcrumbHome": "Home"
   },
   "contact": {

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -243,6 +243,7 @@
     "communicationScripts": "Scripts de communication",
     "burnout": "Test burn-out parental",
     "adminVault": "Coffre-fort",
+    "adminAnalytics": "Analyses internes",
     "achievements": "Mes badges",
     "activity": "Activité",
     "barkley": "Programme Barkley",
@@ -272,6 +273,7 @@
     "groupKnowledge": "Ressources",
     "groupTracking": "Suivi",
     "groupCare": "Soins",
+    "groupAdmin": "Administration",
     "breadcrumbHome": "Accueil"
   },
   "contact": {

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -144,6 +144,9 @@ function AppSidebar() {
   const { t, i18n } = useTranslation();
   const { setOpenMobile } = useSidebar();
   const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const session = useSession();
+  const isAdmin =
+    (session.data?.user as { isAdmin?: boolean } | undefined)?.isAdmin === true;
 
   const locale = i18n.resolvedLanguage === "en" ? "en-US" : "fr-FR";
   const buildDateObj = new Date(__BUILD_DATE__);
@@ -180,7 +183,9 @@ function AppSidebar() {
 
       <SidebarContent>
         {navGroups.map((group) => {
-          const items = navItems.filter((i) => i.group === group.key);
+          const items = navItems.filter(
+            (i) => i.group === group.key && (!i.requiresAdmin || isAdmin),
+          );
           if (items.length === 0) return null;
           return (
             <SidebarGroup key={group.key}>


### PR DESCRIPTION
## Summary
This PR introduces a new admin analytics page accessible only to users with admin privileges, along with role-based access control for navigation items.

## Key Changes
- **New Navigation Item**: Added `/admin-analytics` route to the navigation configuration with a new "admin" group
- **Role-Based Access Control**: 
  - Added `requiresAdmin` optional property to `NavItem` type to restrict navigation items to admin users
  - Updated sidebar rendering to filter out admin-only items for non-admin users
  - Added `isAdmin` check in `AppSidebar` component using session data
- **UI Updates**:
  - Added `ShieldCheck` icon from lucide-react for the admin analytics nav item
  - Created new "admin" navigation group separate from existing groups (knowledge, tracking, care, account)
- **Internationalization**:
  - Added English translation: "Internal analytics"
  - Added French translation: "Analyses internes"
  - Added group labels for both languages: "Admin" (EN) and "Administration" (FR)

## Implementation Details
- The admin check filters navigation items at render time based on the authenticated user's `isAdmin` property
- Admin items are completely hidden from non-admin users rather than disabled
- The implementation follows the existing navigation structure and patterns

https://claude.ai/code/session_01QcrUSgMfR6sbns52e65r3K