### PR TITLE
Remove built-in sequence templates, keep user routines only

### DIFF
--- a/apps/web/src/components/timer/sequences.ts
+++ b/apps/web/src/components/timer/sequences.ts
@@ -1,15 +1,13 @@
 // Sequence templates for the visual timer. A sequence chains short
 // timers so a parent doesn't have to reconfigure the timer between each
-// step of a routine ("matin", "devoirs", "coucher"). This is the killer
-// feature for the "épuisé" persona — it replaces the parent's voice
-// repeating "next step now" at every transition.
+// step of a routine. This is the killer feature for the "épuisé" persona —
+// it replaces the parent's voice repeating "next step now" at every
+// transition.
 //
-// Sequences come from two sources:
-//   - built-in ready-made templates (translated via i18n)
-//   - the user's own routines (created in the Routines tab), where each
-//     step that has a duration becomes a chained timer step.
+// Sequences are built from the user's own routines (created in the
+// Routines tab), where each step that has a duration becomes a chained
+// timer step.
 
-import type { TFunction } from "i18next";
 import type { Routine } from "@focusflow/validators";
 
 export type SequenceStep = {
@@ -24,58 +22,6 @@ export type SequenceTemplate = {
   emoji: string;
   steps: SequenceStep[];
 };
-
-type BuiltinSequenceDef = {
-  id: string;
-  labelKey: string;
-  emoji: string;
-  steps: { labelKey: string; durationSec: number }[];
-};
-
-const BUILTIN_SEQUENCES: BuiltinSequenceDef[] = [
-  {
-    id: "matin",
-    labelKey: "timer.sequences.matin.label",
-    emoji: "🌅",
-    steps: [
-      { labelKey: "timer.sequences.matin.steps.dressing", durationSec: 600 },
-      { labelKey: "timer.sequences.matin.steps.breakfast", durationSec: 900 },
-      { labelKey: "timer.sequences.matin.steps.teeth", durationSec: 180 },
-    ],
-  },
-  {
-    id: "devoirs",
-    labelKey: "timer.sequences.devoirs.label",
-    emoji: "📚",
-    steps: [
-      { labelKey: "timer.sequences.devoirs.steps.focus", durationSec: 900 },
-      { labelKey: "timer.sequences.devoirs.steps.break", durationSec: 300 },
-      { labelKey: "timer.sequences.devoirs.steps.review", durationSec: 600 },
-    ],
-  },
-  {
-    id: "coucher",
-    labelKey: "timer.sequences.coucher.label",
-    emoji: "🌙",
-    steps: [
-      { labelKey: "timer.sequences.coucher.steps.bath", durationSec: 600 },
-      { labelKey: "timer.sequences.coucher.steps.teeth", durationSec: 180 },
-      { labelKey: "timer.sequences.coucher.steps.story", durationSec: 600 },
-    ],
-  },
-];
-
-export function getBuiltinSequences(t: TFunction): SequenceTemplate[] {
-  return BUILTIN_SEQUENCES.map((seq) => ({
-    id: `builtin-${seq.id}`,
-    label: t(seq.labelKey),
-    emoji: seq.emoji,
-    steps: seq.steps.map((step) => ({
-      label: t(step.labelKey),
-      durationSec: step.durationSec,
-    })),
-  }));
-}
 
 const FALLBACK_ROUTINE_EMOJI = "📋";
 

--- a/apps/web/src/components/timer/visual-timer.tsx
+++ b/apps/web/src/components/timer/visual-timer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   Play,
@@ -13,7 +13,6 @@ import {
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import {
-  getBuiltinSequences,
   totalSequenceDurationSec,
   type SequenceTemplate,
 } from "./sequences";
@@ -106,7 +105,6 @@ export function VisualTimer({
   userSequences?: SequenceTemplate[];
 }) {
   const { t } = useTranslation();
-  const builtinSequences = useMemo(() => getBuiltinSequences(t), [t]);
   const [durationSec, setDurationSec] = useState(defaultMinutes * 60);
   const [remainingSec, setRemainingSec] = useState(defaultMinutes * 60);
   const [running, setRunning] = useState(false);
@@ -592,24 +590,6 @@ export function VisualTimer({
           </div>
           <div className="grid w-full grid-cols-1 gap-2 sm:grid-cols-3">
             {userSequences.map((seq) => (
-              <SequenceCard
-                key={seq.id}
-                seq={seq}
-                onStart={() => startSequence(seq)}
-              />
-            ))}
-          </div>
-        </div>
-      )}
-
-      {idle && !activeSequence && !fullscreen && (
-        <div className="flex w-full max-w-xl flex-col items-center gap-3 border-t border-border/40 pt-5">
-          <div className="flex items-center gap-1.5 text-xs uppercase tracking-wide text-muted-foreground">
-            <ListChecks className="h-3.5 w-3.5" />
-            {t("timer.sequencesHeader")}
-          </div>
-          <div className="grid w-full grid-cols-1 gap-2 sm:grid-cols-3">
-            {builtinSequences.map((seq) => (
               <SequenceCard
                 key={seq.id}
                 seq={seq}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -754,7 +754,6 @@
       "hatched": "Yay, a new companion has arrived!",
       "tryAgain": "Well done for trying. We'll give it another go next time."
     },
-    "sequencesHeader": "Ready-made routines",
     "userRoutinesHeader": "My routines",
     "sequenceLabel": "Routine · {{name}}",
     "sequenceMeta_one": "{{count}} step · {{minutes}} min",
@@ -762,33 +761,7 @@
     "stepCounter": "Step {{current}}/{{total}}",
     "nextStep": "Next step",
     "sequenceFinished": "Routine finished!",
-    "cancelSequence": "Leave routine",
-    "sequences": {
-      "matin": {
-        "label": "Morning",
-        "steps": {
-          "dressing": "Getting dressed",
-          "breakfast": "Breakfast",
-          "teeth": "Brushing teeth"
-        }
-      },
-      "devoirs": {
-        "label": "Homework",
-        "steps": {
-          "focus": "Focus",
-          "break": "Break",
-          "review": "Review"
-        }
-      },
-      "coucher": {
-        "label": "Bedtime",
-        "steps": {
-          "bath": "Bath",
-          "teeth": "Brushing teeth",
-          "story": "Story"
-        }
-      }
-    }
+    "cancelSequence": "Leave routine"
   },
   "achievements": {
     "title": "My parent badges",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -1165,7 +1165,6 @@
       "hatched": "Bravo, un nouveau compagnon est arrivé !",
       "tryAgain": "Bravo d'avoir essayé. On retentera la prochaine fois."
     },
-    "sequencesHeader": "Routines prêtes à l'emploi",
     "userRoutinesHeader": "Mes routines",
     "sequenceLabel": "Routine · {{name}}",
     "sequenceMeta_one": "{{count}} étape · {{minutes}} min",
@@ -1173,33 +1172,7 @@
     "stepCounter": "Étape {{current}}/{{total}}",
     "nextStep": "Étape suivante",
     "sequenceFinished": "Routine terminée !",
-    "cancelSequence": "Quitter la routine",
-    "sequences": {
-      "matin": {
-        "label": "Matin",
-        "steps": {
-          "dressing": "Habillage",
-          "breakfast": "Petit-déjeuner",
-          "teeth": "Brossage de dents"
-        }
-      },
-      "devoirs": {
-        "label": "Devoirs",
-        "steps": {
-          "focus": "Concentration",
-          "break": "Pause",
-          "review": "Vérification"
-        }
-      },
-      "coucher": {
-        "label": "Coucher",
-        "steps": {
-          "bath": "Bain",
-          "teeth": "Brossage de dents",
-          "story": "Histoire"
-        }
-      }
-    }
+    "cancelSequence": "Quitter la routine"
   },
   "achievements": {
     "title": "Mes badges parent",


### PR DESCRIPTION
## Summary

Removes the built-in "ready-made" sequence templates (Morning, Homework, Bedtime) from the timer feature. Users now create and manage their own routines exclusively via the Routines tab, simplifying the UI and reducing cognitive load.

## Changes

- **Removed built-in sequences:** Deleted `BUILTIN_SEQUENCES` constant and `getBuiltinSequences()` function from `sequences.ts`
- **Removed UI section:** Eliminated the "Ready-made routines" card grid from the idle timer view in `visual-timer.tsx`
- **Cleaned up imports:** Removed unused `useMemo` hook and `getBuiltinSequences` import from `visual-timer.tsx`
- **Updated i18n:** Removed all built-in sequence translation keys (`timer.sequencesHeader` and nested `timer.sequences.*`) from both English and French locale files

## Rationale

This aligns with the project's core principle of **maximum simplicity** for ADHD-affected users. Pre-made templates added visual clutter and decision fatigue. Users can now focus on their own custom routines, which are more relevant to their specific family needs. The feature still fully supports chained timers through user-created routines.

https://claude.ai/code/session_01DWnv7e6ijS3kYN1kkEd4n5