### PR TITLE
feat(timer): launch user routines as sequential timer chains

### DIFF
--- a/apps/web/src/components/timer/sequences.ts
+++ b/apps/web/src/components/timer/sequences.ts
@@ -4,26 +4,35 @@
 // feature for the "épuisé" persona — it replaces the parent's voice
 // repeating "next step now" at every transition.
 //
-// Slated for premium gating once the paywall infrastructure lands
-// (see issue #184). Currently shipped free because there is no paywall
-// code to honor, and `docs/freemium-ethics-policy.md` forbids surprise
-// gating — better free now than gated retroactively.
+// Sequences come from two sources:
+//   - built-in ready-made templates (translated via i18n)
+//   - the user's own routines (created in the Routines tab), where each
+//     step that has a duration becomes a chained timer step.
+
+import type { TFunction } from "i18next";
+import type { Routine } from "@focusflow/validators";
 
 export type SequenceStep = {
-  /** i18n key under `timer.sequences.<sequenceId>.steps.<stepId>` */
-  labelKey: string;
+  label: string;
+  emoji?: string;
   durationSec: number;
 };
 
 export type SequenceTemplate = {
   id: string;
-  /** i18n key under `timer.sequences.<sequenceId>.label` */
-  labelKey: string;
+  label: string;
   emoji: string;
   steps: SequenceStep[];
 };
 
-export const SEQUENCE_TEMPLATES: SequenceTemplate[] = [
+type BuiltinSequenceDef = {
+  id: string;
+  labelKey: string;
+  emoji: string;
+  steps: { labelKey: string; durationSec: number }[];
+};
+
+const BUILTIN_SEQUENCES: BuiltinSequenceDef[] = [
   {
     id: "matin",
     labelKey: "timer.sequences.matin.label",
@@ -55,6 +64,41 @@ export const SEQUENCE_TEMPLATES: SequenceTemplate[] = [
     ],
   },
 ];
+
+export function getBuiltinSequences(t: TFunction): SequenceTemplate[] {
+  return BUILTIN_SEQUENCES.map((seq) => ({
+    id: `builtin-${seq.id}`,
+    label: t(seq.labelKey),
+    emoji: seq.emoji,
+    steps: seq.steps.map((step) => ({
+      label: t(step.labelKey),
+      durationSec: step.durationSec,
+    })),
+  }));
+}
+
+const FALLBACK_ROUTINE_EMOJI = "📋";
+
+// Convert a user routine into a runnable sequence. Only steps with a
+// duration become timer steps — steps without a duration are checklist
+// items only, not timer-friendly. Returns null when no step is usable.
+export function routineToSequence(routine: Routine): SequenceTemplate | null {
+  const usable = routine.steps
+    .slice()
+    .sort((a, b) => a.position - b.position)
+    .filter((s) => (s.durationMinutes ?? 0) > 0);
+  if (usable.length === 0) return null;
+  return {
+    id: `user-${routine.id}`,
+    label: routine.name,
+    emoji: routine.emoji ?? FALLBACK_ROUTINE_EMOJI,
+    steps: usable.map((s) => ({
+      label: s.label,
+      emoji: s.emoji ?? undefined,
+      durationSec: (s.durationMinutes ?? 0) * 60,
+    })),
+  };
+}
 
 export function totalSequenceDurationSec(seq: SequenceTemplate): number {
   return seq.steps.reduce((sum, step) => sum + step.durationSec, 0);

--- a/apps/web/src/components/timer/visual-timer.tsx
+++ b/apps/web/src/components/timer/visual-timer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Play,
@@ -13,7 +13,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
-  SEQUENCE_TEMPLATES,
+  getBuiltinSequences,
   totalSequenceDurationSec,
   type SequenceTemplate,
 } from "./sequences";
@@ -97,8 +97,16 @@ const VIBRATION_PATTERN_MS = [
   220, 80, 220, 80, 220, 80, 220, 200, 220, 80, 220, 80, 480,
 ] as const;
 
-export function VisualTimer({ defaultMinutes = 10 }: { defaultMinutes?: number }) {
+export function VisualTimer({
+  defaultMinutes = 10,
+  userSequences = [],
+}: {
+  defaultMinutes?: number;
+  /** User-defined routines converted to runnable sequences. */
+  userSequences?: SequenceTemplate[];
+}) {
   const { t } = useTranslation();
+  const builtinSequences = useMemo(() => getBuiltinSequences(t), [t]);
   const [durationSec, setDurationSec] = useState(defaultMinutes * 60);
   const [remainingSec, setRemainingSec] = useState(defaultMinutes * 60);
   const [running, setRunning] = useState(false);
@@ -380,7 +388,7 @@ export function VisualTimer({ defaultMinutes = 10 }: { defaultMinutes?: number }
         <div className="flex flex-col items-center gap-1 text-center">
           <span className="text-xs uppercase tracking-wide text-muted-foreground">
             {t("timer.sequenceLabel", {
-              name: t(activeSequence.labelKey),
+              name: activeSequence.label,
             })}
           </span>
           {currentStep && (
@@ -389,7 +397,7 @@ export function VisualTimer({ defaultMinutes = 10 }: { defaultMinutes?: number }
                 current: currentStepIndex + 1,
                 total: activeSequence.steps.length,
               })}{" "}
-              · {t(currentStep.labelKey)}
+              · {currentStep.label}
             </span>
           )}
         </div>
@@ -451,7 +459,7 @@ export function VisualTimer({ defaultMinutes = 10 }: { defaultMinutes?: number }
                 {t("timer.nextStep")}
               </span>
               <span className="mt-1 font-heading text-2xl font-semibold text-foreground sm:text-3xl">
-                {t(nextStep.labelKey)}
+                {nextStep.label}
               </span>
               <span className="mt-1 text-sm text-muted-foreground">
                 {t("timer.minutes", {
@@ -576,6 +584,24 @@ export function VisualTimer({ defaultMinutes = 10 }: { defaultMinutes?: number }
         </div>
       )}
 
+      {idle && !activeSequence && !fullscreen && userSequences.length > 0 && (
+        <div className="flex w-full max-w-xl flex-col items-center gap-3 border-t border-border/40 pt-5">
+          <div className="flex items-center gap-1.5 text-xs uppercase tracking-wide text-muted-foreground">
+            <ListChecks className="h-3.5 w-3.5" />
+            {t("timer.userRoutinesHeader")}
+          </div>
+          <div className="grid w-full grid-cols-1 gap-2 sm:grid-cols-3">
+            {userSequences.map((seq) => (
+              <SequenceCard
+                key={seq.id}
+                seq={seq}
+                onStart={() => startSequence(seq)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
       {idle && !activeSequence && !fullscreen && (
         <div className="flex w-full max-w-xl flex-col items-center gap-3 border-t border-border/40 pt-5">
           <div className="flex items-center gap-1.5 text-xs uppercase tracking-wide text-muted-foreground">
@@ -583,28 +609,12 @@ export function VisualTimer({ defaultMinutes = 10 }: { defaultMinutes?: number }
             {t("timer.sequencesHeader")}
           </div>
           <div className="grid w-full grid-cols-1 gap-2 sm:grid-cols-3">
-            {SEQUENCE_TEMPLATES.map((seq) => (
-              <button
+            {builtinSequences.map((seq) => (
+              <SequenceCard
                 key={seq.id}
-                type="button"
-                onClick={() => startSequence(seq)}
-                className="flex items-center gap-3 rounded-xl border border-border/60 bg-background px-3 py-3 text-left transition-colors hover:bg-accent"
-              >
-                <span className="text-2xl" aria-hidden="true">
-                  {seq.emoji}
-                </span>
-                <span className="flex flex-col">
-                  <span className="text-sm font-medium text-foreground">
-                    {t(seq.labelKey)}
-                  </span>
-                  <span className="text-xs text-muted-foreground">
-                    {t("timer.sequenceMeta", {
-                      count: seq.steps.length,
-                      minutes: Math.ceil(totalSequenceDurationSec(seq) / 60),
-                    })}
-                  </span>
-                </span>
-              </button>
+                seq={seq}
+                onStart={() => startSequence(seq)}
+              />
             ))}
           </div>
         </div>
@@ -679,6 +689,38 @@ export function VisualTimer({ defaultMinutes = 10 }: { defaultMinutes?: number }
         )}
       </div>
     </div>
+  );
+}
+
+function SequenceCard({
+  seq,
+  onStart,
+}: {
+  seq: SequenceTemplate;
+  onStart: () => void;
+}) {
+  const { t } = useTranslation();
+  return (
+    <button
+      type="button"
+      onClick={onStart}
+      className="flex items-center gap-3 rounded-xl border border-border/60 bg-background px-3 py-3 text-left transition-colors hover:bg-accent"
+    >
+      <span className="text-2xl" aria-hidden="true">
+        {seq.emoji}
+      </span>
+      <span className="flex min-w-0 flex-col">
+        <span className="truncate text-sm font-medium text-foreground">
+          {seq.label}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {t("timer.sequenceMeta", {
+            count: seq.steps.length,
+            minutes: Math.ceil(totalSequenceDurationSec(seq) / 60),
+          })}
+        </span>
+      </span>
+    </button>
   );
 }
 

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -755,6 +755,7 @@
       "tryAgain": "Well done for trying. We'll give it another go next time."
     },
     "sequencesHeader": "Ready-made routines",
+    "userRoutinesHeader": "My routines",
     "sequenceLabel": "Routine · {{name}}",
     "sequenceMeta_one": "{{count}} step · {{minutes}} min",
     "sequenceMeta_other": "{{count}} steps · {{minutes}} min",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -1166,6 +1166,7 @@
       "tryAgain": "Bravo d'avoir essayé. On retentera la prochaine fois."
     },
     "sequencesHeader": "Routines prêtes à l'emploi",
+    "userRoutinesHeader": "Mes routines",
     "sequenceLabel": "Routine · {{name}}",
     "sequenceMeta_one": "{{count}} étape · {{minutes}} min",
     "sequenceMeta_other": "{{count}} étapes · {{minutes}} min",

--- a/apps/web/src/routes/_authenticated/timer/index.tsx
+++ b/apps/web/src/routes/_authenticated/timer/index.tsx
@@ -1,7 +1,11 @@
+import { useMemo } from "react";
 import { createFileRoute } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { PageHeader } from "@/components/layout/page-header";
 import { VisualTimer } from "@/components/timer/visual-timer";
+import { routineToSequence } from "@/components/timer/sequences";
+import { useRoutines } from "@/hooks/use-routines";
+import { useUiStore } from "@/stores/ui-store";
 
 export const Route = createFileRoute("/_authenticated/timer/")({
   component: TimerPage,
@@ -12,6 +16,17 @@ export const Route = createFileRoute("/_authenticated/timer/")({
 
 function TimerPage() {
   const { t } = useTranslation();
+  const activeChildId = useUiStore((s) => s.activeChildId);
+  const { data: routines } = useRoutines(activeChildId ?? "");
+
+  const userSequences = useMemo(() => {
+    if (!routines) return [];
+    return routines
+      .filter((r) => r.active)
+      .map(routineToSequence)
+      .filter((seq): seq is NonNullable<typeof seq> => seq !== null);
+  }, [routines]);
+
   return (
     <div className="space-y-8">
       <PageHeader
@@ -19,7 +34,7 @@ function TimerPage() {
         description={t("timer.subtitle")}
       />
       <div className="flex justify-center pt-4">
-        <VisualTimer />
+        <VisualTimer userSequences={userSequences} />
       </div>
     </div>
   );


### PR DESCRIPTION
User-defined routines from the Routines tab now appear as runnable
sequences in the Minuteur, above the built-in templates. Each step that
has a duration becomes a chained timer step so a parent can launch their
own routine directly from the timer without re-entering durations.

https://claude.ai/code/session_01Aw8XgeNt1vSPYZWco9jUw2