### PR TITLE
feat: add agent access keys, MCP server and developer docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,8 @@ design principles are binding.
 
 Tokō is an ADHD-child management web app for French-speaking parents.
 pnpm + Turborepo monorepo: React 19 SPA (`apps/web`), Hono API (`apps/api`),
-a stdio MCP server (`apps/mcp`), shared Drizzle schema (`packages/db`) and
-shared Zod validators (`packages/validators`).
+a stdio MCP server (`apps/mcp`), a read-only CLI (`apps/cli`), shared Drizzle
+schema (`packages/db`) and shared Zod validators (`packages/validators`).
 
 ## Setup & commands
 
@@ -40,11 +40,13 @@ pnpm db:generate      # generate a Drizzle migration after a schema change
 ## Agent access (runtime)
 
 Parents can connect their own AI assistant to Tokō through the MCP server
-in `apps/mcp`. It authenticates with an agent access key (`toko_sk_…`) the
-parent issues from the `/developers` page.
+(`apps/mcp`, for shell-less chat assistants) or the `toko` CLI (`apps/cli`,
+for terminal/coding agents). Both authenticate with an agent access key
+(`toko_sk_…`) the parent issues from the `/developers` page.
 
 These keys are **read-only** and confined to an endpoint allowlist defined
 in `apps/api/src/lib/agent-access.ts`. When adding a new API route, it is
 unreachable by agent keys until explicitly added to that allowlist — keep
-the allowlist, the OpenAPI document (`apps/api/src/lib/openapi-spec.ts`) and
-the MCP tools (`apps/mcp/src/index.ts`) in sync.
+the allowlist, the OpenAPI document (`apps/api/src/lib/openapi-spec.ts`), the
+MCP tools (`apps/mcp/src/index.ts`) and the CLI commands
+(`apps/cli/src/index.ts`) in sync.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md — Tokō
+
+Guidance for AI coding agents working in this repository. Human-facing
+product/design rules live in `CLAUDE.md`; read it too — its ADHD-audience
+design principles are binding.
+
+## Project
+
+Tokō is an ADHD-child management web app for French-speaking parents.
+pnpm + Turborepo monorepo: React 19 SPA (`apps/web`), Hono API (`apps/api`),
+a stdio MCP server (`apps/mcp`), shared Drizzle schema (`packages/db`) and
+shared Zod validators (`packages/validators`).
+
+## Setup & commands
+
+```bash
+pnpm install          # install workspace deps
+pnpm dev              # run API + web
+pnpm build            # build everything
+pnpm typecheck        # type-check all packages — run before committing
+pnpm test             # Vitest unit tests
+pnpm lint             # lint
+pnpm db:generate      # generate a Drizzle migration after a schema change
+```
+
+## Conventions
+
+- **Language:** all parent-facing UI text is in French. The `/developers`
+  page is also French (it targets the French-speaking parent).
+- **Validation:** Zod schemas in `packages/validators/src/`, shared by API
+  routes and the web forms.
+- **DB:** Drizzle tables in `packages/db/src/schema/`, one file per domain.
+  After editing a schema, run `pnpm db:generate` and commit the SQL.
+- **Ownership:** every child-scoped query must be filtered by the owning
+  parent — never trust an id from the request alone.
+- **API routes:** Hono handlers in `apps/api/src/routes/`, validated with a
+  Zod schema, returning 422 on invalid input.
+- Run `pnpm typecheck` before committing.
+
+## Agent access (runtime)
+
+Parents can connect their own AI assistant to Tokō through the MCP server
+in `apps/mcp`. It authenticates with an agent access key (`toko_sk_…`) the
+parent issues from the `/developers` page.
+
+These keys are **read-only** and confined to an endpoint allowlist defined
+in `apps/api/src/lib/agent-access.ts`. When adding a new API route, it is
+unreachable by agent keys until explicitly added to that allowlist — keep
+the allowlist, the OpenAPI document (`apps/api/src/lib/openapi-spec.ts`) and
+the MCP tools (`apps/mcp/src/index.ts`) in sync.

--- a/apps/api/src/__tests__/child-invitations.integration.test.ts
+++ b/apps/api/src/__tests__/child-invitations.integration.test.ts
@@ -13,8 +13,13 @@ import { vi } from "vitest";
 // IMPORTANT: vi.mock calls are hoisted above imports, so the auth
 // middleware is replaced before app.ts loads its routes.
 vi.mock("../middleware/auth", async () => {
-  const { testAuthMiddleware } = await import("./helpers/auth-mock");
-  return { authMiddleware: testAuthMiddleware };
+  const { testAuthMiddleware, testRequireSession } = await import(
+    "./helpers/auth-mock"
+  );
+  return {
+    authMiddleware: testAuthMiddleware,
+    requireSession: testRequireSession,
+  };
 });
 
 // Stub Resend so the invite POST doesn't 500 in CI: production refuses to

--- a/apps/api/src/__tests__/helpers/auth-mock.ts
+++ b/apps/api/src/__tests__/helpers/auth-mock.ts
@@ -40,5 +40,15 @@ export async function testAuthMiddleware(
     id: "test-session",
     expiresAt: new Date(Date.now() + 60 * 60_000),
   });
+  c.set("authType", "session");
+  await next();
+}
+
+// Stand-in for `requireSession` — a no-op in tests, since fixtures always
+// authenticate via the test header and never via an agent API key.
+export async function testRequireSession(
+  _c: Context,
+  next: Next,
+): Promise<void> {
   await next();
 }

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -37,6 +37,8 @@ import { solidarityRoutes } from "./routes/solidarity";
 import { eventsRoutes } from "./routes/events";
 import { adminAnalyticsRoutes } from "./routes/admin-analytics";
 import { featureFlagsRoutes } from "./routes/feature-flags";
+import { agentKeysRoutes } from "./routes/agent-keys";
+import { openApiSpec } from "./lib/openapi-spec";
 import { auth } from "./lib/auth";
 
 const app = new Hono();
@@ -154,5 +156,11 @@ app.route("/api/solidarity", solidarityRoutes);
 app.route("/api/events", eventsRoutes);
 app.route("/api/admin/analytics", adminAnalyticsRoutes);
 app.route("/api/feature-flags", featureFlagsRoutes);
+app.route("/api/agent-keys", agentKeysRoutes);
+
+// Machine-readable contract for the agent-readable surface. Public on
+// purpose — it documents the API, carries no secrets, and is consumed by
+// the developer docs and the Tokō MCP server.
+app.get("/api/openapi.json", (c) => c.json(openApiSpec));
 
 export { app };

--- a/apps/api/src/lib/agent-access.ts
+++ b/apps/api/src/lib/agent-access.ts
@@ -1,0 +1,36 @@
+// Endpoint allowlist for agent access keys.
+//
+// Agent keys are READ-ONLY and may only reach the tracking-data endpoints
+// listed here. This is a deny-by-default allowlist on purpose: a new route
+// is unreachable by an agent key until it is explicitly added, so we can
+// never accidentally expose a sensitive surface (medical-document vault,
+// RGPD export, account deletion, billing, audit log, family invitations).
+//
+// Keep this list in sync with the OpenAPI document (lib/openapi-spec.ts)
+// and the MCP server tools (apps/mcp).
+const AGENT_READ_PREFIXES = [
+  "/api/children",
+  "/api/symptoms",
+  "/api/journal",
+  "/api/strengths",
+  "/api/stats",
+  "/api/barkley",
+  "/api/medications",
+  "/api/crisis-list",
+  "/api/routines",
+  "/api/care-pathway",
+  "/api/parent-mood",
+] as const;
+
+/**
+ * Whether an agent-key request is allowed: it must be a GET (read-only) and
+ * its path must fall under an allowlisted prefix.
+ */
+export function isAgentReadAllowed(method: string, path: string): boolean {
+  if (method !== "GET") return false;
+  return AGENT_READ_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+  );
+}
+
+export { AGENT_READ_PREFIXES };

--- a/apps/api/src/lib/agent-key.ts
+++ b/apps/api/src/lib/agent-key.ts
@@ -1,0 +1,117 @@
+import crypto from "node:crypto";
+import type { Context } from "hono";
+import { eq } from "drizzle-orm";
+import { db, agentKey, user as userTable } from "@focusflow/db";
+
+// Agent access keys look like `toko_sk_<43 base64url chars>`. The prefix is
+// both a human cue and a scannable token for secret-detection tooling.
+const KEY_PREFIX = "toko_sk_";
+
+export function hashAgentKey(secret: string): string {
+  return crypto.createHash("sha256").update(secret).digest("hex");
+}
+
+/**
+ * Mint a fresh key. The returned `secret` is shown to the parent exactly
+ * once and never persisted — only `keyHash` and the display `prefix` are.
+ */
+export function generateAgentKey(): {
+  secret: string;
+  keyHash: string;
+  prefix: string;
+} {
+  const secret = `${KEY_PREFIX}${crypto.randomBytes(32).toString("base64url")}`;
+  return {
+    secret,
+    keyHash: hashAgentKey(secret),
+    // First 16 chars — enough to recognise a key in a list, far too few
+    // to reconstruct the 256-bit secret.
+    prefix: secret.slice(0, 16),
+  };
+}
+
+/** Pull an agent key out of the request, supporting both header styles. */
+export function extractApiKey(c: Context): string | null {
+  const headerKey = c.req.header("x-api-key");
+  if (headerKey) return headerKey.trim();
+  const authz = c.req.header("authorization");
+  if (authz?.startsWith(`Bearer ${KEY_PREFIX}`)) {
+    return authz.slice("Bearer ".length).trim();
+  }
+  return null;
+}
+
+export interface VerifiedAgentKey {
+  keyId: string;
+  user: { id: string; name: string; email: string; emailVerified: boolean };
+}
+
+/**
+ * Resolve a raw key to its owner, or null if the key is unknown, revoked or
+ * expired. Updates `lastUsedAt` as a fire-and-forget side effect.
+ */
+export async function verifyAgentKey(
+  rawKey: string,
+): Promise<VerifiedAgentKey | null> {
+  if (!rawKey.startsWith(KEY_PREFIX)) return null;
+
+  const keyHash = hashAgentKey(rawKey);
+  const [row] = await db
+    .select({
+      id: agentKey.id,
+      expiresAt: agentKey.expiresAt,
+      revokedAt: agentKey.revokedAt,
+      userId: userTable.id,
+      userName: userTable.name,
+      userEmail: userTable.email,
+      userEmailVerified: userTable.emailVerified,
+    })
+    .from(agentKey)
+    .innerJoin(userTable, eq(userTable.id, agentKey.userId))
+    .where(eq(agentKey.keyHash, keyHash))
+    .limit(1);
+
+  if (!row || row.revokedAt) return null;
+  if (row.expiresAt && row.expiresAt.getTime() <= Date.now()) return null;
+
+  void db
+    .update(agentKey)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(agentKey.id, row.id))
+    .catch(() => {});
+
+  return {
+    keyId: row.id,
+    user: {
+      id: row.userId,
+      name: row.userName,
+      email: row.userEmail,
+      emailVerified: row.userEmailVerified,
+    },
+  };
+}
+
+// Per-key rate limit — deliberately well below the 120 req/min global IP
+// limit. A personal assistant polling tracking data has no need for more.
+const AGENT_RATE_WINDOW_MS = 60_000;
+const AGENT_RATE_MAX = 60;
+const agentRateStore = new Map<string, { count: number; resetAt: number }>();
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [k, e] of agentRateStore) {
+    if (e.resetAt <= now) agentRateStore.delete(k);
+  }
+}, 5 * 60 * 1000).unref();
+
+/** Returns false once a key exceeds its per-minute quota. */
+export function checkAgentRateLimit(keyId: string): boolean {
+  const now = Date.now();
+  let entry = agentRateStore.get(keyId);
+  if (!entry || entry.resetAt <= now) {
+    entry = { count: 0, resetAt: now + AGENT_RATE_WINDOW_MS };
+    agentRateStore.set(keyId, entry);
+  }
+  entry.count++;
+  return entry.count <= AGENT_RATE_MAX;
+}

--- a/apps/api/src/lib/openapi-spec.ts
+++ b/apps/api/src/lib/openapi-spec.ts
@@ -1,0 +1,234 @@
+// OpenAPI 3.1 description of the Tokō agent-readable surface.
+//
+// This documents ONLY the endpoints an agent access key can reach — the
+// read-only tracking-data allowlist (see lib/agent-access.ts). It is served
+// at GET /api/openapi.json and is the machine-readable contract behind both
+// the developer docs and the Tokō MCP server.
+//
+// Keep it in sync with AGENT_READ_PREFIXES and the MCP tools.
+
+const childIdParam = {
+  name: "childId",
+  in: "path",
+  required: true,
+  description: "Identifiant de l'enfant",
+  schema: { type: "string" },
+} as const;
+
+function listOp(summary: string, itemRef: string, params: unknown[] = []) {
+  return {
+    summary,
+    security: [{ agentKey: [] }],
+    parameters: params,
+    responses: {
+      "200": {
+        description: "OK",
+        content: {
+          "application/json": {
+            schema: { type: "array", items: { $ref: itemRef } },
+          },
+        },
+      },
+      "401": { $ref: "#/components/responses/Unauthorized" },
+      "403": { $ref: "#/components/responses/AgentForbidden" },
+    },
+  };
+}
+
+export const openApiSpec = {
+  openapi: "3.1.0",
+  info: {
+    title: "Tokō — API d'accès agent",
+    version: "1.0.0",
+    description:
+      "Surface en lecture seule permettant à l'assistant IA d'un parent de consulter les données de suivi de ses enfants. Authentification par clé d'accès (`toko_sk_…`) dans l'en-tête `x-api-key`.",
+  },
+  servers: [{ url: "/", description: "Hôte courant" }],
+  components: {
+    securitySchemes: {
+      agentKey: {
+        type: "apiKey",
+        in: "header",
+        name: "x-api-key",
+        description:
+          "Clé d'accès agent. Générée par le parent depuis la page Développeurs.",
+      },
+    },
+    responses: {
+      Unauthorized: {
+        description: "Clé d'accès absente, invalide, expirée ou révoquée",
+      },
+      AgentForbidden: {
+        description:
+          "La clé est en lecture seule et limitée aux données de suivi",
+      },
+    },
+    schemas: {
+      Child: {
+        type: "object",
+        properties: {
+          id: { type: "string" },
+          name: { type: "string" },
+          ageRange: { type: "string", enum: ["0-5", "6-8", "9-11", "12-14", "15-17"] },
+          gender: { type: "string", enum: ["male", "female", "other"] },
+          diagnosisType: {
+            type: "string",
+            enum: ["inattentive", "hyperactive", "mixed", "undefined"],
+          },
+          createdAt: { type: "string", format: "date-time" },
+        },
+      },
+      Symptom: {
+        type: "object",
+        description: "Observation ponctuelle d'un symptôme TDAH",
+        additionalProperties: true,
+      },
+      JournalEntry: {
+        type: "object",
+        description: "Entrée de journal quotidien (humeur, événements)",
+        additionalProperties: true,
+      },
+      Strength: {
+        type: "object",
+        description: "Force ou réussite identifiée chez l'enfant",
+        additionalProperties: true,
+      },
+      Medication: {
+        type: "object",
+        description: "Traitement et historique de prises",
+        additionalProperties: true,
+      },
+      Routine: {
+        type: "object",
+        description: "Routine quotidienne et ses étapes",
+        additionalProperties: true,
+      },
+      CrisisItem: {
+        type: "object",
+        description: "Étape du plan d'action en cas de crise",
+        additionalProperties: true,
+      },
+      BarkleyBehavior: {
+        type: "object",
+        description: "Comportement suivi sur l'échelle Barkley",
+        additionalProperties: true,
+      },
+      Stats: {
+        type: "object",
+        description: "Statistiques agrégées de suivi",
+        additionalProperties: true,
+      },
+    },
+  },
+  paths: {
+    "/api/children": {
+      get: listOp("Lister les enfants accessibles", "#/components/schemas/Child"),
+    },
+    "/api/children/{id}": {
+      get: {
+        summary: "Détail d'un enfant",
+        security: [{ agentKey: [] }],
+        parameters: [
+          { name: "id", in: "path", required: true, schema: { type: "string" } },
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Child" },
+              },
+            },
+          },
+          "401": { $ref: "#/components/responses/Unauthorized" },
+          "403": { $ref: "#/components/responses/AgentForbidden" },
+          "404": { description: "Enfant non trouvé" },
+        },
+      },
+    },
+    "/api/symptoms/{childId}": {
+      get: listOp("Lister les symptômes d'un enfant", "#/components/schemas/Symptom", [childIdParam]),
+    },
+    "/api/journal/{childId}": {
+      get: listOp("Lister les entrées de journal d'un enfant", "#/components/schemas/JournalEntry", [childIdParam]),
+    },
+    "/api/strengths/{childId}": {
+      get: listOp("Lister les forces d'un enfant", "#/components/schemas/Strength", [childIdParam]),
+    },
+    "/api/medications/{childId}": {
+      get: listOp("Lister les traitements d'un enfant", "#/components/schemas/Medication", [childIdParam]),
+    },
+    "/api/medications/{childId}/adherence": {
+      get: {
+        summary: "Observance des traitements d'un enfant",
+        security: [{ agentKey: [] }],
+        parameters: [childIdParam],
+        responses: {
+          "200": {
+            description: "OK",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+          "401": { $ref: "#/components/responses/Unauthorized" },
+          "403": { $ref: "#/components/responses/AgentForbidden" },
+        },
+      },
+    },
+    "/api/routines/{childId}": {
+      get: listOp("Lister les routines d'un enfant", "#/components/schemas/Routine", [childIdParam]),
+    },
+    "/api/crisis-list/{childId}": {
+      get: listOp("Lister le plan de crise d'un enfant", "#/components/schemas/CrisisItem", [childIdParam]),
+    },
+    "/api/barkley/behaviors/{childId}": {
+      get: listOp("Lister les comportements Barkley d'un enfant", "#/components/schemas/BarkleyBehavior", [childIdParam]),
+    },
+    "/api/care-pathway/{childId}": {
+      get: {
+        summary: "Parcours de soin d'un enfant",
+        security: [{ agentKey: [] }],
+        parameters: [childIdParam],
+        responses: {
+          "200": {
+            description: "OK",
+            content: { "application/json": { schema: { type: "object" } } },
+          },
+          "401": { $ref: "#/components/responses/Unauthorized" },
+          "403": { $ref: "#/components/responses/AgentForbidden" },
+        },
+      },
+    },
+    "/api/stats/{childId}": {
+      get: {
+        summary: "Statistiques de suivi d'un enfant",
+        security: [{ agentKey: [] }],
+        parameters: [childIdParam],
+        responses: {
+          "200": {
+            description: "OK",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/Stats" },
+              },
+            },
+          },
+          "401": { $ref: "#/components/responses/Unauthorized" },
+          "403": { $ref: "#/components/responses/AgentForbidden" },
+        },
+      },
+    },
+    "/api/parent-mood": {
+      get: {
+        summary: "Historique d'humeur du parent",
+        security: [{ agentKey: [] }],
+        responses: {
+          "200": {
+            description: "OK",
+            content: { "application/json": { schema: { type: "array", items: { type: "object" } } } },
+          },
+          "401": { $ref: "#/components/responses/Unauthorized" },
+          "403": { $ref: "#/components/responses/AgentForbidden" },
+        },
+      },
+    },
+  },
+} as const;

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -1,7 +1,53 @@
 import type { Context, Next } from "hono";
 import { auth } from "../lib/auth";
+import {
+  extractApiKey,
+  verifyAgentKey,
+  checkAgentRateLimit,
+} from "../lib/agent-key";
+import { isAgentReadAllowed } from "../lib/agent-access";
 
 export async function authMiddleware(c: Context, next: Next) {
+  // Agent access key path — checked before the session so an AI assistant
+  // can authenticate without a browser cookie.
+  const rawKey = extractApiKey(c);
+  if (rawKey) {
+    const verified = await verifyAgentKey(rawKey);
+    if (!verified) {
+      return c.json(
+        { error: "Clé d'accès invalide, expirée ou révoquée", code: "UNAUTHORIZED" },
+        401,
+      );
+    }
+
+    // Agent keys are read-only and confined to a fixed allowlist. This is
+    // enforced here, not derived from the key, so the boundary holds even
+    // if a key row were tampered with.
+    if (!isAgentReadAllowed(c.req.method, c.req.path)) {
+      return c.json(
+        {
+          error:
+            "Cette clé d'accès est en lecture seule et limitée aux données de suivi de l'enfant.",
+          code: "AGENT_FORBIDDEN",
+        },
+        403,
+      );
+    }
+
+    if (!checkAgentRateLimit(verified.keyId)) {
+      return c.json(
+        { error: "Trop de requêtes pour cette clé d'accès", code: "RATE_LIMITED" },
+        429,
+      );
+    }
+
+    c.set("user", verified.user);
+    c.set("authType", "apiKey");
+    c.set("agentKeyId", verified.keyId);
+    await next();
+    return;
+  }
+
   const session = await auth.api.getSession({
     headers: c.req.raw.headers,
   });
@@ -12,5 +58,23 @@ export async function authMiddleware(c: Context, next: Next) {
 
   c.set("user", session.user);
   c.set("session", session.session);
+  c.set("authType", "session");
+  await next();
+}
+
+/**
+ * Guard for routes that must only ever be reached by a real browser session
+ * — never an agent key (e.g. issuing or revoking keys themselves).
+ */
+export async function requireSession(c: Context, next: Next) {
+  if (c.get("authType") === "apiKey") {
+    return c.json(
+      {
+        error: "Action réservée à une session connectée",
+        code: "SESSION_REQUIRED",
+      },
+      403,
+    );
+  }
   await next();
 }

--- a/apps/api/src/routes/agent-keys.ts
+++ b/apps/api/src/routes/agent-keys.ts
@@ -1,0 +1,104 @@
+import { randomUUID } from "node:crypto";
+import { Hono } from "hono";
+import { and, desc, eq } from "drizzle-orm";
+import { db, agentKey } from "@focusflow/db";
+import { createAgentKeySchema } from "@focusflow/validators";
+import type { AppEnv } from "../types";
+import { authMiddleware, requireSession } from "../middleware/auth";
+import { generateAgentKey } from "../lib/agent-key";
+import { AppError } from "../middleware/error-handler";
+
+// Management of agent access keys. These routes are session-only: an agent
+// key can never mint or revoke other keys.
+export const agentKeysRoutes = new Hono<AppEnv>();
+
+agentKeysRoutes.use("*", authMiddleware);
+agentKeysRoutes.use("*", requireSession);
+
+// Public-safe projection — the hash is never selected.
+const publicColumns = {
+  id: agentKey.id,
+  name: agentKey.name,
+  prefix: agentKey.prefix,
+  scopes: agentKey.scopes,
+  lastUsedAt: agentKey.lastUsedAt,
+  expiresAt: agentKey.expiresAt,
+  revokedAt: agentKey.revokedAt,
+  createdAt: agentKey.createdAt,
+};
+
+agentKeysRoutes.get("/", async (c) => {
+  const user = c.get("user");
+  const rows = await db
+    .select(publicColumns)
+    .from(agentKey)
+    .where(eq(agentKey.userId, user.id))
+    .orderBy(desc(agentKey.createdAt));
+  return c.json(rows);
+});
+
+agentKeysRoutes.post("/", async (c) => {
+  const user = c.get("user");
+  const body = await c.req.json();
+  const parsed = createAgentKeySchema.safeParse(body);
+  if (!parsed.success) {
+    return c.json(
+      { error: "Données invalides", details: parsed.error.flatten() },
+      422,
+    );
+  }
+
+  // Cap on how many active keys one account can hold — keeps a leaked
+  // account from being turned into a key farm.
+  const existing = await db
+    .select({ id: agentKey.id })
+    .from(agentKey)
+    .where(eq(agentKey.userId, user.id));
+  if (existing.length >= 10) {
+    throw new AppError(
+      "FORBIDDEN",
+      "Limite de 10 clés d'accès atteinte. Supprimez-en une pour en créer une nouvelle.",
+      403,
+    );
+  }
+
+  const { secret, keyHash, prefix } = generateAgentKey();
+  const expiresAt = parsed.data.expiresInDays
+    ? new Date(Date.now() + parsed.data.expiresInDays * 24 * 60 * 60 * 1000)
+    : null;
+
+  const [created] = await db
+    .insert(agentKey)
+    .values({
+      id: randomUUID(),
+      userId: user.id,
+      name: parsed.data.name,
+      keyHash,
+      prefix,
+      scopes: "read",
+      expiresAt,
+    })
+    .returning(publicColumns);
+
+  if (!created) throw new AppError("INTERNAL", "Échec de création", 500);
+
+  // `secret` is returned exactly once and is never retrievable afterwards.
+  return c.json({ ...created, secret }, 201);
+});
+
+agentKeysRoutes.delete("/:id", async (c) => {
+  const user = c.get("user");
+  const id = c.req.param("id");
+
+  const [revoked] = await db
+    .update(agentKey)
+    .set({ revokedAt: new Date() })
+    .where(and(eq(agentKey.id, id), eq(agentKey.userId, user.id)))
+    .returning({ id: agentKey.id });
+
+  if (!revoked) {
+    throw new AppError("NOT_FOUND", "Clé d'accès non trouvée", 404);
+  }
+
+  return c.json({ ok: true });
+});

--- a/apps/api/src/types.ts
+++ b/apps/api/src/types.ts
@@ -7,5 +7,10 @@ export interface AppEnv {
       emailVerified: boolean;
     };
     session: { id: string; expiresAt: Date };
+    // How the request authenticated. "apiKey" means an agent access key —
+    // such requests are read-only and restricted to an endpoint allowlist.
+    authType: "session" | "apiKey";
+    // Set only when authType === "apiKey": the id of the agent_key row.
+    agentKeyId?: string;
   };
 }

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@toko/cli",
+  "version": "0.1.0",
+  "description": "CLI Tokō — accès en lecture seule aux données de suivi pour les agents disposant d'un terminal",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "toko": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/**
+ * CLI Tokō.
+ *
+ * Outil en ligne de commande, en LECTURE SEULE, pour consulter les données
+ * de suivi d'un enfant. Destiné aux agents IA disposant d'un terminal
+ * (Claude Code, scripts, CI…) — un assistant conversationnel sans shell
+ * passe lui par le serveur MCP (`@toko/mcp`).
+ *
+ * S'appuie sur la même clé d'accès `toko_sk_…` et la même surface en
+ * lecture seule que le serveur MCP. Aucune écriture n'est possible.
+ *
+ * Authentification : variable d'environnement TOKO_API_KEY (ou --key).
+ * Hôte de l'API : TOKO_API_URL (ou --url), par défaut http://localhost:3001.
+ */
+import { parseArgs } from "node:util";
+
+const VERSION = "0.1.0";
+
+interface CommandDef {
+  /** Builds the API path; receives the positional argument if any. */
+  path: (arg: string) => string;
+  /** Name of the required positional argument, or null if none. */
+  arg: string | null;
+  desc: string;
+}
+
+const COMMANDS: Record<string, CommandDef> = {
+  children: {
+    path: () => "/api/children",
+    arg: null,
+    desc: "Lister les enfants accessibles",
+  },
+  child: {
+    path: (id) => `/api/children/${encodeURIComponent(id)}`,
+    arg: "id-enfant",
+    desc: "Détail d'un enfant",
+  },
+  symptoms: {
+    path: (id) => `/api/symptoms/${encodeURIComponent(id)}`,
+    arg: "id-enfant",
+    desc: "Symptômes TDAH d'un enfant",
+  },
+  journal: {
+    path: (id) => `/api/journal/${encodeURIComponent(id)}`,
+    arg: "id-enfant",
+    desc: "Entrées de journal d'un enfant",
+  },
+  strengths: {
+    path: (id) => `/api/strengths/${encodeURIComponent(id)}`,
+    arg: "id-enfant",
+    desc: "Forces et réussites d'un enfant",
+  },
+  medications: {
+    path: (id) => `/api/medications/${encodeURIComponent(id)}`,
+    arg: "id-enfant",
+    desc: "Traitements d'un enfant",
+  },
+  adherence: {
+    path: (id) => `/api/medications/${encodeURIComponent(id)}/adherence`,
+    arg: "id-enfant",
+    desc: "Observance des traitements d'un enfant",
+  },
+  routines: {
+    path: (id) => `/api/routines/${encodeURIComponent(id)}`,
+    arg: "id-enfant",
+    desc: "Routines quotidiennes d'un enfant",
+  },
+  crisis: {
+    path: (id) => `/api/crisis-list/${encodeURIComponent(id)}`,
+    arg: "id-enfant",
+    desc: "Plan de crise d'un enfant",
+  },
+  barkley: {
+    path: (id) => `/api/barkley/behaviors/${encodeURIComponent(id)}`,
+    arg: "id-enfant",
+    desc: "Comportements Barkley d'un enfant",
+  },
+  stats: {
+    path: (id) => `/api/stats/${encodeURIComponent(id)}`,
+    arg: "id-enfant",
+    desc: "Statistiques de suivi d'un enfant",
+  },
+  "parent-mood": {
+    path: () => "/api/parent-mood",
+    arg: null,
+    desc: "Historique d'humeur du parent",
+  },
+};
+
+function helpText(): string {
+  const rows = Object.entries(COMMANDS)
+    .map(([name, def]) => {
+      const usage = def.arg ? `${name} <${def.arg}>` : name;
+      return `  ${usage.padEnd(26)} ${def.desc}`;
+    })
+    .join("\n");
+  return `toko — accès en lecture seule aux données de suivi Tokō (v${VERSION})
+
+Usage :
+  toko <commande> [argument] [options]
+
+Commandes :
+${rows}
+  help                       Afficher cette aide
+
+Options :
+  --key <clé>     Clé d'accès (sinon : variable TOKO_API_KEY)
+  --url <url>     Hôte de l'API (sinon : TOKO_API_URL, ou localhost:3001)
+  --compact       Sortie JSON sur une seule ligne
+  --version       Afficher la version
+
+Exemples :
+  export TOKO_API_KEY=toko_sk_votre_cle
+  toko children
+  toko stats 1234-5678 --compact
+
+Codes de sortie : 0 succès · 1 erreur · 2 authentification · 3 quota dépassé`;
+}
+
+/** Print to stderr and exit with the given code. */
+function errExit(message: string, code: number): never {
+  console.error(`toko: ${message}`);
+  process.exit(code);
+}
+
+async function main(): Promise<void> {
+  let values: Record<string, string | boolean | undefined>;
+  let positionals: string[];
+  try {
+    const parsed = parseArgs({
+      allowPositionals: true,
+      options: {
+        key: { type: "string" },
+        url: { type: "string" },
+        compact: { type: "boolean" },
+        help: { type: "boolean" },
+        version: { type: "boolean" },
+      },
+    });
+    values = parsed.values;
+    positionals = parsed.positionals;
+  } catch (err) {
+    errExit(err instanceof Error ? err.message : String(err), 1);
+  }
+
+  if (values.version) {
+    console.log(VERSION);
+    return;
+  }
+
+  const command = positionals[0];
+  if (!command || command === "help" || values.help) {
+    console.log(helpText());
+    return;
+  }
+
+  const def = COMMANDS[command];
+  if (!def) {
+    errExit(`commande inconnue « ${command} » — voir « toko help »`, 1);
+  }
+
+  let arg = "";
+  if (def.arg) {
+    const positional = positionals[1];
+    if (!positional) {
+      errExit(`argument requis : <${def.arg}> — voir « toko help »`, 1);
+    }
+    arg = positional;
+  }
+
+  const apiKey =
+    typeof values.key === "string" ? values.key : process.env.TOKO_API_KEY;
+  if (!apiKey) {
+    errExit(
+      "clé d'accès manquante — définissez TOKO_API_KEY ou utilisez --key",
+      2,
+    );
+  }
+
+  const apiUrl = (
+    (typeof values.url === "string" ? values.url : process.env.TOKO_API_URL) ??
+    "http://localhost:3001"
+  ).replace(/\/$/, "");
+
+  let res: Response;
+  try {
+    res = await fetch(`${apiUrl}${def.path(arg)}`, {
+      headers: { "x-api-key": apiKey, accept: "application/json" },
+    });
+  } catch (err) {
+    errExit(
+      `impossible de joindre l'API (${apiUrl}) : ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+      1,
+    );
+  }
+
+  const text = await res.text();
+  if (!res.ok) {
+    const code =
+      res.status === 401 || res.status === 403
+        ? 2
+        : res.status === 429
+          ? 3
+          : 1;
+    errExit(`erreur ${res.status} — ${text || res.statusText}`, code);
+  }
+
+  try {
+    const data: unknown = JSON.parse(text);
+    console.log(
+      values.compact ? JSON.stringify(data) : JSON.stringify(data, null, 2),
+    );
+  } catch {
+    console.log(text);
+  }
+}
+
+main().catch((err) => {
+  errExit(err instanceof Error ? err.message : String(err), 1);
+});

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@toko/mcp",
+  "version": "0.1.0",
+  "description": "Serveur MCP Tokō — accès en lecture seule aux données de suivi pour l'assistant IA d'un parent",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "toko-mcp": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc -p tsconfig.json",
+    "start": "node dist/index.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * Serveur MCP Tokō.
+ *
+ * Expose, via le Model Context Protocol, un ensemble d'outils en LECTURE
+ * SEULE permettant à l'assistant IA d'un parent de consulter les données
+ * de suivi de ses enfants (symptômes, journal, traitements, routines…).
+ *
+ * Authentification : une clé d'accès `toko_sk_…` que le parent génère
+ * depuis la page Développeurs de l'application, fournie via la variable
+ * d'environnement TOKO_API_KEY.
+ *
+ * Aucune écriture n'est possible — l'API rejette toute requête non-GET
+ * portée par une clé d'accès agent.
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const API_URL = (process.env.TOKO_API_URL ?? "http://localhost:3001").replace(
+  /\/$/,
+  "",
+);
+const API_KEY = process.env.TOKO_API_KEY;
+
+if (!API_KEY) {
+  // stderr only — stdout is reserved for the MCP protocol stream.
+  console.error(
+    "[toko-mcp] TOKO_API_KEY manquante. Générez une clé sur la page " +
+      "Développeurs de Tokō et exportez-la dans TOKO_API_KEY.",
+  );
+  process.exit(1);
+}
+
+type ToolResult = {
+  content: { type: "text"; text: string }[];
+  isError?: boolean;
+};
+
+/** GET an allowlisted Tokō endpoint with the agent key. */
+async function apiGet(path: string): Promise<ToolResult> {
+  let res: Response;
+  try {
+    res = await fetch(`${API_URL}${path}`, {
+      headers: { "x-api-key": API_KEY as string, accept: "application/json" },
+    });
+  } catch (err) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: `Impossible de joindre l'API Tokō (${API_URL}) : ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        },
+      ],
+    };
+  }
+
+  const body = await res.text();
+  if (!res.ok) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: `Erreur ${res.status} sur ${path} : ${body || res.statusText}`,
+        },
+      ],
+    };
+  }
+
+  return { content: [{ type: "text", text: body }] };
+}
+
+const server = new McpServer({ name: "toko", version: "1.0.0" });
+
+const childIdShape = {
+  childId: z.string().describe("Identifiant de l'enfant (voir list_children)"),
+};
+const readOnly = { readOnlyHint: true, idempotentHint: true } as const;
+
+server.registerTool(
+  "list_children",
+  {
+    title: "Lister les enfants",
+    description:
+      "Liste les enfants accessibles sur le compte du parent, avec leur identifiant.",
+    inputSchema: {},
+    annotations: readOnly,
+  },
+  async () => apiGet("/api/children"),
+);
+
+server.registerTool(
+  "get_child",
+  {
+    title: "Détail d'un enfant",
+    description: "Renvoie le profil détaillé d'un enfant.",
+    inputSchema: childIdShape,
+    annotations: readOnly,
+  },
+  async ({ childId }) => apiGet(`/api/children/${encodeURIComponent(childId)}`),
+);
+
+server.registerTool(
+  "list_symptoms",
+  {
+    title: "Lister les symptômes",
+    description: "Liste les symptômes TDAH suivis pour un enfant.",
+    inputSchema: childIdShape,
+    annotations: readOnly,
+  },
+  async ({ childId }) => apiGet(`/api/symptoms/${encodeURIComponent(childId)}`),
+);
+
+server.registerTool(
+  "list_journal_entries",
+  {
+    title: "Lister le journal",
+    description: "Liste les entrées de journal quotidien (humeurs, événements) d'un enfant.",
+    inputSchema: childIdShape,
+    annotations: readOnly,
+  },
+  async ({ childId }) => apiGet(`/api/journal/${encodeURIComponent(childId)}`),
+);
+
+server.registerTool(
+  "list_strengths",
+  {
+    title: "Lister les forces",
+    description: "Liste les forces et réussites identifiées chez un enfant.",
+    inputSchema: childIdShape,
+    annotations: readOnly,
+  },
+  async ({ childId }) => apiGet(`/api/strengths/${encodeURIComponent(childId)}`),
+);
+
+server.registerTool(
+  "list_medications",
+  {
+    title: "Lister les traitements",
+    description: "Liste les traitements et l'historique de prises d'un enfant.",
+    inputSchema: childIdShape,
+    annotations: readOnly,
+  },
+  async ({ childId }) =>
+    apiGet(`/api/medications/${encodeURIComponent(childId)}`),
+);
+
+server.registerTool(
+  "get_medication_adherence",
+  {
+    title: "Observance des traitements",
+    description: "Renvoie le taux d'observance des traitements d'un enfant.",
+    inputSchema: childIdShape,
+    annotations: readOnly,
+  },
+  async ({ childId }) =>
+    apiGet(`/api/medications/${encodeURIComponent(childId)}/adherence`),
+);
+
+server.registerTool(
+  "list_routines",
+  {
+    title: "Lister les routines",
+    description: "Liste les routines quotidiennes d'un enfant et leurs étapes.",
+    inputSchema: childIdShape,
+    annotations: readOnly,
+  },
+  async ({ childId }) => apiGet(`/api/routines/${encodeURIComponent(childId)}`),
+);
+
+server.registerTool(
+  "list_crisis_plan",
+  {
+    title: "Plan de crise",
+    description: "Liste les étapes du plan d'action en cas de crise d'un enfant.",
+    inputSchema: childIdShape,
+    annotations: readOnly,
+  },
+  async ({ childId }) =>
+    apiGet(`/api/crisis-list/${encodeURIComponent(childId)}`),
+);
+
+server.registerTool(
+  "list_barkley_behaviors",
+  {
+    title: "Comportements Barkley",
+    description: "Liste les comportements suivis sur l'échelle Barkley d'un enfant.",
+    inputSchema: childIdShape,
+    annotations: readOnly,
+  },
+  async ({ childId }) =>
+    apiGet(`/api/barkley/behaviors/${encodeURIComponent(childId)}`),
+);
+
+server.registerTool(
+  "get_child_stats",
+  {
+    title: "Statistiques de suivi",
+    description:
+      "Renvoie les statistiques agrégées de suivi d'un enfant (tendances de symptômes, humeurs).",
+    inputSchema: childIdShape,
+    annotations: readOnly,
+  },
+  async ({ childId }) => apiGet(`/api/stats/${encodeURIComponent(childId)}`),
+);
+
+server.registerTool(
+  "get_parent_mood",
+  {
+    title: "Humeur du parent",
+    description: "Renvoie l'historique des points d'humeur du parent.",
+    inputSchema: {},
+    annotations: readOnly,
+  },
+  async () => apiGet("/api/parent-mood"),
+);
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error(`[toko-mcp] Serveur MCP Tokō prêt — API : ${API_URL}`);
+}
+
+main().catch((err) => {
+  console.error("[toko-mcp] Échec du démarrage :", err);
+  process.exit(1);
+});

--- a/apps/mcp/tsconfig.json
+++ b/apps/mcp/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -31,7 +31,7 @@ L'application est une PWA installable, fonctionnant sur mobile, tablette et ordi
 
 ## Développeurs
 
-- [Développeurs](/developers): connecter son assistant IA à Tokō — génération de clés d'accès et configuration du serveur MCP
+- [Développeurs](/developers): connecter son assistant IA à Tokō — clés d'accès, serveur MCP et outil en ligne de commande
 - [Spécification OpenAPI](/api/openapi.json): contrat machine de l'API d'accès agent (lecture seule, données de suivi de l'enfant)
 
 ## Optional

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -29,6 +29,11 @@ L'application est une PWA installable, fonctionnant sur mobile, tablette et ordi
 - [Rapports](/report): export des données pour professionnels de santé
 - [Compte](/account): gestion du profil, des enfants et de l'abonnement
 
+## Développeurs
+
+- [Développeurs](/developers): connecter son assistant IA à Tokō — génération de clés d'accès et configuration du serveur MCP
+- [Spécification OpenAPI](/api/openapi.json): contrat machine de l'API d'accès agent (lecture seule, données de suivi de l'enfant)
+
 ## Optional
 
 - [Manifeste PWA](/manifest.webmanifest): métadonnées de l'application installable

--- a/apps/web/src/hooks/use-agent-keys.ts
+++ b/apps/web/src/hooks/use-agent-keys.ts
@@ -1,0 +1,36 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import type { AgentKey, CreateAgentKey } from "@focusflow/validators";
+
+// The freshly-minted key carries the one-time `secret`. The list endpoint
+// never returns it again.
+export type CreatedAgentKey = AgentKey & { secret: string };
+
+export const agentKeysKeys = { all: ["agent-keys"] as const };
+
+export function useAgentKeys(enabled: boolean) {
+  return useQuery({
+    queryKey: agentKeysKeys.all,
+    queryFn: () => api.get<AgentKey[]>("/agent-keys"),
+    enabled,
+  });
+}
+
+export function useCreateAgentKey() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateAgentKey) =>
+      api.post<CreatedAgentKey>("/agent-keys", data),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: agentKeysKeys.all }),
+  });
+}
+
+export function useRevokeAgentKey() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.delete<{ ok: true }>(`/agent-keys/${id}`),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: agentKeysKeys.all }),
+  });
+}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -185,7 +185,8 @@
       "version": "v{{version}} — Built on {{date}}",
       "legal": "Legal notice",
       "privacy": "Privacy",
-      "contact": "Contact"
+      "contact": "Contact",
+      "developers": "Developers"
     }
   },
   "login": {

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -185,7 +185,8 @@
       "version": "v{{version}} — Build du {{date}}",
       "legal": "Mentions légales",
       "privacy": "Confidentialité",
-      "contact": "Contact"
+      "contact": "Contact",
+      "developers": "Développeurs"
     }
   },
   "login": {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as MentionsLegalesRouteImport } from './routes/mentions-legales'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
+import { Route as DevelopersRouteImport } from './routes/developers'
 import { Route as ContactRouteImport } from './routes/contact'
 import { Route as ConfidentialiteRouteImport } from './routes/confidentialite'
 import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
@@ -70,6 +71,11 @@ const LoginRoute = LoginRouteImport.update({
 const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
   id: '/forgot-password',
   path: '/forgot-password',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DevelopersRoute = DevelopersRouteImport.update({
+  id: '/developers',
+  path: '/developers',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ContactRoute = ContactRouteImport.update({
@@ -263,6 +269,7 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/confidentialite': typeof ConfidentialiteRoute
   '/contact': typeof ContactRoute
+  '/developers': typeof DevelopersRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/mentions-legales': typeof MentionsLegalesRoute
@@ -301,6 +308,7 @@ export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/confidentialite': typeof ConfidentialiteRoute
   '/contact': typeof ContactRoute
+  '/developers': typeof DevelopersRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/mentions-legales': typeof MentionsLegalesRoute
@@ -341,6 +349,7 @@ export interface FileRoutesById {
   '/_authenticated': typeof AuthenticatedRouteWithChildren
   '/confidentialite': typeof ConfidentialiteRoute
   '/contact': typeof ContactRoute
+  '/developers': typeof DevelopersRoute
   '/forgot-password': typeof ForgotPasswordRoute
   '/login': typeof LoginRoute
   '/mentions-legales': typeof MentionsLegalesRoute
@@ -381,6 +390,7 @@ export interface FileRouteTypes {
     | '/'
     | '/confidentialite'
     | '/contact'
+    | '/developers'
     | '/forgot-password'
     | '/login'
     | '/mentions-legales'
@@ -419,6 +429,7 @@ export interface FileRouteTypes {
     | '/'
     | '/confidentialite'
     | '/contact'
+    | '/developers'
     | '/forgot-password'
     | '/login'
     | '/mentions-legales'
@@ -458,6 +469,7 @@ export interface FileRouteTypes {
     | '/_authenticated'
     | '/confidentialite'
     | '/contact'
+    | '/developers'
     | '/forgot-password'
     | '/login'
     | '/mentions-legales'
@@ -498,6 +510,7 @@ export interface RootRouteChildren {
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   ConfidentialiteRoute: typeof ConfidentialiteRoute
   ContactRoute: typeof ContactRoute
+  DevelopersRoute: typeof DevelopersRoute
   ForgotPasswordRoute: typeof ForgotPasswordRoute
   LoginRoute: typeof LoginRoute
   MentionsLegalesRoute: typeof MentionsLegalesRoute
@@ -544,6 +557,13 @@ declare module '@tanstack/react-router' {
       path: '/forgot-password'
       fullPath: '/forgot-password'
       preLoaderRoute: typeof ForgotPasswordRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/developers': {
+      id: '/developers'
+      path: '/developers'
+      fullPath: '/developers'
+      preLoaderRoute: typeof DevelopersRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/contact': {
@@ -837,6 +857,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
   ConfidentialiteRoute: ConfidentialiteRoute,
   ContactRoute: ContactRoute,
+  DevelopersRoute: DevelopersRoute,
   ForgotPasswordRoute: ForgotPasswordRoute,
   LoginRoute: LoginRoute,
   MentionsLegalesRoute: MentionsLegalesRoute,

--- a/apps/web/src/routes/developers.tsx
+++ b/apps/web/src/routes/developers.tsx
@@ -98,6 +98,14 @@ function DevelopersPage() {
     2,
   );
 
+  const cliExample = [
+    "export TOKO_API_KEY=toko_sk_votre_cle_ici",
+    `export TOKO_API_URL=${apiOrigin}`,
+    "",
+    "npx -y @toko/cli children",
+    "npx -y @toko/cli stats <id-enfant>",
+  ].join("\n");
+
   return (
     <div className="mx-auto max-w-3xl px-4 py-16">
       <Link
@@ -164,6 +172,32 @@ function DevelopersPage() {
           pas publié sur npm, lancez le serveur depuis les sources du dépôt :{" "}
           <code className="text-xs">node apps/mcp/dist/index.js</code> après{" "}
           <code className="text-xs">pnpm --filter @toko/mcp build</code>.
+        </Callout>
+      </section>
+
+      {/* --- Ligne de commande (CLI) --- */}
+      <section className="mb-12">
+        <h2 className="mb-4 text-xl font-medium">Ligne de commande</h2>
+        <p className="mb-4 text-sm text-muted-foreground leading-relaxed">
+          Si votre agent dispose d'un terminal (Claude Code, un script, une
+          intégration continue…), l'outil <code className="text-xs">toko</code>{" "}
+          est plus direct qu'un serveur MCP. Il utilise la même clé d'accès et
+          la même surface en lecture seule.
+        </p>
+        <CodeBlock code={cliExample} />
+        <p className="mt-4 text-sm text-muted-foreground leading-relaxed">
+          Lancez <code className="text-xs">toko help</code> pour la liste
+          complète des commandes (<code className="text-xs">children</code>,{" "}
+          <code className="text-xs">symptoms</code>,{" "}
+          <code className="text-xs">journal</code>,{" "}
+          <code className="text-xs">stats</code>…). Chaque commande renvoie du
+          JSON sur la sortie standard.
+        </p>
+        <Callout variant="info" className="mt-4">
+          Tant que le paquet <code className="text-xs">@toko/cli</code> n'est
+          pas publié sur npm, lancez l'outil depuis les sources du dépôt :{" "}
+          <code className="text-xs">node apps/cli/dist/index.js</code> après{" "}
+          <code className="text-xs">pnpm --filter @toko/cli build</code>.
         </Callout>
       </section>
 

--- a/apps/web/src/routes/developers.tsx
+++ b/apps/web/src/routes/developers.tsx
@@ -1,0 +1,380 @@
+import { useState } from "react";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import {
+  ArrowLeft,
+  Check,
+  Copy,
+  KeyRound,
+  Plus,
+  ShieldCheck,
+  Trash2,
+} from "lucide-react";
+import { toast } from "sonner";
+import { useSession } from "@/lib/auth-client";
+import {
+  useAgentKeys,
+  useCreateAgentKey,
+  useRevokeAgentKey,
+  type CreatedAgentKey,
+} from "@/hooks/use-agent-keys";
+import { ApiError } from "@/lib/api-client";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Callout } from "@/components/ui/callout";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+
+// Section "Développeurs" de Tokō. Page publique, accessible depuis le pied
+// de page. Elle permet à un parent de connecter son propre assistant IA
+// (en lecture seule) à ses données de suivi via le serveur MCP Tokō.
+//
+// Le contenu est volontairement rédigé en français directement dans le JSX :
+// la cible est le parent francophone qui configure son assistant, pas un
+// développeur tiers.
+export const Route = createFileRoute("/developers")({
+  component: DevelopersPage,
+});
+
+function formatDate(value: string | null): string {
+  if (!value) return "—";
+  return new Date(value).toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function CodeBlock({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <div className="relative">
+      <pre className="overflow-x-auto rounded-lg border border-border bg-muted/50 p-4 text-xs leading-relaxed">
+        <code>{code}</code>
+      </pre>
+      <Button
+        type="button"
+        variant="outline"
+        size="xs"
+        className="absolute right-2 top-2"
+        onClick={() => {
+          void navigator.clipboard.writeText(code);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1500);
+        }}
+      >
+        {copied ? <Check /> : <Copy />}
+        {copied ? "Copié" : "Copier"}
+      </Button>
+    </div>
+  );
+}
+
+function DevelopersPage() {
+  const { data: session } = useSession();
+  const isLoggedIn = Boolean(session?.user);
+  const apiOrigin =
+    typeof window !== "undefined" ? window.location.origin : "https://toko.app";
+
+  const mcpConfig = JSON.stringify(
+    {
+      mcpServers: {
+        toko: {
+          command: "npx",
+          args: ["-y", "@toko/mcp"],
+          env: {
+            TOKO_API_KEY: "toko_sk_votre_cle_ici",
+            TOKO_API_URL: apiOrigin,
+          },
+        },
+      },
+    },
+    null,
+    2,
+  );
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-16">
+      <Link
+        to="/"
+        className="mb-8 inline-flex items-center gap-2 text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Retour
+      </Link>
+
+      <h1 className="mb-3 text-3xl font-semibold tracking-tight">
+        Développeurs
+      </h1>
+      <p className="mb-10 text-muted-foreground leading-relaxed">
+        Tokō permet de connecter votre propre assistant IA à vos données de
+        suivi, en <strong>lecture seule</strong>. Vous générez une clé
+        d'accès, vous la confiez à votre assistant, et il peut consulter les
+        symptômes, le journal, les traitements ou les routines de vos enfants
+        pour vous aider — sans jamais rien modifier ni supprimer.
+      </p>
+
+      {/* --- Clés d'accès --- */}
+      <section className="mb-12">
+        <h2 className="mb-4 flex items-center gap-2 text-xl font-medium">
+          <KeyRound className="h-5 w-5 text-primary" />
+          Vos clés d'accès
+        </h2>
+        {isLoggedIn ? (
+          <AgentKeysManager />
+        ) : (
+          <Callout variant="info">
+            Connectez-vous à votre compte pour générer une clé d'accès.{" "}
+            <Link to="/login" className="font-medium underline">
+              Se connecter
+            </Link>
+          </Callout>
+        )}
+      </section>
+
+      {/* --- Connecter un assistant (MCP) --- */}
+      <section className="mb-12">
+        <h2 className="mb-4 text-xl font-medium">
+          Connecter votre assistant IA
+        </h2>
+        <p className="mb-4 text-sm text-muted-foreground leading-relaxed">
+          Tokō fournit un serveur <strong>MCP</strong> (Model Context
+          Protocol), le standard utilisé par les assistants IA pour se
+          connecter à une application. Ajoutez la configuration suivante à
+          votre assistant (par exemple dans le fichier de configuration de
+          Claude Desktop), en remplaçant la clé par celle générée ci-dessus :
+        </p>
+        <CodeBlock code={mcpConfig} />
+        <p className="mt-4 text-sm text-muted-foreground leading-relaxed">
+          Le serveur expose des outils en lecture seule&nbsp;:{" "}
+          <code className="text-xs">list_children</code>,{" "}
+          <code className="text-xs">list_symptoms</code>,{" "}
+          <code className="text-xs">list_journal_entries</code>,{" "}
+          <code className="text-xs">list_medications</code>,{" "}
+          <code className="text-xs">list_routines</code>,{" "}
+          <code className="text-xs">get_child_stats</code>, etc.
+        </p>
+        <Callout variant="info" className="mt-4">
+          Tant que le paquet <code className="text-xs">@toko/mcp</code> n'est
+          pas publié sur npm, lancez le serveur depuis les sources du dépôt :{" "}
+          <code className="text-xs">node apps/mcp/dist/index.js</code> après{" "}
+          <code className="text-xs">pnpm --filter @toko/mcp build</code>.
+        </Callout>
+      </section>
+
+      {/* --- API REST --- */}
+      <section className="mb-12">
+        <h2 className="mb-4 text-xl font-medium">API REST</h2>
+        <p className="mb-3 text-sm text-muted-foreground leading-relaxed">
+          Le serveur MCP s'appuie sur l'API REST de Tokō. Vous pouvez aussi
+          l'appeler directement en plaçant votre clé dans l'en-tête{" "}
+          <code className="text-xs">x-api-key</code>. Le contrat complet est
+          décrit au format OpenAPI&nbsp;:
+        </p>
+        <p className="mb-4">
+          <a
+            href="/api/openapi.json"
+            className="text-sm font-medium text-primary underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            /api/openapi.json
+          </a>
+        </p>
+        <ul className="space-y-2 text-sm text-muted-foreground">
+          <li className="flex gap-2">
+            <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+            <span>
+              <strong>Lecture seule</strong> — toute requête de modification
+              est rejetée (erreur 403).
+            </span>
+          </li>
+          <li className="flex gap-2">
+            <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+            <span>
+              <strong>Périmètre limité</strong> — seules les données de suivi
+              de l'enfant sont accessibles. Le coffre de documents médicaux,
+              l'export RGPD, la facturation et la gestion du compte restent
+              hors de portée d'une clé.
+            </span>
+          </li>
+          <li className="flex gap-2">
+            <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-primary" />
+            <span>
+              <strong>Quota</strong> — 60 requêtes par minute et par clé.
+            </span>
+          </li>
+        </ul>
+      </section>
+
+      {/* --- RGPD --- */}
+      <Callout variant="warning">
+        Une clé d'accès donne à un outil tiers un accès à des{" "}
+        <strong>données de santé concernant des mineurs</strong>. Ne la
+        partagez qu'avec un assistant de confiance, ne la publiez jamais, et
+        révoquez-la dès que vous ne l'utilisez plus. Vous gardez le contrôle&nbsp;:
+        une clé révoquée cesse de fonctionner immédiatement.
+      </Callout>
+    </div>
+  );
+}
+
+function AgentKeysManager() {
+  const keys = useAgentKeys(true);
+  const createKey = useCreateAgentKey();
+  const revokeKey = useRevokeAgentKey();
+
+  const [name, setName] = useState("");
+  const [consent, setConsent] = useState(false);
+  const [created, setCreated] = useState<CreatedAgentKey | null>(null);
+
+  const canSubmit = name.trim().length > 0 && consent && !createKey.isPending;
+
+  function handleCreate() {
+    createKey.mutate(
+      { name: name.trim() },
+      {
+        onSuccess: (key) => {
+          setCreated(key);
+          setName("");
+          setConsent(false);
+        },
+        onError: (err) => {
+          toast.error(
+            err instanceof ApiError
+              ? err.message
+              : "Échec de la création de la clé",
+          );
+        },
+      },
+    );
+  }
+
+  function handleRevoke(id: string, label: string) {
+    if (
+      !window.confirm(
+        `Révoquer la clé « ${label} » ? Tout assistant qui l'utilise perdra l'accès.`,
+      )
+    ) {
+      return;
+    }
+    revokeKey.mutate(id, {
+      onSuccess: () => toast.success("Clé révoquée"),
+      onError: () => toast.error("Échec de la révocation"),
+    });
+  }
+
+  const activeKeys = keys.data ?? [];
+
+  return (
+    <div className="space-y-6">
+      {/* Secret affiché une seule fois après création */}
+      {created && (
+        <Callout variant="success">
+          <p className="mb-2 font-medium">
+            Clé « {created.name} » créée. Copiez-la maintenant — elle ne sera
+            plus jamais affichée.
+          </p>
+          <CodeBlock code={created.secret} />
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="mt-2"
+            onClick={() => setCreated(null)}
+          >
+            J'ai copié la clé
+          </Button>
+        </Callout>
+      )}
+
+      {/* Formulaire de création */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Créer une clé d'accès</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="agent-key-name">Nom de la clé</Label>
+            <Input
+              id="agent-key-name"
+              value={name}
+              maxLength={60}
+              placeholder="Mon assistant Claude"
+              onChange={(e) => setName(e.target.value)}
+            />
+          </div>
+          <div className="flex items-start gap-2">
+            <Checkbox
+              id="agent-consent"
+              checked={consent}
+              onCheckedChange={(value) => setConsent(value === true)}
+            />
+            <Label
+              htmlFor="agent-consent"
+              className="text-sm font-normal leading-relaxed text-muted-foreground"
+            >
+              Je comprends que cette clé donnera à mon assistant IA un accès en
+              lecture seule aux données de suivi de mes enfants — des données
+              de santé concernant des mineurs — et que je peux la révoquer à
+              tout moment.
+            </Label>
+          </div>
+          <Button type="button" disabled={!canSubmit} onClick={handleCreate}>
+            <Plus />
+            Créer la clé
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* Liste des clés */}
+      {keys.isLoading ? (
+        <p className="text-sm text-muted-foreground">Chargement…</p>
+      ) : activeKeys.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Aucune clé pour l'instant.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border rounded-lg border border-border">
+          {activeKeys.map((key) => (
+            <li
+              key={key.id}
+              className="flex items-center justify-between gap-4 px-4 py-3"
+            >
+              <div className="min-w-0">
+                <p className="truncate text-sm font-medium">{key.name}</p>
+                <p className="text-xs text-muted-foreground">
+                  <code>{key.prefix}…</code> · créée le{" "}
+                  {formatDate(key.createdAt)} · dernière utilisation&nbsp;:{" "}
+                  {formatDate(key.lastUsedAt)}
+                  {key.revokedAt && " · révoquée"}
+                </p>
+              </div>
+              {key.revokedAt ? (
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  Révoquée
+                </span>
+              ) : (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  size="sm"
+                  disabled={revokeKey.isPending}
+                  onClick={() => handleRevoke(key.id, key.name)}
+                >
+                  <Trash2 />
+                  Révoquer
+                </Button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -453,6 +453,12 @@ function Footer() {
           >
             {t("landing.footer.contact")}
           </Link>
+          <Link
+            to="/developers"
+            className="transition-colors hover:text-foreground"
+          >
+            {t("landing.footer.developers")}
+          </Link>
         </div>
       </div>
     </footer>

--- a/packages/db/drizzle/0047_lean_tag.sql
+++ b/packages/db/drizzle/0047_lean_tag.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "agent_key" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"name" text NOT NULL,
+	"key_hash" text NOT NULL,
+	"prefix" text NOT NULL,
+	"scopes" text DEFAULT 'read' NOT NULL,
+	"last_used_at" timestamp,
+	"expires_at" timestamp,
+	"revoked_at" timestamp,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "agent_key_key_hash_unique" UNIQUE("key_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "agent_key" ADD CONSTRAINT "agent_key_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/drizzle/meta/0047_snapshot.json
+++ b/packages/db/drizzle/meta/0047_snapshot.json
@@ -1,0 +1,3934 @@
+{
+  "id": "40784e98-b86e-4940-a5f4-f8a9666fec47",
+  "prevId": "78aa9256-d3f7-48b1-ad8c-f4a81942d797",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deletion_scheduled_at": {
+          "name": "deletion_scheduled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "user_stripe_customer_id_unique": {
+          "name": "user_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.children": {
+      "name": "children",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age_range": {
+          "name": "age_range",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "diagnosis_type": {
+          "name": "diagnosis_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'undefined'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "children_parent_id_idx": {
+          "name": "children_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "children_parent_id_user_id_fk": {
+          "name": "children_parent_id_user_id_fk",
+          "tableFrom": "children",
+          "tableTo": "user",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.symptoms": {
+      "name": "symptoms",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agitation": {
+          "name": "agitation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "focus": {
+          "name": "focus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impulse": {
+          "name": "impulse",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood": {
+          "name": "mood",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sleep": {
+          "name": "sleep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "routines_ok": {
+          "name": "routines_ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "symptoms_child_id_date_idx": {
+          "name": "symptoms_child_id_date_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "symptoms_child_id_children_id_fk": {
+          "name": "symptoms_child_id_children_id_fk",
+          "tableFrom": "symptoms",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.journal_entries": {
+      "name": "journal_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tags": {
+          "name": "tags",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "journal_entries_child_id_date_idx": {
+          "name": "journal_entries_child_id_date_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "journal_entries_child_id_children_id_fk": {
+          "name": "journal_entries_child_id_children_id_fk",
+          "tableFrom": "journal_entries",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscription": {
+      "name": "subscription",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "interval": {
+          "name": "interval",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cancel_at_period_end": {
+          "name": "cancel_at_period_end",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "paused_until": {
+          "name": "paused_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pause_months_used": {
+          "name": "pause_months_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "pause_year_ref": {
+          "name": "pause_year_ref",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trial_reminder_sent_at": {
+          "name": "trial_reminder_sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "subscription_user_id_idx": {
+          "name": "subscription_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "subscription_user_id_user_id_fk": {
+          "name": "subscription_user_id_user_id_fk",
+          "tableFrom": "subscription",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "subscription_user_id_unique": {
+          "name": "subscription_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "subscription_stripe_subscription_id_unique": {
+          "name": "subscription_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_behavior_logs": {
+      "name": "barkley_behavior_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "behavior_id": {
+          "name": "behavior_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_behavior_logs_behavior_id_idx": {
+          "name": "barkley_behavior_logs_behavior_id_idx",
+          "columns": [
+            {
+              "expression": "behavior_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_behavior_logs_behavior_id_barkley_behaviors_id_fk": {
+          "name": "barkley_behavior_logs_behavior_id_barkley_behaviors_id_fk",
+          "tableFrom": "barkley_behavior_logs",
+          "tableTo": "barkley_behaviors",
+          "columnsFrom": [
+            "behavior_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "barkley_behavior_logs_behavior_id_date_unique": {
+          "name": "barkley_behavior_logs_behavior_id_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "behavior_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_behaviors": {
+      "name": "barkley_behaviors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_behaviors_child_id_idx": {
+          "name": "barkley_behaviors_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_behaviors_child_id_children_id_fk": {
+          "name": "barkley_behaviors_child_id_children_id_fk",
+          "tableFrom": "barkley_behaviors",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_rewards": {
+      "name": "barkley_rewards",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stars_required": {
+          "name": "stars_required",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "times_claimed": {
+          "name": "times_claimed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_rewards_child_id_idx": {
+          "name": "barkley_rewards_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_rewards_child_id_children_id_fk": {
+          "name": "barkley_rewards_child_id_children_id_fk",
+          "tableFrom": "barkley_rewards",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.barkley_steps": {
+      "name": "barkley_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "barkley_steps_child_id_idx": {
+          "name": "barkley_steps_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "barkley_steps_child_id_children_id_fk": {
+          "name": "barkley_steps_child_id_children_id_fk",
+          "tableFrom": "barkley_steps",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "barkley_steps_child_id_step_number_unique": {
+          "name": "barkley_steps_child_id_step_number_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "child_id",
+            "step_number"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.crisis_items": {
+      "name": "crisis_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "crisis_items_child_id_idx": {
+          "name": "crisis_items_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "crisis_items_child_id_children_id_fk": {
+          "name": "crisis_items_child_id_children_id_fk",
+          "tableFrom": "crisis_items",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medication_logs": {
+      "name": "medication_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "medication_id": {
+          "name": "medication_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "taken": {
+          "name": "taken",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_effects": {
+          "name": "side_effects",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "medication_logs_medication_id_idx": {
+          "name": "medication_logs_medication_id_idx",
+          "columns": [
+            {
+              "expression": "medication_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medication_logs_medication_id_medications_id_fk": {
+          "name": "medication_logs_medication_id_medications_id_fk",
+          "tableFrom": "medication_logs",
+          "tableTo": "medications",
+          "columnsFrom": [
+            "medication_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "medication_logs_medication_id_date_unique": {
+          "name": "medication_logs_medication_id_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "medication_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.medications": {
+      "name": "medications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dose": {
+          "name": "dose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "medications_child_id_idx": {
+          "name": "medications_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "medications_child_id_children_id_fk": {
+          "name": "medications_child_id_children_id_fk",
+          "tableFrom": "medications",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Europe/Paris'"
+        },
+        "daily_reminder_opt_in": {
+          "name": "daily_reminder_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "weekly_digest_opt_in": {
+          "name": "weekly_digest_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "co_parent_activity_opt_in": {
+          "name": "co_parent_activity_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "morning_reminder_time": {
+          "name": "morning_reminder_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'09:00'"
+        },
+        "evening_reminder_opt_in": {
+          "name": "evening_reminder_opt_in",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "evening_reminder_time": {
+          "name": "evening_reminder_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'20:30'"
+        },
+        "last_daily_reminder_at": {
+          "name": "last_daily_reminder_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_weekly_digest_at": {
+          "name": "last_weekly_digest_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_evening_reminder_at": {
+          "name": "last_evening_reminder_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lock_pin_hash": {
+          "name": "lock_pin_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lock_pin_salt": {
+          "name": "lock_pin_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_user_id_fk": {
+          "name": "user_preferences_user_id_user_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news": {
+      "name": "news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "excerpt": {
+          "name": "excerpt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "news_published_at_idx": {
+          "name": "news_published_at_idx",
+          "columns": [
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news_slug_idx": {
+          "name": "news_slug_idx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "news_author_id_user_id_fk": {
+          "name": "news_author_id_user_id_fk",
+          "tableFrom": "news",
+          "tableTo": "user",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "news_slug_unique": {
+          "name": "news_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consents": {
+      "name": "consents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "consents_user_type_idx": {
+          "name": "consents_user_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "consents_user_id_user_id_fk": {
+          "name": "consents_user_id_user_id_fk",
+          "tableFrom": "consents",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_recommendations": {
+      "name": "ai_recommendations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_template": {
+          "name": "prompt_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggestion": {
+          "name": "suggestion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence": {
+          "name": "evidence",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_note": {
+          "name": "feedback_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ai_recommendations_user_id_idx": {
+          "name": "ai_recommendations_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_recommendations_user_id_user_id_fk": {
+          "name": "ai_recommendations_user_id_user_id_fk",
+          "tableFrom": "ai_recommendations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ai_recommendations_child_id_children_id_fk": {
+          "name": "ai_recommendations_child_id_children_id_fk",
+          "tableFrom": "ai_recommendations",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nps_responses": {
+      "name": "nps_responses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cohort": {
+          "name": "cohort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "submitted_at": {
+          "name": "submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "nps_responses_user_cohort_unique": {
+          "name": "nps_responses_user_cohort_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cohort",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "nps_responses_user_id_user_id_fk": {
+          "name": "nps_responses_user_id_user_id_fk",
+          "tableFrom": "nps_responses",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_items": {
+      "name": "roadmap_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'proposed'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roadmap_items_status_idx": {
+          "name": "roadmap_items_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roadmap_votes": {
+      "name": "roadmap_votes",
+      "schema": "",
+      "columns": {
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "roadmap_votes_item_user_unique": {
+          "name": "roadmap_votes_item_user_unique",
+          "columns": [
+            {
+              "expression": "item_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roadmap_votes_item_id_roadmap_items_id_fk": {
+          "name": "roadmap_votes_item_id_roadmap_items_id_fk",
+          "tableFrom": "roadmap_votes",
+          "tableTo": "roadmap_items",
+          "columnsFrom": [
+            "item_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roadmap_votes_user_id_user_id_fk": {
+          "name": "roadmap_votes_user_id_user_id_fk",
+          "tableFrom": "roadmap_votes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.push_subscriptions": {
+      "name": "push_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth_key": {
+          "name": "auth_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "push_subscriptions_user_endpoint_unique": {
+          "name": "push_subscriptions_user_endpoint_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "endpoint",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "push_subscriptions_user_id_idx": {
+          "name": "push_subscriptions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "push_subscriptions_user_id_user_id_fk": {
+          "name": "push_subscriptions_user_id_user_id_fk",
+          "tableFrom": "push_subscriptions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_access": {
+      "name": "child_access",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'co_parent'"
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "child_access_child_user_unique": {
+          "name": "child_access_child_user_unique",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_access_user_id_idx": {
+          "name": "child_access_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_access_child_id_idx": {
+          "name": "child_access_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "child_access_child_id_children_id_fk": {
+          "name": "child_access_child_id_children_id_fk",
+          "tableFrom": "child_access",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "child_access_user_id_user_id_fk": {
+          "name": "child_access_user_id_user_id_fk",
+          "tableFrom": "child_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "child_access_granted_by_user_id_fk": {
+          "name": "child_access_granted_by_user_id_fk",
+          "tableFrom": "child_access",
+          "tableTo": "user",
+          "columnsFrom": [
+            "granted_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.child_invitations": {
+      "name": "child_invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_email": {
+          "name": "invited_email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'single'"
+        },
+        "batch_id": {
+          "name": "batch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "child_invitations_child_id_idx": {
+          "name": "child_invitations_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_invitations_email_idx": {
+          "name": "child_invitations_email_idx",
+          "columns": [
+            {
+              "expression": "invited_email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "child_invitations_batch_id_idx": {
+          "name": "child_invitations_batch_id_idx",
+          "columns": [
+            {
+              "expression": "batch_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "child_invitations_child_id_children_id_fk": {
+          "name": "child_invitations_child_id_children_id_fk",
+          "tableFrom": "child_invitations",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "child_invitations_invited_by_user_id_fk": {
+          "name": "child_invitations_invited_by_user_id_fk",
+          "tableFrom": "child_invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "child_invitations_token_hash_unique": {
+          "name": "child_invitations_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "actor_name": {
+          "name": "actor_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "audit_log_child_created_idx": {
+          "name": "audit_log_child_created_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "audit_log_actor_id_idx": {
+          "name": "audit_log_actor_id_idx",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "audit_log_actor_id_user_id_fk": {
+          "name": "audit_log_actor_id_user_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "user",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "audit_log_child_id_children_id_fk": {
+          "name": "audit_log_child_id_children_id_fk",
+          "tableFrom": "audit_log",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.stripe_webhook_event": {
+      "name": "stripe_webhook_event",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.strengths": {
+      "name": "strengths",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "strengths_child_id_occurred_on_idx": {
+          "name": "strengths_child_id_occurred_on_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_on",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "strengths_child_id_children_id_fk": {
+          "name": "strengths_child_id_children_id_fk",
+          "tableFrom": "strengths",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine_completions": {
+      "name": "routine_completions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routine_completions_child_date_idx": {
+          "name": "routine_completions_child_date_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine_completions_routine_id_routines_id_fk": {
+          "name": "routine_completions_routine_id_routines_id_fk",
+          "tableFrom": "routine_completions",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine_completions_step_id_routine_steps_id_fk": {
+          "name": "routine_completions_step_id_routine_steps_id_fk",
+          "tableFrom": "routine_completions",
+          "tableTo": "routine_steps",
+          "columnsFrom": [
+            "step_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "routine_completions_child_id_children_id_fk": {
+          "name": "routine_completions_child_id_children_id_fk",
+          "tableFrom": "routine_completions",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "routine_completions_step_date_unique": {
+          "name": "routine_completions_step_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "step_id",
+            "date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routine_steps": {
+      "name": "routine_steps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "routine_id": {
+          "name": "routine_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routine_steps_routine_id_idx": {
+          "name": "routine_steps_routine_id_idx",
+          "columns": [
+            {
+              "expression": "routine_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routine_steps_routine_id_routines_id_fk": {
+          "name": "routine_steps_routine_id_routines_id_fk",
+          "tableFrom": "routine_steps",
+          "tableTo": "routines",
+          "columnsFrom": [
+            "routine_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.routines": {
+      "name": "routines",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "time_of_day": {
+          "name": "time_of_day",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'morning'"
+        },
+        "days_of_week": {
+          "name": "days_of_week",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "routines_child_id_idx": {
+          "name": "routines_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "routines_child_id_children_id_fk": {
+          "name": "routines_child_id_children_id_fk",
+          "tableFrom": "routines",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.care_pathway_progress": {
+      "name": "care_pathway_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_id": {
+          "name": "step_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'todo'"
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "care_pathway_progress_child_step_idx": {
+          "name": "care_pathway_progress_child_step_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "care_pathway_progress_child_id_children_id_fk": {
+          "name": "care_pathway_progress_child_id_children_id_fk",
+          "tableFrom": "care_pathway_progress",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.admin_documents": {
+      "name": "admin_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "child_id": {
+          "name": "child_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_size_bytes": {
+          "name": "file_size_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_on": {
+          "name": "occurred_on",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "admin_documents_child_id_idx": {
+          "name": "admin_documents_child_id_idx",
+          "columns": [
+            {
+              "expression": "child_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "admin_documents_child_id_children_id_fk": {
+          "name": "admin_documents_child_id_children_id_fk",
+          "tableFrom": "admin_documents",
+          "tableTo": "children",
+          "columnsFrom": [
+            "child_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.parent_mood_logs": {
+      "name": "parent_mood_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "parent_mood_logs_user_date_idx": {
+          "name": "parent_mood_logs_user_date_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "parent_mood_logs_user_id_user_id_fk": {
+          "name": "parent_mood_logs_user_id_user_id_fk",
+          "tableFrom": "parent_mood_logs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.job_run": {
+      "name": "job_run",
+      "schema": "",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_started_at": {
+          "name": "last_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_finished_at": {
+          "name": "last_finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "last_duration_ms": {
+          "name": "last_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_result": {
+          "name": "last_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.solidarity_requests": {
+      "name": "solidarity_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "admin_note": {
+          "name": "admin_note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "solidarity_requests_parent_id_idx": {
+          "name": "solidarity_requests_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "solidarity_requests_parent_id_user_id_fk": {
+          "name": "solidarity_requests_parent_id_user_id_fk",
+          "tableFrom": "solidarity_requests",
+          "tableTo": "user",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "properties": {
+          "name": "properties",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_event_name_created_at_idx": {
+          "name": "events_event_name_created_at_idx",
+          "columns": [
+            {
+              "expression": "event_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_parent_id_idx": {
+          "name": "events_parent_id_idx",
+          "columns": [
+            {
+              "expression": "parent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_parent_id_user_id_fk": {
+          "name": "events_parent_id_user_id_fk",
+          "tableFrom": "events",
+          "tableTo": "user",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feature_flags": {
+      "name": "feature_flags",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "variants": {
+          "name": "variants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_key": {
+      "name": "agent_key",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'read'"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_key_user_id_user_id_fk": {
+          "name": "agent_key_user_id_user_id_fk",
+          "tableFrom": "agent_key",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "agent_key_key_hash_unique": {
+          "name": "agent_key_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1778572753705,
       "tag": "0046_tired_nebula",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "7",
+      "when": 1778857802388,
+      "tag": "0047_lean_tag",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema/agent-keys.ts
+++ b/packages/db/src/schema/agent-keys.ts
@@ -1,0 +1,32 @@
+import { pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { user } from "./users";
+
+// Agent access keys — credentials a parent issues so their own AI assistant
+// (via the Tokō MCP server) can READ their children's tracking data.
+//
+// Security model:
+//  - The raw secret (`toko_sk_…`) is shown once at creation and never stored;
+//    only its SHA-256 hash lives here. Lookup is by hash.
+//  - Keys are read-only and scoped to a fixed endpoint allowlist — enforced
+//    in authMiddleware, never trusted from the key itself.
+//  - `revokedAt` is a soft-revoke so a leaked key can be killed instantly
+//    without losing the audit trail of when it existed.
+export const agentKey = pgTable("agent_key", {
+  id: text("id").primaryKey(),
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+  // Parent-chosen label, e.g. "Mon assistant Claude".
+  name: text("name").notNull(),
+  // SHA-256 hex of the full secret. Unique so a hash collision can't shadow.
+  keyHash: text("key_hash").notNull().unique(),
+  // Human-readable, non-secret start of the key for display in the UI,
+  // e.g. "toko_sk_a1b2c3d4". Never enough to reconstruct the secret.
+  prefix: text("prefix").notNull(),
+  // CSV of granted scopes. v1 only ever issues "read".
+  scopes: text("scopes").notNull().default("read"),
+  lastUsedAt: timestamp("last_used_at"),
+  expiresAt: timestamp("expires_at"),
+  revokedAt: timestamp("revoked_at"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+});

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -26,3 +26,4 @@ export * from "./job-runs";
 export * from "./solidarity-requests";
 export * from "./events";
 export * from "./feature-flags";
+export * from "./agent-keys";

--- a/packages/validators/src/agent-key.ts
+++ b/packages/validators/src/agent-key.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+// Input for creating an agent access key. The parent only supplies a label
+// and an optional expiry; the secret is generated server-side.
+export const createAgentKeySchema = z.object({
+  name: z.string().trim().min(1).max(60),
+  // Optional self-imposed expiry. Capped at one year so a forgotten key
+  // cannot live indefinitely. Omitted → no expiry (revoke-only).
+  expiresInDays: z.number().int().positive().max(365).optional(),
+});
+
+// Shape returned to the management UI — never includes the hash or secret.
+export const agentKeySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  prefix: z.string(),
+  scopes: z.string(),
+  lastUsedAt: z.string().datetime().nullable(),
+  expiresAt: z.string().datetime().nullable(),
+  revokedAt: z.string().datetime().nullable(),
+  createdAt: z.string().datetime(),
+});
+
+export type CreateAgentKey = z.infer<typeof createAgentKeySchema>;
+export type AgentKey = z.infer<typeof agentKeySchema>;

--- a/packages/validators/src/index.ts
+++ b/packages/validators/src/index.ts
@@ -23,3 +23,4 @@ export * from "./parent-mood";
 export * from "./solidarity";
 export * from "./event";
 export * from "./feature-flag";
+export * from "./agent-key";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,25 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))
 
+  apps/mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@3.25.76)
+      zod:
+        specifier: ^3.24.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   apps/web:
     dependencies:
       '@base-ui/react':
@@ -1462,12 +1481,6 @@ packages:
   '@fontsource-variable/source-serif-4@5.2.9':
     resolution: {integrity: sha512-PPcxjLFk/fS0WHg79pDM2YNvz61kC+oYZ5cWZZyCS0DHpJncmuYOuiZAsvj4tDxlWPBEvxxcRLQQNmSaRbPkqw==}
 
-  '@hono/node-server@1.19.11':
-    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
-    engines: {node: '>=18.14.1'}
-    peerDependencies:
-      hono: ^4
-
   '@hono/node-server@1.19.13':
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
     engines: {node: '>=18.14.1'}
@@ -1532,8 +1545,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@modelcontextprotocol/sdk@1.27.1':
-    resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
@@ -3240,10 +3253,6 @@ packages:
 
   hono@4.12.12:
     resolution: {integrity: sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==}
-    engines: {node: '>=16.9.0'}
-
-  hono@4.12.8:
-    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
     engines: {node: '>=16.9.0'}
 
   html-encoding-sniffer@6.0.0:
@@ -6125,10 +6134,6 @@ snapshots:
 
   '@fontsource-variable/source-serif-4@5.2.9': {}
 
-  '@hono/node-server@1.19.11(hono@4.12.8)':
-    dependencies:
-      hono: 4.12.8
-
   '@hono/node-server@1.19.13(hono@4.12.12)':
     dependencies:
       hono: 4.12.12
@@ -6187,9 +6192,9 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.11(hono@4.12.8)
+      '@hono/node-server': 1.19.13(hono@4.12.12)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -6199,7 +6204,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.8
+      hono: 4.12.12
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -7840,8 +7845,6 @@ snapshots:
 
   hono@4.12.12: {}
 
-  hono@4.12.8: {}
-
   html-encoding-sniffer@6.0.0(@noble/hashes@2.0.1):
     dependencies:
       '@exodus/bytes': 1.15.0(@noble/hashes@2.0.1)
@@ -8888,7 +8891,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@dotenvx/dotenvx': 1.57.1
-      '@modelcontextprotocol/sdk': 1.27.1(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.1
       commander: 14.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,18 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))
 
+  apps/cli:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   apps/mcp:
     dependencies:
       '@modelcontextprotocol/sdk':


### PR DESCRIPTION
Lets a parent connect their own AI assistant to Tokō in read-only
mode so it can consult their children's tracking data on their behalf.

- API: hashed, scoped, revocable agent access keys (toko_sk_…); the
  auth middleware accepts an x-api-key header and confines such
  requests to a GET-only endpoint allowlist with a stricter per-key
  rate limit. Key management routes are session-only.
- MCP: a new @toko/mcp stdio server exposing ~12 read-only tools over
  the Model Context Protocol.
- Web: a public /developers page (linked discreetly from the footer)
  to issue and revoke keys with explicit RGPD consent, plus MCP setup
  instructions.
- Docs: an OpenAPI 3.1 document at /api/openapi.json, an extended
  llms.txt and an AGENTS.md.

https://claude.ai/code/session_01BEcGowg6iYgBPnW3iNH9sU