### PR TITLE
Add admin account deletion scheduling with 30-day grace period

### DIFF
--- a/apps/api/src/routes/admin-users.ts
+++ b/apps/api/src/routes/admin-users.ts
@@ -201,3 +201,76 @@ adminUsersRoutes.post("/:id/reset-password", async (c) => {
 
   return c.json({ email: target.email, name: target.name });
 });
+
+// POST /api/admin/users/:id/schedule-deletion — schedule the account for
+// erasure after the 30-day grace period. Reversible via /cancel-deletion.
+// Mirrors the self-service flow in account.ts: this only stamps the
+// timestamp; the cron finalizer performs the actual deletion (and the
+// Stripe cleanup that goes with it).
+adminUsersRoutes.post("/:id/schedule-deletion", async (c) => {
+  const me = c.get("user");
+  await assertAdmin(me.id);
+
+  const targetId = c.req.param("id");
+
+  // An admin can't schedule their own deletion from the console — the
+  // self-service account-deletion flow exists for that.
+  if (targetId === me.id) {
+    throw new AppError(
+      "CANNOT_DELETE_SELF",
+      "Vous ne pouvez pas programmer la suppression de votre propre compte.",
+      422,
+    );
+  }
+
+  const [target] = await db
+    .select({ isAdmin: user.isAdmin })
+    .from(user)
+    .where(eq(user.id, targetId))
+    .limit(1);
+
+  if (!target) {
+    throw new AppError("NOT_FOUND", "Utilisateur introuvable.", 404);
+  }
+
+  // Administrator accounts can't be deleted from the console — removing
+  // an admin must go through an explicit role change first, so the last
+  // admin can never be deleted by mistake.
+  if (target.isAdmin) {
+    throw new AppError(
+      "CANNOT_DELETE_ADMIN",
+      "Les comptes administrateurs ne peuvent pas être supprimés. Retirez d'abord le rôle administrateur.",
+      422,
+    );
+  }
+
+  const [updated] = await db
+    .update(user)
+    .set({ deletionScheduledAt: new Date(), updatedAt: new Date() })
+    .where(eq(user.id, targetId))
+    .returning(accountColumns);
+
+  return c.json(updated);
+});
+
+// POST /api/admin/users/:id/cancel-deletion — call off a scheduled
+// deletion while the grace period is still running. A safe recovery
+// action, so it carries no self/admin guard.
+adminUsersRoutes.post("/:id/cancel-deletion", async (c) => {
+  const me = c.get("user");
+  await assertAdmin(me.id);
+
+  const targetId = c.req.param("id");
+
+  const [updated] = await db
+    .update(user)
+    .set({ deletionScheduledAt: null, updatedAt: new Date() })
+    .where(eq(user.id, targetId))
+    .returning(accountColumns);
+
+  if (!updated) {
+    throw new AppError("NOT_FOUND", "Utilisateur introuvable.", 404);
+  }
+
+  return c.json(updated);
+});

--- a/apps/web/src/hooks/use-admin-users.ts
+++ b/apps/web/src/hooks/use-admin-users.ts
@@ -137,3 +137,45 @@ export function useResetUserPassword() {
     },
   });
 }
+
+export function useScheduleUserDeletion() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api.post<AdminUserAccount>(`/admin/users/${id}/schedule-deletion`, {}),
+    onSuccess: (updated) => {
+      queryClient.invalidateQueries({ queryKey: adminUsersKeys.all });
+      toast.success(
+        `La suppression du compte de ${updated.name} est programmée. Les données seront effacées dans 30 jours.`,
+      );
+    },
+    onError: (err) => {
+      toast.error(
+        err instanceof ApiError
+          ? err.message
+          : "Impossible de programmer la suppression de ce compte.",
+      );
+    },
+  });
+}
+
+export function useCancelUserDeletion() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) =>
+      api.post<AdminUserAccount>(`/admin/users/${id}/cancel-deletion`, {}),
+    onSuccess: (updated) => {
+      queryClient.invalidateQueries({ queryKey: adminUsersKeys.all });
+      toast.success(
+        `La suppression du compte de ${updated.name} a été annulée.`,
+      );
+    },
+    onError: (err) => {
+      toast.error(
+        err instanceof ApiError
+          ? err.message
+          : "Impossible d'annuler la suppression de ce compte.",
+      );
+    },
+  });
+}

--- a/apps/web/src/routes/_authenticated/admin-users/index.tsx
+++ b/apps/web/src/routes/_authenticated/admin-users/index.tsx
@@ -10,6 +10,8 @@ import {
   UserCheck,
   UserX,
   UserCog,
+  Trash2,
+  RotateCcw,
 } from "lucide-react";
 import {
   AlertDialog,
@@ -52,7 +54,9 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import {
   useAdminUsers,
   useBlockUser,
+  useCancelUserDeletion,
   useResetUserPassword,
+  useScheduleUserDeletion,
   useUpdateUserPremium,
   useUpdateUserRole,
   type AdminUser,
@@ -83,6 +87,16 @@ function formatDate(iso: string): string {
     month: "short",
     year: "numeric",
   });
+}
+
+// A scheduled account is erased once the 30-day grace period elapses.
+// The admin cares about that erasure date, not the scheduling timestamp.
+const DELETION_GRACE_DAYS = 30;
+
+function scheduledDeletionDate(scheduledAtIso: string): string {
+  const d = new Date(scheduledAtIso);
+  d.setDate(d.getDate() + DELETION_GRACE_DAYS);
+  return formatDate(d.toISOString());
 }
 
 // Maps the user's Stripe subscription state to a read-only badge.
@@ -382,6 +396,87 @@ function BlockUserDialog({
   );
 }
 
+// Deletion confirmation. Scheduling an erasure is high-stakes even with
+// the 30-day grace, so the confirm button stays locked until the admin
+// retypes the account's e-mail — a deliberate guard against a misclick.
+function DeleteUserDialog({
+  user,
+  disabled,
+  onConfirm,
+  fullWidth,
+}: {
+  user: AdminUser;
+  disabled?: boolean;
+  onConfirm: () => void;
+  fullWidth?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [confirmEmail, setConfirmEmail] = useState("");
+  const emailId = `delete-confirm-${user.id}`;
+  const matches =
+    confirmEmail.trim().toLowerCase() === user.email.toLowerCase();
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setConfirmEmail("");
+      }}
+    >
+      <DialogTrigger
+        render={
+          <Button
+            variant="destructive"
+            size={fullWidth ? "default" : "sm"}
+            disabled={disabled}
+            className={fullWidth ? "w-full" : undefined}
+          >
+            <Trash2 className="h-4 w-4" aria-hidden="true" />
+            Programmer la suppression
+          </Button>
+        }
+      />
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Supprimer le compte de {user.name}</DialogTitle>
+          <DialogDescription>
+            Le compte et toutes ses données (enfants, suivis, journal) seront
+            définitivement supprimés dans 30 jours. Vous pourrez annuler cette
+            suppression à tout moment pendant ce délai.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="space-y-1.5">
+          <Label htmlFor={emailId}>
+            Tapez l'adresse e-mail du compte pour confirmer
+          </Label>
+          <Input
+            id={emailId}
+            type="email"
+            value={confirmEmail}
+            onChange={(e) => setConfirmEmail(e.target.value)}
+            placeholder={user.email}
+            autoComplete="off"
+          />
+        </div>
+        <DialogFooter>
+          <DialogClose render={<Button variant="outline">Annuler</Button>} />
+          <Button
+            variant="destructive"
+            disabled={!matches}
+            onClick={() => {
+              onConfirm();
+              setOpen(false);
+            }}
+          >
+            Programmer la suppression
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 // Role badge + the grant/revoke action. Shared by the desktop table cell
 // and the mobile management sheet — `fullWidth` switches the button sizing.
 function RoleControl({
@@ -561,6 +656,74 @@ function AccountControl({
         confirmLabel="Envoyer le lien"
         onConfirm={() => resetPassword.mutate(user.id)}
       />
+      <div className="mt-1 w-full border-t border-border/60 pt-3">
+        <DeletionControl
+          user={user}
+          isCurrentUser={isCurrentUser}
+          fullWidth={fullWidth}
+        />
+      </div>
+    </div>
+  );
+}
+
+// Account-deletion badge + the schedule/cancel action. Deletion is a
+// 30-day scheduled erasure (reversible during the grace period), kept
+// fenced off below the reversible account actions above. Administrator
+// accounts — and your own — can't be deleted here: an admin must be
+// demoted first, which keeps the last admin from being removed by error.
+function DeletionControl({
+  user,
+  isCurrentUser,
+  fullWidth,
+}: {
+  user: AdminUser;
+  isCurrentUser: boolean;
+  fullWidth?: boolean;
+}) {
+  const scheduleDeletion = useScheduleUserDeletion();
+  const cancelDeletion = useCancelUserDeletion();
+  const pending =
+    (scheduleDeletion.isPending && scheduleDeletion.variables === user.id) ||
+    (cancelDeletion.isPending && cancelDeletion.variables === user.id);
+
+  return (
+    <div className="flex flex-col items-start gap-1.5">
+      {user.deletionScheduledAt ? (
+        <>
+          <Badge variant="destructive">Suppression programmée</Badge>
+          <span className="text-xs text-muted-foreground">
+            Compte supprimé le{" "}
+            {scheduledDeletionDate(user.deletionScheduledAt)}
+          </span>
+          <ConfirmAction
+            fullWidth={fullWidth}
+            buttonLabel="Annuler la suppression"
+            buttonIcon={RotateCcw}
+            buttonVariant="outline"
+            disabled={pending}
+            title="Annuler la suppression du compte"
+            description={`Le compte de ${user.name} ne sera pas supprimé et restera actif.`}
+            confirmLabel="Annuler la suppression"
+            onConfirm={() => cancelDeletion.mutate(user.id)}
+          />
+        </>
+      ) : isCurrentUser ? (
+        <span className="text-xs text-muted-foreground">
+          Vous ne pouvez pas supprimer votre propre compte
+        </span>
+      ) : user.isAdmin ? (
+        <span className="text-xs text-muted-foreground">
+          Les comptes administrateurs ne peuvent pas être supprimés
+        </span>
+      ) : (
+        <DeleteUserDialog
+          user={user}
+          fullWidth={fullWidth}
+          disabled={pending}
+          onConfirm={() => scheduleDeletion.mutate(user.id)}
+        />
+      )}
     </div>
   );
 }
@@ -593,12 +756,7 @@ function UserRow({
         {formatDate(user.createdAt)}
       </td>
       <td className="px-4 py-3 align-top">
-        <div className="flex flex-wrap items-center gap-1.5">
-          <Badge variant={sub.variant}>{sub.label}</Badge>
-          {user.deletionScheduledAt && (
-            <Badge variant="destructive">Suppression programmée</Badge>
-          )}
-        </div>
+        <Badge variant={sub.variant}>{sub.label}</Badge>
       </td>
       <td className="px-4 py-3 align-top">
         <RoleControl user={user} isCurrentUser={isCurrentUser} />


### PR DESCRIPTION
## Summary

Adds a reversible account deletion feature to the admin user management console. Admins can now schedule user accounts for erasure with a 30-day grace period during which the deletion can be cancelled. This mirrors the self-service deletion flow already available to users in their account settings.

## Key Changes

- **Backend API routes** (`apps/api/src/routes/admin-users.ts`):
  - `POST /api/admin/users/:id/schedule-deletion` — schedules account erasure after 30 days
  - `POST /api/admin/users/:id/cancel-deletion` — cancels a scheduled deletion during the grace period
  - Guards prevent admins from deleting themselves or other admin accounts (must be demoted first)

- **Frontend UI** (`apps/web/src/routes/_authenticated/admin-users/index.tsx`):
  - New `DeleteUserDialog` component with email confirmation requirement (deliberate friction to prevent misclicks on high-stakes action)
  - New `DeletionControl` component displaying deletion status and action buttons
  - Moved deletion badge from subscription column to dedicated account control section
  - Added `scheduledDeletionDate()` helper to calculate actual erasure date (scheduling timestamp + 30 days)
  - Integrated `useScheduleUserDeletion()` and `useCancelUserDeletion()` mutations

- **Custom hooks** (`apps/web/src/hooks/use-admin-users.ts`):
  - `useScheduleUserDeletion()` — mutation with success/error toast feedback
  - `useCancelUserDeletion()` — mutation with success/error toast feedback

## Implementation Details

- **Safety guards**: Admins cannot delete themselves or other admin accounts from the console; admin role must be revoked first to prevent accidental removal of the last admin
- **Email confirmation**: The delete dialog requires the admin to retype the target account's email address before confirming — a deliberate UX pattern to guard against misclicks on destructive actions
- **Grace period**: 30-day reversible window before actual data erasure (account, children, tracking, journal)
- **UI separation**: Deletion controls are visually separated below reversible account actions (password reset, blocking) to emphasize the different risk level
- **Consistent messaging**: All user-facing text in French, following project conventions for ADHD-friendly clarity

https://claude.ai/code/session_01NiQigxt1ktgqg28Fu3A3ay