### PR TITLE
feat: add admin user management page

### DIFF
--- a/apps/api/src/__tests__/admin-users.routes.test.ts
+++ b/apps/api/src/__tests__/admin-users.routes.test.ts
@@ -19,4 +19,13 @@ describe("admin users routes", () => {
     });
     expect(res.status).toBe(401);
   });
+
+  it("PATCH /api/admin/users/:id/premium returns 401 without a session", async () => {
+    const res = await app.request("/api/admin/users/some-id/premium", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ premiumGranted: true }),
+    });
+    expect(res.status).toBe(401);
+  });
 });

--- a/apps/api/src/__tests__/admin-users.routes.test.ts
+++ b/apps/api/src/__tests__/admin-users.routes.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { app } from "../app";
+
+// Smoke tests on the admin auth gate. We don't fabricate a session here
+// (Better Auth integration is covered by other suites); the goal is to
+// prove that an anonymous caller cannot reach the user-management routes.
+
+describe("admin users routes", () => {
+  it("GET /api/admin/users returns 401 without a session", async () => {
+    const res = await app.request("/api/admin/users");
+    expect(res.status).toBe(401);
+  });
+
+  it("PATCH /api/admin/users/:id/role returns 401 without a session", async () => {
+    const res = await app.request("/api/admin/users/some-id/role", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ isAdmin: true }),
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -36,6 +36,7 @@ import { parentMoodRoutes } from "./routes/parent-mood";
 import { solidarityRoutes } from "./routes/solidarity";
 import { eventsRoutes } from "./routes/events";
 import { adminAnalyticsRoutes } from "./routes/admin-analytics";
+import { adminUsersRoutes } from "./routes/admin-users";
 import { featureFlagsRoutes } from "./routes/feature-flags";
 import { auth } from "./lib/auth";
 
@@ -153,6 +154,7 @@ app.route("/api/parent-mood", parentMoodRoutes);
 app.route("/api/solidarity", solidarityRoutes);
 app.route("/api/events", eventsRoutes);
 app.route("/api/admin/analytics", adminAnalyticsRoutes);
+app.route("/api/admin/users", adminUsersRoutes);
 app.route("/api/feature-flags", featureFlagsRoutes);
 
 export { app };

--- a/apps/api/src/lib/premium.ts
+++ b/apps/api/src/lib/premium.ts
@@ -1,0 +1,49 @@
+import { eq } from "drizzle-orm";
+import { db, user, subscription } from "@focusflow/db";
+
+export type PremiumAccess = {
+  /** True when the user may use plan-gated ("Famille") features right now. */
+  active: boolean;
+  /** True when a real subscription is paused (read-only window, C3). */
+  paused: boolean;
+  pausedUntil: Date | null;
+  /** Stripe-mirrored status, or "none" when there is no subscription row. */
+  subscriptionStatus: string;
+  /** True when an administrator granted complimentary access. */
+  granted: boolean;
+};
+
+/**
+ * Single source of truth for "does this user have premium access?".
+ *
+ * Access is granted either by an active/trialing Stripe subscription or by
+ * an admin-set complimentary flag (`user.premiumGranted`). The grant
+ * overrides Stripe entirely — it ignores a paused subscription and never
+ * expires until an admin revokes it.
+ */
+export async function getPremiumAccess(userId: string): Promise<PremiumAccess> {
+  const [row] = await db
+    .select({
+      granted: user.premiumGranted,
+      status: subscription.status,
+      pausedUntil: subscription.pausedUntil,
+    })
+    .from(user)
+    .leftJoin(subscription, eq(subscription.userId, user.id))
+    .where(eq(user.id, userId))
+    .limit(1);
+
+  const granted = row?.granted ?? false;
+  const status = row?.status ?? "none";
+  const paused = row?.pausedUntil != null && row.pausedUntil > new Date();
+  const subActive =
+    (status === "active" || status === "trialing") && !paused;
+
+  return {
+    active: granted || subActive,
+    paused: paused && !granted,
+    pausedUntil: paused && !granted ? row!.pausedUntil : null,
+    subscriptionStatus: status,
+    granted,
+  };
+}

--- a/apps/api/src/middleware/require-plan.ts
+++ b/apps/api/src/middleware/require-plan.ts
@@ -1,6 +1,5 @@
 import type { Context, Next } from "hono";
-import { db, subscription } from "@focusflow/db";
-import { eq } from "drizzle-orm";
+import { getPremiumAccess } from "../lib/premium";
 
 export async function requirePlan(c: Context, next: Next) {
   const user = c.get("user") as { id: string } | undefined;
@@ -8,34 +7,23 @@ export async function requirePlan(c: Context, next: Next) {
     return c.json({ error: "Non autorisé", code: "UNAUTHORIZED" }, 401);
   }
 
-  const [sub] = await db
-    .select({
-      status: subscription.status,
-      pausedUntil: subscription.pausedUntil,
-    })
-    .from(subscription)
-    .where(eq(subscription.userId, user.id))
-    .limit(1);
+  const access = await getPremiumAccess(user.id);
 
-  // A paused subscription stays `status === "active"` in Stripe
-  // (pause_collection only suspends invoicing), so without checking
-  // `pausedUntil` we would silently let paused users through to gated
-  // endpoints — which contradicts the C3 contract that paused = read-only.
-  // Surface a distinct PLAN_PAUSED code so the frontend can route them to
-  // a "Reprendre l'abonnement" CTA instead of an "Upgrade" upsell.
-  const paused = sub?.pausedUntil != null && sub.pausedUntil > new Date();
-  if (paused) {
+  // A paused subscription gets a distinct PLAN_PAUSED code so the frontend
+  // can route to a "Reprendre l'abonnement" CTA instead of an upsell. An
+  // admin-granted comp ignores the pause entirely (handled in getPremiumAccess).
+  if (access.paused) {
     return c.json(
       {
-        error: "Abonnement en pause — reprenez-le pour utiliser cette fonctionnalité.",
+        error:
+          "Abonnement en pause — reprenez-le pour utiliser cette fonctionnalité.",
         code: "PLAN_PAUSED",
       },
       403,
     );
   }
 
-  const active = sub?.status === "active" || sub?.status === "trialing";
-  if (!active) {
+  if (!access.active) {
     return c.json(
       {
         error: "Fonctionnalité réservée au plan Famille",

--- a/apps/api/src/routes/admin-users.ts
+++ b/apps/api/src/routes/admin-users.ts
@@ -1,0 +1,83 @@
+import { Hono } from "hono";
+import { desc, eq } from "drizzle-orm";
+import type { AppEnv } from "../types";
+import { authMiddleware } from "../middleware/auth";
+import { AppError } from "../middleware/error-handler";
+import { updateUserRoleSchema } from "@focusflow/validators";
+import { db, user } from "@focusflow/db";
+
+export const adminUsersRoutes = new Hono<AppEnv>();
+
+adminUsersRoutes.use("*", authMiddleware);
+
+async function assertAdmin(userId: string) {
+  const [row] = await db
+    .select({ isAdmin: user.isAdmin })
+    .from(user)
+    .where(eq(user.id, userId))
+    .limit(1);
+  if (!row?.isAdmin) {
+    throw new AppError("FORBIDDEN", "Action réservée aux admins", 403);
+  }
+}
+
+const userColumns = {
+  id: user.id,
+  name: user.name,
+  email: user.email,
+  emailVerified: user.emailVerified,
+  isAdmin: user.isAdmin,
+  deletionScheduledAt: user.deletionScheduledAt,
+  createdAt: user.createdAt,
+} as const;
+
+// GET /api/admin/users — full account list for the admin console.
+adminUsersRoutes.get("/", async (c) => {
+  const me = c.get("user");
+  await assertAdmin(me.id);
+
+  const rows = await db
+    .select(userColumns)
+    .from(user)
+    .orderBy(desc(user.createdAt));
+
+  return c.json(rows);
+});
+
+// PATCH /api/admin/users/:id/role — grant or revoke the admin role.
+adminUsersRoutes.patch("/:id/role", async (c) => {
+  const me = c.get("user");
+  await assertAdmin(me.id);
+
+  const targetId = c.req.param("id");
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = updateUserRoleSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "Payload invalide", issues: parsed.error.issues },
+      422,
+    );
+  }
+
+  // An admin can't strip their own role — without this guard the last
+  // admin could lock everyone out of the console by mistake.
+  if (targetId === me.id && !parsed.data.isAdmin) {
+    throw new AppError(
+      "CANNOT_DEMOTE_SELF",
+      "Vous ne pouvez pas retirer votre propre rôle administrateur.",
+      422,
+    );
+  }
+
+  const [updated] = await db
+    .update(user)
+    .set({ isAdmin: parsed.data.isAdmin, updatedAt: new Date() })
+    .where(eq(user.id, targetId))
+    .returning(userColumns);
+
+  if (!updated) {
+    throw new AppError("NOT_FOUND", "Utilisateur introuvable.", 404);
+  }
+
+  return c.json(updated);
+});

--- a/apps/api/src/routes/admin-users.ts
+++ b/apps/api/src/routes/admin-users.ts
@@ -3,8 +3,11 @@ import { desc, eq } from "drizzle-orm";
 import type { AppEnv } from "../types";
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
-import { updateUserRoleSchema } from "@focusflow/validators";
-import { db, user } from "@focusflow/db";
+import {
+  updateUserRoleSchema,
+  updateUserPremiumSchema,
+} from "@focusflow/validators";
+import { db, user, subscription } from "@focusflow/db";
 
 export const adminUsersRoutes = new Hono<AppEnv>();
 
@@ -21,24 +24,33 @@ async function assertAdmin(userId: string) {
   }
 }
 
-const userColumns = {
+// Columns returned by the PATCH endpoints — the mutated account row.
+const accountColumns = {
   id: user.id,
   name: user.name,
   email: user.email,
   emailVerified: user.emailVerified,
   isAdmin: user.isAdmin,
+  premiumGranted: user.premiumGranted,
   deletionScheduledAt: user.deletionScheduledAt,
   createdAt: user.createdAt,
 } as const;
 
-// GET /api/admin/users — full account list for the admin console.
+// GET /api/admin/users — full account list for the admin console, with
+// each user's Stripe subscription state joined in (read-only).
 adminUsersRoutes.get("/", async (c) => {
   const me = c.get("user");
   await assertAdmin(me.id);
 
   const rows = await db
-    .select(userColumns)
+    .select({
+      ...accountColumns,
+      subscriptionStatus: subscription.status,
+      subscriptionPausedUntil: subscription.pausedUntil,
+      subscriptionCancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
+    })
     .from(user)
+    .leftJoin(subscription, eq(subscription.userId, user.id))
     .orderBy(desc(user.createdAt));
 
   return c.json(rows);
@@ -73,7 +85,36 @@ adminUsersRoutes.patch("/:id/role", async (c) => {
     .update(user)
     .set({ isAdmin: parsed.data.isAdmin, updatedAt: new Date() })
     .where(eq(user.id, targetId))
-    .returning(userColumns);
+    .returning(accountColumns);
+
+  if (!updated) {
+    throw new AppError("NOT_FOUND", "Utilisateur introuvable.", 404);
+  }
+
+  return c.json(updated);
+});
+
+// PATCH /api/admin/users/:id/premium — grant or revoke complimentary
+// premium access, independent of any Stripe subscription.
+adminUsersRoutes.patch("/:id/premium", async (c) => {
+  const me = c.get("user");
+  await assertAdmin(me.id);
+
+  const targetId = c.req.param("id");
+  const body = await c.req.json().catch(() => ({}));
+  const parsed = updateUserPremiumSchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "Payload invalide", issues: parsed.error.issues },
+      422,
+    );
+  }
+
+  const [updated] = await db
+    .update(user)
+    .set({ premiumGranted: parsed.data.premiumGranted, updatedAt: new Date() })
+    .where(eq(user.id, targetId))
+    .returning(accountColumns);
 
   if (!updated) {
     throw new AppError("NOT_FOUND", "Utilisateur introuvable.", 404);

--- a/apps/api/src/routes/billing.ts
+++ b/apps/api/src/routes/billing.ts
@@ -196,8 +196,22 @@ billingRoutes.get("/status", authMiddleware, async (c) => {
     .where(eq(subscription.userId, currentUser.id))
     .limit(1);
 
+  // Admin-granted complimentary access is independent of Stripe — it
+  // grants full access even with no subscription row, and overrides a
+  // paused subscription.
+  const [account] = await db
+    .select({ premiumGranted: user.premiumGranted })
+    .from(user)
+    .where(eq(user.id, currentUser.id))
+    .limit(1);
+  const granted = account?.premiumGranted ?? false;
+
   if (!sub) {
-    return c.json({ status: "none", active: false });
+    return c.json({
+      status: granted ? "granted" : "none",
+      active: granted,
+      granted,
+    });
   }
 
   // Surface the paused window so the frontend can render a distinct
@@ -210,9 +224,10 @@ billingRoutes.get("/status", authMiddleware, async (c) => {
 
   return c.json({
     status: sub.status,
-    active: sub.status === "active" || sub.status === "trialing",
-    paused,
-    pausedUntil: paused ? sub.pausedUntil : null,
+    active: granted || sub.status === "active" || sub.status === "trialing",
+    granted,
+    paused: paused && !granted,
+    pausedUntil: paused && !granted ? sub.pausedUntil : null,
     // Surface the scheduled-cancellation window so the frontend can
     // render a distinct "Annulation programmée — Réactiver" branch.
     // Stripe leaves status="active" until the period actually lapses,

--- a/apps/api/src/routes/children.ts
+++ b/apps/api/src/routes/children.ts
@@ -1,10 +1,11 @@
 import { Hono } from "hono";
 import type { AppEnv } from "../types";
 import { eq, inArray } from "drizzle-orm";
-import { db, children, childAccess, subscription } from "@focusflow/db";
+import { db, children, childAccess } from "@focusflow/db";
 import { createChildSchema, updateChildSchema } from "@focusflow/validators";
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
+import { getPremiumAccess } from "../lib/premium";
 import { seedBarkleyStarterPack } from "../lib/barkley-defaults";
 import {
   assertChildAccess,
@@ -48,14 +49,7 @@ childrenRoutes.post("/", async (c) => {
     .from(children)
     .where(eq(children.parentId, user.id));
 
-  const [sub] = await db
-    .select()
-    .from(subscription)
-    .where(eq(subscription.userId, user.id))
-    .limit(1);
-
-  const isActive =
-    sub && (sub.status === "active" || sub.status === "trialing");
+  const { active: isActive } = await getPremiumAccess(user.id);
   const maxChildren = isActive ? 3 : 1;
 
   if (existingChildren.length >= maxChildren) {

--- a/apps/api/src/routes/report.ts
+++ b/apps/api/src/routes/report.ts
@@ -8,7 +8,6 @@ import {
     journalEntries,
     barkleySteps,
     crisisItems,
-    subscription,
     medications,
     medicationLogs,
     carePathwayProgress,
@@ -18,6 +17,7 @@ import { authMiddleware } from "../middleware/auth";
 import { rateLimiter } from "../middleware/rate-limiter";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess, getChildOwnerId } from "../lib/child-access";
+import { getPremiumAccess } from "../lib/premium";
 import { sendEmail } from "../lib/email";
 import { z } from "zod";
 
@@ -181,13 +181,7 @@ async function assertOwnerHasFamillePlan(childId: string): Promise<void> {
     if (!ownerId) {
         throw new AppError("NOT_FOUND", "Enfant non trouvé", 404);
     }
-    const [ownerSub] = await db
-        .select({ status: subscription.status })
-        .from(subscription)
-        .where(eq(subscription.userId, ownerId))
-        .limit(1);
-    const active =
-        ownerSub?.status === "active" || ownerSub?.status === "trialing";
+    const { active } = await getPremiumAccess(ownerId);
     if (!active) {
         throw new AppError(
             "PLAN_REQUIRED",

--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -20,10 +20,11 @@ import {
   MessageSquareText,
   TrendingUp,
   ShieldCheck,
+  Users,
 } from "lucide-react";
 
 export type NavItem = {
-  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/timer" | "/care-pathway" | "/admin-vault" | "/admin-analytics" | "/achievements" | "/activity" | "/connaissances" | "/account" | "/decodeur" | "/burnout" | "/insights" | "/scripts";
+  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/strengths" | "/timer" | "/care-pathway" | "/admin-vault" | "/admin-analytics" | "/admin-users" | "/achievements" | "/activity" | "/connaissances" | "/account" | "/decodeur" | "/burnout" | "/insights" | "/scripts";
   labelKey: string;
   shortLabelKey?: string;
   icon: React.ComponentType<{ className?: string }>;
@@ -65,6 +66,7 @@ export const navItems: readonly NavItem[] = [
   { to: "/account", labelKey: "nav.account", icon: UserCog, group: "account" },
 
   // Admin — réservé aux utilisateurs avec isAdmin === true
+  { to: "/admin-users", labelKey: "nav.adminUsers", icon: Users, group: "admin", requiresAdmin: true },
   { to: "/admin-analytics", labelKey: "nav.adminAnalytics", icon: ShieldCheck, group: "admin", requiresAdmin: true },
 ] as const;
 

--- a/apps/web/src/hooks/use-admin-users.ts
+++ b/apps/web/src/hooks/use-admin-users.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api, ApiError } from "@/lib/api-client";
-import type { UpdateUserRole } from "@focusflow/validators";
+import type { UpdateUserPremium, UpdateUserRole } from "@focusflow/validators";
 
 export type AdminUser = {
   id: string;
@@ -9,9 +9,20 @@ export type AdminUser = {
   email: string;
   emailVerified: boolean;
   isAdmin: boolean;
+  premiumGranted: boolean;
   deletionScheduledAt: string | null;
   createdAt: string;
+  subscriptionStatus: string | null;
+  subscriptionPausedUntil: string | null;
+  subscriptionCancelAtPeriodEnd: boolean | null;
 };
+
+// The PATCH endpoints return only the mutated account row (no subscription
+// join), which is all the success toast needs.
+type AdminUserAccount = Pick<
+  AdminUser,
+  "id" | "name" | "isAdmin" | "premiumGranted"
+>;
 
 export const adminUsersKeys = {
   all: ["admin-users"] as const,
@@ -29,7 +40,7 @@ export function useUpdateUserRole() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ id, isAdmin }: UpdateUserRole & { id: string }) =>
-      api.patch<AdminUser>(`/admin/users/${id}/role`, { isAdmin }),
+      api.patch<AdminUserAccount>(`/admin/users/${id}/role`, { isAdmin }),
     onSuccess: (updated) => {
       queryClient.invalidateQueries({ queryKey: adminUsersKeys.all });
       toast.success(
@@ -43,6 +54,31 @@ export function useUpdateUserRole() {
         err instanceof ApiError
           ? err.message
           : "Impossible de modifier le rôle de cet utilisateur.",
+      );
+    },
+  });
+}
+
+export function useUpdateUserPremium() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, premiumGranted }: UpdateUserPremium & { id: string }) =>
+      api.patch<AdminUserAccount>(`/admin/users/${id}/premium`, {
+        premiumGranted,
+      }),
+    onSuccess: (updated) => {
+      queryClient.invalidateQueries({ queryKey: adminUsersKeys.all });
+      toast.success(
+        updated.premiumGranted
+          ? `Accès premium accordé à ${updated.name}.`
+          : `Accès premium retiré à ${updated.name}.`,
+      );
+    },
+    onError: (err) => {
+      toast.error(
+        err instanceof ApiError
+          ? err.message
+          : "Impossible de modifier l'accès premium de cet utilisateur.",
       );
     },
   });

--- a/apps/web/src/hooks/use-admin-users.ts
+++ b/apps/web/src/hooks/use-admin-users.ts
@@ -1,0 +1,49 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { api, ApiError } from "@/lib/api-client";
+import type { UpdateUserRole } from "@focusflow/validators";
+
+export type AdminUser = {
+  id: string;
+  name: string;
+  email: string;
+  emailVerified: boolean;
+  isAdmin: boolean;
+  deletionScheduledAt: string | null;
+  createdAt: string;
+};
+
+export const adminUsersKeys = {
+  all: ["admin-users"] as const,
+};
+
+export function useAdminUsers() {
+  return useQuery({
+    queryKey: adminUsersKeys.all,
+    queryFn: () => api.get<AdminUser[]>("/admin/users"),
+    retry: false,
+  });
+}
+
+export function useUpdateUserRole() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, isAdmin }: UpdateUserRole & { id: string }) =>
+      api.patch<AdminUser>(`/admin/users/${id}/role`, { isAdmin }),
+    onSuccess: (updated) => {
+      queryClient.invalidateQueries({ queryKey: adminUsersKeys.all });
+      toast.success(
+        updated.isAdmin
+          ? `${updated.name} est maintenant administrateur.`
+          : `${updated.name} n'est plus administrateur.`,
+      );
+    },
+    onError: (err) => {
+      toast.error(
+        err instanceof ApiError
+          ? err.message
+          : "Impossible de modifier le rôle de cet utilisateur.",
+      );
+    },
+  });
+}

--- a/apps/web/src/hooks/use-billing.ts
+++ b/apps/web/src/hooks/use-billing.ts
@@ -6,8 +6,12 @@ import { api } from "@/lib/api-client";
 export type BillingPlan = "monthly" | "annual";
 
 interface BillingStatus {
+  // Stripe-mirrored status, or "granted" when an admin gave complimentary
+  // access with no subscription, or "none" when the user is on the free plan.
   status: string;
   active: boolean;
+  // True when premium access was granted by an administrator.
+  granted?: boolean;
   paused?: boolean;
   pausedUntil?: string | null;
   // Mirrored from Stripe: true while the user is still inside their paid

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -240,6 +240,7 @@
     "carePathway": "Care pathway",
     "adminVault": "Vault",
     "adminAnalytics": "Internal analytics",
+    "adminUsers": "Users",
     "achievements": "My badges",
     "activity": "Activity",
     "barkley": "Barkley program",

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -440,6 +440,8 @@
     "upgradeToFamily": "Unlock medical tracking",
     "trial": "Trial",
     "active": "Active",
+    "complimentary": "Complimentary access",
+    "complimentaryHint": "The Tokō team has granted you premium access. You have all Family plan features, free of charge.",
     "familyPlan": "Family plan",
     "intervalAnnual": "annual",
     "intervalMonthly": "monthly",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -244,6 +244,7 @@
     "burnout": "Test burn-out parental",
     "adminVault": "Coffre-fort",
     "adminAnalytics": "Analyses internes",
+    "adminUsers": "Utilisateurs",
     "achievements": "Mes badges",
     "activity": "Activité",
     "barkley": "Programme Barkley",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -444,6 +444,8 @@
     "upgradeToFamily": "Débloquer le suivi médical",
     "trial": "Essai",
     "active": "Actif",
+    "complimentary": "Accès offert",
+    "complimentaryHint": "Un accès premium vous a été accordé par l'équipe Tokō. Vous bénéficiez de toutes les fonctionnalités du plan Famille, gratuitement.",
     "familyPlan": "Plan Famille",
     "intervalAnnual": "annuel",
     "intervalMonthly": "mensuel",

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -40,6 +40,7 @@ import { Route as AuthenticatedCarePathwayIndexRouteImport } from './routes/_aut
 import { Route as AuthenticatedBurnoutIndexRouteImport } from './routes/_authenticated/burnout/index'
 import { Route as AuthenticatedBarkleyIndexRouteImport } from './routes/_authenticated/barkley/index'
 import { Route as AuthenticatedAdminVaultIndexRouteImport } from './routes/_authenticated/admin-vault/index'
+import { Route as AuthenticatedAdminUsersIndexRouteImport } from './routes/_authenticated/admin-users/index'
 import { Route as AuthenticatedAdminAnalyticsIndexRouteImport } from './routes/_authenticated/admin-analytics/index'
 import { Route as AuthenticatedActivityIndexRouteImport } from './routes/_authenticated/activity/index'
 import { Route as AuthenticatedAchievementsIndexRouteImport } from './routes/_authenticated/achievements/index'
@@ -218,6 +219,12 @@ const AuthenticatedAdminVaultIndexRoute =
     path: '/admin-vault/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedAdminUsersIndexRoute =
+  AuthenticatedAdminUsersIndexRouteImport.update({
+    id: '/admin-users/',
+    path: '/admin-users/',
+    getParentRoute: () => AuthenticatedRoute,
+  } as any)
 const AuthenticatedAdminAnalyticsIndexRoute =
   AuthenticatedAdminAnalyticsIndexRouteImport.update({
     id: '/admin-analytics/',
@@ -277,6 +284,7 @@ export interface FileRoutesByFullPath {
   '/achievements/': typeof AuthenticatedAchievementsIndexRoute
   '/activity/': typeof AuthenticatedActivityIndexRoute
   '/admin-analytics/': typeof AuthenticatedAdminAnalyticsIndexRoute
+  '/admin-users/': typeof AuthenticatedAdminUsersIndexRoute
   '/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley/': typeof AuthenticatedBarkleyIndexRoute
   '/burnout/': typeof AuthenticatedBurnoutIndexRoute
@@ -315,6 +323,7 @@ export interface FileRoutesByTo {
   '/achievements': typeof AuthenticatedAchievementsIndexRoute
   '/activity': typeof AuthenticatedActivityIndexRoute
   '/admin-analytics': typeof AuthenticatedAdminAnalyticsIndexRoute
+  '/admin-users': typeof AuthenticatedAdminUsersIndexRoute
   '/admin-vault': typeof AuthenticatedAdminVaultIndexRoute
   '/barkley': typeof AuthenticatedBarkleyIndexRoute
   '/burnout': typeof AuthenticatedBurnoutIndexRoute
@@ -355,6 +364,7 @@ export interface FileRoutesById {
   '/_authenticated/achievements/': typeof AuthenticatedAchievementsIndexRoute
   '/_authenticated/activity/': typeof AuthenticatedActivityIndexRoute
   '/_authenticated/admin-analytics/': typeof AuthenticatedAdminAnalyticsIndexRoute
+  '/_authenticated/admin-users/': typeof AuthenticatedAdminUsersIndexRoute
   '/_authenticated/admin-vault/': typeof AuthenticatedAdminVaultIndexRoute
   '/_authenticated/barkley/': typeof AuthenticatedBarkleyIndexRoute
   '/_authenticated/burnout/': typeof AuthenticatedBurnoutIndexRoute
@@ -395,6 +405,7 @@ export interface FileRouteTypes {
     | '/achievements/'
     | '/activity/'
     | '/admin-analytics/'
+    | '/admin-users/'
     | '/admin-vault/'
     | '/barkley/'
     | '/burnout/'
@@ -433,6 +444,7 @@ export interface FileRouteTypes {
     | '/achievements'
     | '/activity'
     | '/admin-analytics'
+    | '/admin-users'
     | '/admin-vault'
     | '/barkley'
     | '/burnout'
@@ -472,6 +484,7 @@ export interface FileRouteTypes {
     | '/_authenticated/achievements/'
     | '/_authenticated/activity/'
     | '/_authenticated/admin-analytics/'
+    | '/_authenticated/admin-users/'
     | '/_authenticated/admin-vault/'
     | '/_authenticated/barkley/'
     | '/_authenticated/burnout/'
@@ -728,6 +741,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedAdminVaultIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/admin-users/': {
+      id: '/_authenticated/admin-users/'
+      path: '/admin-users'
+      fullPath: '/admin-users/'
+      preLoaderRoute: typeof AuthenticatedAdminUsersIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/admin-analytics/': {
       id: '/_authenticated/admin-analytics/'
       path: '/admin-analytics'
@@ -779,6 +799,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedAchievementsIndexRoute: typeof AuthenticatedAchievementsIndexRoute
   AuthenticatedActivityIndexRoute: typeof AuthenticatedActivityIndexRoute
   AuthenticatedAdminAnalyticsIndexRoute: typeof AuthenticatedAdminAnalyticsIndexRoute
+  AuthenticatedAdminUsersIndexRoute: typeof AuthenticatedAdminUsersIndexRoute
   AuthenticatedAdminVaultIndexRoute: typeof AuthenticatedAdminVaultIndexRoute
   AuthenticatedBarkleyIndexRoute: typeof AuthenticatedBarkleyIndexRoute
   AuthenticatedBurnoutIndexRoute: typeof AuthenticatedBurnoutIndexRoute
@@ -806,6 +827,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedAchievementsIndexRoute: AuthenticatedAchievementsIndexRoute,
   AuthenticatedActivityIndexRoute: AuthenticatedActivityIndexRoute,
   AuthenticatedAdminAnalyticsIndexRoute: AuthenticatedAdminAnalyticsIndexRoute,
+  AuthenticatedAdminUsersIndexRoute: AuthenticatedAdminUsersIndexRoute,
   AuthenticatedAdminVaultIndexRoute: AuthenticatedAdminVaultIndexRoute,
   AuthenticatedBarkleyIndexRoute: AuthenticatedBarkleyIndexRoute,
   AuthenticatedBurnoutIndexRoute: AuthenticatedBurnoutIndexRoute,

--- a/apps/web/src/routes/_authenticated/account/index.tsx
+++ b/apps/web/src/routes/_authenticated/account/index.tsx
@@ -157,6 +157,18 @@ function AccountPage() {
                 {t("account.upgradeToFamily")}
               </Button>
             </div>
+          ) : billing.data.status === "granted" ? (
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Badge variant="default">{t("account.complimentary")}</Badge>
+                <span className="text-sm font-medium">
+                  {t("account.familyPlan")}
+                </span>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {t("account.complimentaryHint")}
+              </p>
+            </div>
           ) : billing.data.active ? (
             <div className="space-y-3">
               <div className="flex items-center gap-2">

--- a/apps/web/src/routes/_authenticated/admin-users/index.tsx
+++ b/apps/web/src/routes/_authenticated/admin-users/index.tsx
@@ -1,0 +1,258 @@
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { useState } from "react";
+import { ShieldCheck, ShieldOff, Search } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { PageLoader } from "@/components/ui/page-loader";
+import { PageHeader } from "@/components/layout/page-header";
+import {
+  useAdminUsers,
+  useUpdateUserRole,
+  type AdminUser,
+} from "@/hooks/use-admin-users";
+import { ApiError } from "@/lib/api-client";
+import { getCachedSession, useSession } from "@/lib/auth-client";
+
+export const Route = createFileRoute("/_authenticated/admin-users/")({
+  // Hard gate: only admins reach this route. The API also enforces it
+  // (403), so this is purely to avoid showing a forbidden shell.
+  beforeLoad: async () => {
+    const session = (await getCachedSession()) as
+      | { user?: { isAdmin?: boolean } }
+      | null;
+    if (!session?.user?.isAdmin) {
+      throw redirect({ to: "/dashboard" });
+    }
+  },
+  component: AdminUsersPage,
+  staticData: { crumb: "nav.adminUsers" },
+});
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function AdminUsersPage() {
+  const { data, isLoading, error } = useAdminUsers();
+  const session = useSession();
+  const currentUserId = session.data?.user?.id;
+  const [search, setSearch] = useState("");
+
+  if (isLoading) return <PageLoader />;
+
+  if (error) {
+    const forbidden = error instanceof ApiError && error.status === 403;
+    return (
+      <div className="space-y-4">
+        <PageHeader title="Administration des utilisateurs" />
+        <Card>
+          <CardContent className="py-8 text-sm text-muted-foreground">
+            {forbidden
+              ? "Cette page est réservée aux administrateurs."
+              : "Impossible de charger la liste des utilisateurs pour le moment."}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const users = data ?? [];
+  const query = search.trim().toLowerCase();
+  const filtered = query
+    ? users.filter(
+        (u) =>
+          u.name.toLowerCase().includes(query) ||
+          u.email.toLowerCase().includes(query),
+      )
+    : users;
+  const adminCount = users.filter((u) => u.isAdmin).length;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Administration des utilisateurs"
+        description={`${users.length} compte${
+          users.length > 1 ? "s" : ""
+        } · ${adminCount} administrateur${adminCount > 1 ? "s" : ""}`}
+      />
+
+      <div className="relative max-w-sm">
+        <Search
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          aria-hidden="true"
+        />
+        <Input
+          type="search"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Rechercher par nom ou e-mail"
+          aria-label="Rechercher un utilisateur"
+          className="pl-9"
+        />
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          {filtered.length === 0 ? (
+            <p className="px-4 py-8 text-center text-sm text-muted-foreground">
+              {query
+                ? "Aucun utilisateur ne correspond à votre recherche."
+                : "Aucun utilisateur pour le moment."}
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[40rem] text-sm">
+                <thead>
+                  <tr className="border-b border-border/60 bg-muted/40">
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      Utilisateur
+                    </th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      Inscrit le
+                    </th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      Rôle
+                    </th>
+                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">
+                      Action
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map((u, i) => (
+                    <UserRow
+                      key={u.id}
+                      user={u}
+                      isCurrentUser={u.id === currentUserId}
+                      striped={i % 2 === 1}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function UserRow({
+  user,
+  isCurrentUser,
+  striped,
+}: {
+  user: AdminUser;
+  isCurrentUser: boolean;
+  striped: boolean;
+}) {
+  const updateRole = useUpdateUserRole();
+  const isPending =
+    updateRole.isPending && updateRole.variables?.id === user.id;
+  // Mirrors the API guard: an admin can't strip their own role.
+  const lockedSelf = isCurrentUser && user.isAdmin;
+
+  return (
+    <tr className={striped ? "bg-muted/20" : undefined}>
+      <td className="px-4 py-3">
+        <div className="font-medium text-foreground">
+          {user.name}
+          {isCurrentUser && (
+            <span className="ml-1.5 text-xs font-normal text-muted-foreground">
+              (vous)
+            </span>
+          )}
+        </div>
+        <div className="text-xs text-muted-foreground">{user.email}</div>
+      </td>
+      <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+        {formatDate(user.createdAt)}
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <Badge variant={user.isAdmin ? "secondary" : "outline"}>
+            {user.isAdmin ? "Administrateur" : "Parent"}
+          </Badge>
+          {user.deletionScheduledAt && (
+            <Badge variant="destructive">Suppression programmée</Badge>
+          )}
+        </div>
+      </td>
+      <td className="px-4 py-3 text-right">
+        {lockedSelf ? (
+          <span className="text-xs text-muted-foreground">
+            Vous ne pouvez pas modifier votre propre rôle
+          </span>
+        ) : (
+          <AlertDialog>
+            <AlertDialogTrigger
+              render={
+                <Button
+                  variant={user.isAdmin ? "destructive" : "outline"}
+                  size="sm"
+                  disabled={isPending}
+                >
+                  {user.isAdmin ? (
+                    <>
+                      <ShieldOff className="h-4 w-4" aria-hidden="true" />
+                      Retirer l'accès admin
+                    </>
+                  ) : (
+                    <>
+                      <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+                      Rendre administrateur
+                    </>
+                  )}
+                </Button>
+              }
+            />
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  Confirmer le changement de rôle
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  {user.isAdmin
+                    ? `${user.name} perdra l'accès aux pages d'administration.`
+                    : `${user.name} aura accès à toutes les pages d'administration, y compris la gestion des utilisateurs.`}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Annuler</AlertDialogCancel>
+                <AlertDialogAction
+                  onClick={() =>
+                    updateRole.mutate({
+                      id: user.id,
+                      isAdmin: !user.isAdmin,
+                    })
+                  }
+                >
+                  {user.isAdmin
+                    ? "Retirer l'accès admin"
+                    : "Rendre administrateur"}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        )}
+      </td>
+    </tr>
+  );
+}

--- a/apps/web/src/routes/_authenticated/admin-users/index.tsx
+++ b/apps/web/src/routes/_authenticated/admin-users/index.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useState } from "react";
-import { ShieldCheck, ShieldOff, Search } from "lucide-react";
+import { ShieldCheck, ShieldOff, Crown, Ban, Search } from "lucide-react";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -20,6 +20,7 @@ import { PageLoader } from "@/components/ui/page-loader";
 import { PageHeader } from "@/components/layout/page-header";
 import {
   useAdminUsers,
+  useUpdateUserPremium,
   useUpdateUserRole,
   type AdminUser,
 } from "@/hooks/use-admin-users";
@@ -41,12 +42,44 @@ export const Route = createFileRoute("/_authenticated/admin-users/")({
   staticData: { crumb: "nav.adminUsers" },
 });
 
+type BadgeVariant = "default" | "secondary" | "outline" | "destructive";
+
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleDateString("fr-FR", {
     day: "numeric",
     month: "short",
     year: "numeric",
   });
+}
+
+// Maps the user's Stripe subscription state to a read-only badge.
+function subscriptionBadge(u: AdminUser): {
+  label: string;
+  variant: BadgeVariant;
+} {
+  const status = u.subscriptionStatus;
+  if (!status) return { label: "Aucun", variant: "outline" };
+
+  const paused =
+    u.subscriptionPausedUntil != null &&
+    new Date(u.subscriptionPausedUntil) > new Date();
+  if (paused) return { label: "En pause", variant: "outline" };
+
+  switch (status) {
+    case "active":
+      return u.subscriptionCancelAtPeriodEnd
+        ? { label: "Annulation prévue", variant: "outline" }
+        : { label: "Abonné", variant: "secondary" };
+    case "trialing":
+      return { label: "Essai", variant: "secondary" };
+    case "past_due":
+    case "unpaid":
+      return { label: "Paiement en retard", variant: "destructive" };
+    case "canceled":
+      return { label: "Annulé", variant: "outline" };
+    default:
+      return { label: "Inactif", variant: "outline" };
+  }
 }
 
 function AdminUsersPage() {
@@ -83,6 +116,7 @@ function AdminUsersPage() {
       )
     : users;
   const adminCount = users.filter((u) => u.isAdmin).length;
+  const premiumCount = users.filter((u) => u.premiumGranted).length;
 
   return (
     <div className="space-y-6">
@@ -90,7 +124,11 @@ function AdminUsersPage() {
         title="Administration des utilisateurs"
         description={`${users.length} compte${
           users.length > 1 ? "s" : ""
-        } · ${adminCount} administrateur${adminCount > 1 ? "s" : ""}`}
+        } · ${adminCount} administrateur${
+          adminCount > 1 ? "s" : ""
+        } · ${premiumCount} accès premium accordé${
+          premiumCount > 1 ? "s" : ""
+        }`}
       />
 
       <div className="relative max-w-sm">
@@ -118,7 +156,7 @@ function AdminUsersPage() {
             </p>
           ) : (
             <div className="overflow-x-auto">
-              <table className="w-full min-w-[40rem] text-sm">
+              <table className="w-full min-w-[56rem] text-sm">
                 <thead>
                   <tr className="border-b border-border/60 bg-muted/40">
                     <th className="px-4 py-3 text-left font-medium text-muted-foreground">
@@ -128,10 +166,13 @@ function AdminUsersPage() {
                       Inscrit le
                     </th>
                     <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      Abonnement
+                    </th>
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
                       Rôle
                     </th>
-                    <th className="px-4 py-3 text-right font-medium text-muted-foreground">
-                      Action
+                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
+                      Accès premium
                     </th>
                   </tr>
                 </thead>
@@ -154,6 +195,51 @@ function AdminUsersPage() {
   );
 }
 
+function ConfirmAction({
+  buttonLabel,
+  buttonIcon: Icon,
+  buttonVariant,
+  disabled,
+  title,
+  description,
+  confirmLabel,
+  onConfirm,
+}: {
+  buttonLabel: string;
+  buttonIcon: React.ComponentType<{ className?: string }>;
+  buttonVariant: "outline" | "destructive";
+  disabled?: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger
+        render={
+          <Button variant={buttonVariant} size="sm" disabled={disabled}>
+            <Icon className="h-4 w-4" aria-hidden="true" />
+            {buttonLabel}
+          </Button>
+        }
+      />
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Annuler</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            {confirmLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
 function UserRow({
   user,
   isCurrentUser,
@@ -164,14 +250,18 @@ function UserRow({
   striped: boolean;
 }) {
   const updateRole = useUpdateUserRole();
-  const isPending =
+  const updatePremium = useUpdateUserPremium();
+  const rolePending =
     updateRole.isPending && updateRole.variables?.id === user.id;
+  const premiumPending =
+    updatePremium.isPending && updatePremium.variables?.id === user.id;
   // Mirrors the API guard: an admin can't strip their own role.
   const lockedSelf = isCurrentUser && user.isAdmin;
+  const sub = subscriptionBadge(user);
 
   return (
     <tr className={striped ? "bg-muted/20" : undefined}>
-      <td className="px-4 py-3">
+      <td className="px-4 py-3 align-top">
         <div className="font-medium text-foreground">
           {user.name}
           {isCurrentUser && (
@@ -182,76 +272,90 @@ function UserRow({
         </div>
         <div className="text-xs text-muted-foreground">{user.email}</div>
       </td>
-      <td className="px-4 py-3 whitespace-nowrap text-muted-foreground">
+      <td className="px-4 py-3 align-top whitespace-nowrap text-muted-foreground">
         {formatDate(user.createdAt)}
       </td>
-      <td className="px-4 py-3">
+      <td className="px-4 py-3 align-top">
         <div className="flex flex-wrap items-center gap-1.5">
-          <Badge variant={user.isAdmin ? "secondary" : "outline"}>
-            {user.isAdmin ? "Administrateur" : "Parent"}
-          </Badge>
+          <Badge variant={sub.variant}>{sub.label}</Badge>
           {user.deletionScheduledAt && (
             <Badge variant="destructive">Suppression programmée</Badge>
           )}
         </div>
       </td>
-      <td className="px-4 py-3 text-right">
-        {lockedSelf ? (
-          <span className="text-xs text-muted-foreground">
-            Vous ne pouvez pas modifier votre propre rôle
-          </span>
-        ) : (
-          <AlertDialog>
-            <AlertDialogTrigger
-              render={
-                <Button
-                  variant={user.isAdmin ? "destructive" : "outline"}
-                  size="sm"
-                  disabled={isPending}
-                >
-                  {user.isAdmin ? (
-                    <>
-                      <ShieldOff className="h-4 w-4" aria-hidden="true" />
-                      Retirer l'accès admin
-                    </>
-                  ) : (
-                    <>
-                      <ShieldCheck className="h-4 w-4" aria-hidden="true" />
-                      Rendre administrateur
-                    </>
-                  )}
-                </Button>
+      <td className="px-4 py-3 align-top">
+        <div className="flex flex-col items-start gap-1.5">
+          <Badge variant={user.isAdmin ? "secondary" : "outline"}>
+            {user.isAdmin ? "Administrateur" : "Parent"}
+          </Badge>
+          {lockedSelf ? (
+            <span className="text-xs text-muted-foreground">
+              Vous ne pouvez pas modifier votre propre rôle
+            </span>
+          ) : user.isAdmin ? (
+            <ConfirmAction
+              buttonLabel="Retirer l'accès admin"
+              buttonIcon={ShieldOff}
+              buttonVariant="destructive"
+              disabled={rolePending}
+              title="Confirmer le changement de rôle"
+              description={`${user.name} perdra l'accès aux pages d'administration.`}
+              confirmLabel="Retirer l'accès admin"
+              onConfirm={() =>
+                updateRole.mutate({ id: user.id, isAdmin: false })
               }
             />
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>
-                  Confirmer le changement de rôle
-                </AlertDialogTitle>
-                <AlertDialogDescription>
-                  {user.isAdmin
-                    ? `${user.name} perdra l'accès aux pages d'administration.`
-                    : `${user.name} aura accès à toutes les pages d'administration, y compris la gestion des utilisateurs.`}
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Annuler</AlertDialogCancel>
-                <AlertDialogAction
-                  onClick={() =>
-                    updateRole.mutate({
-                      id: user.id,
-                      isAdmin: !user.isAdmin,
-                    })
-                  }
-                >
-                  {user.isAdmin
-                    ? "Retirer l'accès admin"
-                    : "Rendre administrateur"}
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        )}
+          ) : (
+            <ConfirmAction
+              buttonLabel="Rendre administrateur"
+              buttonIcon={ShieldCheck}
+              buttonVariant="outline"
+              disabled={rolePending}
+              title="Confirmer le changement de rôle"
+              description={`${user.name} aura accès à toutes les pages d'administration, y compris la gestion des utilisateurs.`}
+              confirmLabel="Rendre administrateur"
+              onConfirm={() =>
+                updateRole.mutate({ id: user.id, isAdmin: true })
+              }
+            />
+          )}
+        </div>
+      </td>
+      <td className="px-4 py-3 align-top">
+        <div className="flex flex-col items-start gap-1.5">
+          {user.premiumGranted ? (
+            <Badge variant="default">Premium accordé</Badge>
+          ) : (
+            <span className="text-xs text-muted-foreground">Non accordé</span>
+          )}
+          {user.premiumGranted ? (
+            <ConfirmAction
+              buttonLabel="Retirer le premium"
+              buttonIcon={Ban}
+              buttonVariant="destructive"
+              disabled={premiumPending}
+              title="Retirer l'accès premium"
+              description={`${user.name} perdra l'accès premium accordé. Son accès dépendra alors de son abonnement Stripe.`}
+              confirmLabel="Retirer le premium"
+              onConfirm={() =>
+                updatePremium.mutate({ id: user.id, premiumGranted: false })
+              }
+            />
+          ) : (
+            <ConfirmAction
+              buttonLabel="Accorder le premium"
+              buttonIcon={Crown}
+              buttonVariant="outline"
+              disabled={premiumPending}
+              title="Accorder l'accès premium"
+              description={`${user.name} aura un accès premium complet et gratuit, indépendamment de tout abonnement Stripe.`}
+              confirmLabel="Accorder le premium"
+              onConfirm={() =>
+                updatePremium.mutate({ id: user.id, premiumGranted: true })
+              }
+            />
+          )}
+        </div>
       </td>
     </tr>
   );

--- a/packages/db/drizzle/0047_narrow_rocket_racer.sql
+++ b/packages/db/drizzle/0047_narrow_rocket_racer.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "user" ADD COLUMN "premium_granted" boolean DEFAULT false NOT NULL;

--- a/packages/db/drizzle/meta/0047_snapshot.json
+++ b/packages/db/drizzle/meta/0047_snapshot.json
@@ -1,0 +1,3844 @@
+{
+  "id": "63e426d4-0e66-4059-a439-80b592afbc5b",
+  "prevId": "78aa9256-d3f7-48b1-ad8c-f4a81942d797",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "premium_granted": {
+          "name": "premium_granted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_scheduled_at": {
+          "name": "deletion_scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.children": {
+      "name": "children",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age_range": {
+          "name": "age_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_type": {
+          "name": "diagnosis_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undefined'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "children_parent_id_idx": {
+          "name": "children_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "children_parent_id_user_id_fk": {
+          "name": "children_parent_id_user_id_fk",
+          "tableFrom": "children",
+          "tableTo": "user",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.symptoms": {
+      "name": "symptoms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agitation": {
+          "name": "agitation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "focus": {
+          "name": "focus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impulse": {
+          "name": "impulse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood": {
+          "name": "mood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sleep": {
+          "name": "sleep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routines_ok": {
+          "name": "routines_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "symptoms_child_id_date_idx": {
+          "name": "symptoms_child_id_date_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "symptoms_child_id_children_id_fk": {
+          "name": "symptoms_child_id_children_id_fk",
+          "tableFrom": "symptoms",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entries": {
+      "name": "journal_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "journal_entries_child_id_date_idx": {
+          "name": "journal_entries_child_id_date_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_child_id_children_id_fk": {
+          "name": "journal_entries_child_id_children_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "paused_until": {
+          "name": "paused_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_months_used": {
+          "name": "pause_months_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pause_year_ref": {
+          "name": "pause_year_ref",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_reminder_sent_at": {
+          "name": "trial_reminder_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscription_user_id_idx": {
+          "name": "subscription_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscription_user_id_unique": {
+          "name": "subscription_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "subscription_stripe_subscription_id_unique": {
+          "name": "subscription_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_behavior_logs": {
+      "name": "barkley_behavior_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "behavior_id": {
+          "name": "behavior_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_behavior_logs_behavior_id_idx": {
+          "name": "barkley_behavior_logs_behavior_id_idx",
+          "columns": [
+            {
+              "expression": "behavior_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_behavior_logs_behavior_id_barkley_behaviors_id_fk": {
+          "name": "barkley_behavior_logs_behavior_id_barkley_behaviors_id_fk",
+          "tableFrom": "barkley_behavior_logs",
+          "tableTo": "barkley_behaviors",
+          "columnsFrom": [
+            "behavior_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "barkley_behavior_logs_behavior_id_date_unique": {
+          "name": "barkley_behavior_logs_behavior_id_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "behavior_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_behaviors": {
+      "name": "barkley_behaviors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_behaviors_child_id_idx": {
+          "name": "barkley_behaviors_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_behaviors_child_id_children_id_fk": {
+          "name": "barkley_behaviors_child_id_children_id_fk",
+          "tableFrom": "barkley_behaviors",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_rewards": {
+      "name": "barkley_rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stars_required": {
+          "name": "stars_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "times_claimed": {
+          "name": "times_claimed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_rewards_child_id_idx": {
+          "name": "barkley_rewards_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_rewards_child_id_children_id_fk": {
+          "name": "barkley_rewards_child_id_children_id_fk",
+          "tableFrom": "barkley_rewards",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_steps": {
+      "name": "barkley_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_steps_child_id_idx": {
+          "name": "barkley_steps_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_steps_child_id_children_id_fk": {
+          "name": "barkley_steps_child_id_children_id_fk",
+          "tableFrom": "barkley_steps",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "barkley_steps_child_id_step_number_unique": {
+          "name": "barkley_steps_child_id_step_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "child_id",
+            "step_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crisis_items": {
+      "name": "crisis_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crisis_items_child_id_idx": {
+          "name": "crisis_items_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crisis_items_child_id_children_id_fk": {
+          "name": "crisis_items_child_id_children_id_fk",
+          "tableFrom": "crisis_items",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_logs": {
+      "name": "medication_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "medication_id": {
+          "name": "medication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taken": {
+          "name": "taken",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_effects": {
+          "name": "side_effects",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "medication_logs_medication_id_idx": {
+          "name": "medication_logs_medication_id_idx",
+          "columns": [
+            {
+              "expression": "medication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medication_logs_medication_id_medications_id_fk": {
+          "name": "medication_logs_medication_id_medications_id_fk",
+          "tableFrom": "medication_logs",
+          "tableTo": "medications",
+          "columnsFrom": [
+            "medication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "medication_logs_medication_id_date_unique": {
+          "name": "medication_logs_medication_id_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "medication_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medications": {
+      "name": "medications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose": {
+          "name": "dose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "medications_child_id_idx": {
+          "name": "medications_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medications_child_id_children_id_fk": {
+          "name": "medications_child_id_children_id_fk",
+          "tableFrom": "medications",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Europe/Paris'"
+        },
+        "daily_reminder_opt_in": {
+          "name": "daily_reminder_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weekly_digest_opt_in": {
+          "name": "weekly_digest_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "co_parent_activity_opt_in": {
+          "name": "co_parent_activity_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "morning_reminder_time": {
+          "name": "morning_reminder_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'09:00'"
+        },
+        "evening_reminder_opt_in": {
+          "name": "evening_reminder_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "evening_reminder_time": {
+          "name": "evening_reminder_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'20:30'"
+        },
+        "last_daily_reminder_at": {
+          "name": "last_daily_reminder_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_weekly_digest_at": {
+          "name": "last_weekly_digest_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_evening_reminder_at": {
+          "name": "last_evening_reminder_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lock_pin_hash": {
+          "name": "lock_pin_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lock_pin_salt": {
+          "name": "lock_pin_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_user_id_fk": {
+          "name": "user_preferences_user_id_user_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news": {
+      "name": "news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "news_published_at_idx": {
+          "name": "news_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news_slug_idx": {
+          "name": "news_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "news_author_id_user_id_fk": {
+          "name": "news_author_id_user_id_fk",
+          "tableFrom": "news",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "news_slug_unique": {
+          "name": "news_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consents_user_type_idx": {
+          "name": "consents_user_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consents_user_id_user_id_fk": {
+          "name": "consents_user_id_user_id_fk",
+          "tableFrom": "consents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_recommendations": {
+      "name": "ai_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_template": {
+          "name": "prompt_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion": {
+          "name": "suggestion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_note": {
+          "name": "feedback_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_recommendations_user_id_idx": {
+          "name": "ai_recommendations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_recommendations_user_id_user_id_fk": {
+          "name": "ai_recommendations_user_id_user_id_fk",
+          "tableFrom": "ai_recommendations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_recommendations_child_id_children_id_fk": {
+          "name": "ai_recommendations_child_id_children_id_fk",
+          "tableFrom": "ai_recommendations",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nps_responses": {
+      "name": "nps_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort": {
+          "name": "cohort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nps_responses_user_cohort_unique": {
+          "name": "nps_responses_user_cohort_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cohort",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nps_responses_user_id_user_id_fk": {
+          "name": "nps_responses_user_id_user_id_fk",
+          "tableFrom": "nps_responses",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_items": {
+      "name": "roadmap_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roadmap_items_status_idx": {
+          "name": "roadmap_items_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_votes": {
+      "name": "roadmap_votes",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roadmap_votes_item_user_unique": {
+          "name": "roadmap_votes_item_user_unique",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roadmap_votes_item_id_roadmap_items_id_fk": {
+          "name": "roadmap_votes_item_id_roadmap_items_id_fk",
+          "tableFrom": "roadmap_votes",
+          "tableTo": "roadmap_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roadmap_votes_user_id_user_id_fk": {
+          "name": "roadmap_votes_user_id_user_id_fk",
+          "tableFrom": "roadmap_votes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_endpoint_unique": {
+          "name": "push_subscriptions_user_endpoint_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_user_id_fk": {
+          "name": "push_subscriptions_user_id_user_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_access": {
+      "name": "child_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'co_parent'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "child_access_child_user_unique": {
+          "name": "child_access_child_user_unique",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_access_user_id_idx": {
+          "name": "child_access_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_access_child_id_idx": {
+          "name": "child_access_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "child_access_child_id_children_id_fk": {
+          "name": "child_access_child_id_children_id_fk",
+          "tableFrom": "child_access",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "child_access_user_id_user_id_fk": {
+          "name": "child_access_user_id_user_id_fk",
+          "tableFrom": "child_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "child_access_granted_by_user_id_fk": {
+          "name": "child_access_granted_by_user_id_fk",
+          "tableFrom": "child_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_invitations": {
+      "name": "child_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_email": {
+          "name": "invited_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single'"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "child_invitations_child_id_idx": {
+          "name": "child_invitations_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_invitations_email_idx": {
+          "name": "child_invitations_email_idx",
+          "columns": [
+            {
+              "expression": "invited_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_invitations_batch_id_idx": {
+          "name": "child_invitations_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "child_invitations_child_id_children_id_fk": {
+          "name": "child_invitations_child_id_children_id_fk",
+          "tableFrom": "child_invitations",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "child_invitations_invited_by_user_id_fk": {
+          "name": "child_invitations_invited_by_user_id_fk",
+          "tableFrom": "child_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "child_invitations_token_hash_unique": {
+          "name": "child_invitations_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_child_created_idx": {
+          "name": "audit_log_child_created_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_actor_id_idx": {
+          "name": "audit_log_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_id_user_id_fk": {
+          "name": "audit_log_actor_id_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_log_child_id_children_id_fk": {
+          "name": "audit_log_child_id_children_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_webhook_event": {
+      "name": "stripe_webhook_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strengths": {
+      "name": "strengths",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "strengths_child_id_occurred_on_idx": {
+          "name": "strengths_child_id_occurred_on_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strengths_child_id_children_id_fk": {
+          "name": "strengths_child_id_children_id_fk",
+          "tableFrom": "strengths",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine_completions": {
+      "name": "routine_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routine_completions_child_date_idx": {
+          "name": "routine_completions_child_date_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine_completions_routine_id_routines_id_fk": {
+          "name": "routine_completions_routine_id_routines_id_fk",
+          "tableFrom": "routine_completions",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine_completions_step_id_routine_steps_id_fk": {
+          "name": "routine_completions_step_id_routine_steps_id_fk",
+          "tableFrom": "routine_completions",
+          "tableTo": "routine_steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine_completions_child_id_children_id_fk": {
+          "name": "routine_completions_child_id_children_id_fk",
+          "tableFrom": "routine_completions",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "routine_completions_step_date_unique": {
+          "name": "routine_completions_step_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "step_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine_steps": {
+      "name": "routine_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routine_steps_routine_id_idx": {
+          "name": "routine_steps_routine_id_idx",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine_steps_routine_id_routines_id_fk": {
+          "name": "routine_steps_routine_id_routines_id_fk",
+          "tableFrom": "routine_steps",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routines": {
+      "name": "routines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_of_day": {
+          "name": "time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'morning'"
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routines_child_id_idx": {
+          "name": "routines_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routines_child_id_children_id_fk": {
+          "name": "routines_child_id_children_id_fk",
+          "tableFrom": "routines",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.care_pathway_progress": {
+      "name": "care_pathway_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_pathway_progress_child_step_idx": {
+          "name": "care_pathway_progress_child_step_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "care_pathway_progress_child_id_children_id_fk": {
+          "name": "care_pathway_progress_child_id_children_id_fk",
+          "tableFrom": "care_pathway_progress",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_documents": {
+      "name": "admin_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_documents_child_id_idx": {
+          "name": "admin_documents_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_documents_child_id_children_id_fk": {
+          "name": "admin_documents_child_id_children_id_fk",
+          "tableFrom": "admin_documents",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parent_mood_logs": {
+      "name": "parent_mood_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parent_mood_logs_user_date_idx": {
+          "name": "parent_mood_logs_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parent_mood_logs_user_id_user_id_fk": {
+          "name": "parent_mood_logs_user_id_user_id_fk",
+          "tableFrom": "parent_mood_logs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_started_at": {
+          "name": "last_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_finished_at": {
+          "name": "last_finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "last_duration_ms": {
+          "name": "last_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_result": {
+          "name": "last_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.solidarity_requests": {
+      "name": "solidarity_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "solidarity_requests_parent_id_idx": {
+          "name": "solidarity_requests_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "solidarity_requests_parent_id_user_id_fk": {
+          "name": "solidarity_requests_parent_id_user_id_fk",
+          "tableFrom": "solidarity_requests",
+          "tableTo": "user",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_event_name_created_at_idx": {
+          "name": "events_event_name_created_at_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_parent_id_idx": {
+          "name": "events_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_parent_id_user_id_fk": {
+          "name": "events_parent_id_user_id_fk",
+          "tableFrom": "events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variants": {
+          "name": "variants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1778572753705,
       "tag": "0046_tired_nebula",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1778857856429,
+      "tag": "0047_narrow_rocket_racer",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/users.ts
+++ b/packages/db/src/schema/users.ts
@@ -7,6 +7,10 @@ export const user = pgTable("user", {
   emailVerified: boolean("email_verified").notNull().default(false),
   image: text("image"),
   isAdmin: boolean("is_admin").notNull().default(false),
+  // Complimentary premium access granted by an administrator, independent
+  // of Stripe. When true the user has full plan access even without (or
+  // alongside) a subscription. Toggled only from the admin users console.
+  premiumGranted: boolean("premium_granted").notNull().default(false),
   // Pre-allocated when the user first hits /checkout, so an abandoned
   // checkout doesn't create a new orphan Stripe Customer on retry. The
   // webhook still writes to subscription.stripe_customer_id but this is

--- a/packages/validators/src/admin-user.ts
+++ b/packages/validators/src/admin-user.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const updateUserRoleSchema = z.object({
+  isAdmin: z.boolean(),
+});
+
+export type UpdateUserRole = z.infer<typeof updateUserRoleSchema>;

--- a/packages/validators/src/admin-user.ts
+++ b/packages/validators/src/admin-user.ts
@@ -5,3 +5,9 @@ export const updateUserRoleSchema = z.object({
 });
 
 export type UpdateUserRole = z.infer<typeof updateUserRoleSchema>;
+
+export const updateUserPremiumSchema = z.object({
+  premiumGranted: z.boolean(),
+});
+
+export type UpdateUserPremium = z.infer<typeof updateUserPremiumSchema>;

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -23,3 +23,4 @@ export * from "./parent-mood";
 export * from "./solidarity";
 export * from "./event";
 export * from "./feature-flag";
+export * from "./admin-user";


### PR DESCRIPTION
Adds an admin-only page to list all accounts and grant or revoke the
admin role. The route, sidebar entry and API are all gated on
`isAdmin`; an admin cannot strip their own role to avoid lockout.

https://claude.ai/code/session_01CXTD5Hxq6AS24UP4aQ96gi