### PR TITLE
fix: redesign admin users table with shadcn Table component

### DIFF
--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -1,0 +1,114 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Table({ className, ...props }: React.ComponentProps<"table">) {
+  return (
+    <div
+      data-slot="table-container"
+      className="relative w-full overflow-x-auto"
+    >
+      <table
+        data-slot="table"
+        className={cn("w-full caption-bottom text-sm", className)}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("[&_tr]:border-b [&_tr]:border-border/60", className)}
+      {...props}
+    />
+  )
+}
+
+function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {
+  return (
+    <tbody
+      data-slot="table-body"
+      className={cn("[&_tr:last-child]:border-0", className)}
+      {...props}
+    />
+  )
+}
+
+function TableFooter({ className, ...props }: React.ComponentProps<"tfoot">) {
+  return (
+    <tfoot
+      data-slot="table-footer"
+      className={cn(
+        "border-t border-border/60 bg-muted/40 font-medium [&>tr]:last:border-b-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableRow({ className, ...props }: React.ComponentProps<"tr">) {
+  return (
+    <tr
+      data-slot="table-row"
+      className={cn(
+        "border-b border-border/60 transition-colors hover:bg-muted/40 data-[state=selected]:bg-muted",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableHead({ className, ...props }: React.ComponentProps<"th">) {
+  return (
+    <th
+      data-slot="table-head"
+      className={cn(
+        "h-10 px-4 text-left align-middle text-xs font-medium whitespace-nowrap text-muted-foreground [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCell({ className, ...props }: React.ComponentProps<"td">) {
+  return (
+    <td
+      data-slot="table-cell"
+      className={cn(
+        "px-4 py-3 align-middle [&:has([role=checkbox])]:pr-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TableCaption({
+  className,
+  ...props
+}: React.ComponentProps<"caption">) {
+  return (
+    <caption
+      data-slot="table-caption"
+      className={cn("mt-4 text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Table,
+  TableHeader,
+  TableBody,
+  TableFooter,
+  TableHead,
+  TableRow,
+  TableCell,
+  TableCaption,
+}

--- a/apps/web/src/routes/_authenticated/admin-users/index.tsx
+++ b/apps/web/src/routes/_authenticated/admin-users/index.tsx
@@ -45,6 +45,14 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -222,44 +230,32 @@ function AdminUsersPage() {
           ))}
         </div>
       ) : (
-        <Card>
+        <Card className="py-0">
           <CardContent className="p-0">
-            <div className="overflow-x-auto">
-              <table className="w-full min-w-[72rem] text-sm">
-                <thead>
-                  <tr className="border-b border-border/60 bg-muted/40">
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                      Utilisateur
-                    </th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                      Inscrit le
-                    </th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                      Abonnement
-                    </th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                      Rôle
-                    </th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                      Accès premium
-                    </th>
-                    <th className="px-4 py-3 text-left font-medium text-muted-foreground">
-                      Compte
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filtered.map((u, i) => (
-                    <UserRow
-                      key={u.id}
-                      user={u}
-                      isCurrentUser={u.id === currentUserId}
-                      striped={i % 2 === 1}
-                    />
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <Table>
+              <TableHeader>
+                <TableRow className="bg-muted/40">
+                  <TableHead>Utilisateur</TableHead>
+                  <TableHead>Inscrit le</TableHead>
+                  <TableHead>Abonnement</TableHead>
+                  <TableHead>Rôle</TableHead>
+                  <TableHead>Accès premium</TableHead>
+                  <TableHead>Compte</TableHead>
+                  <TableHead className="text-right">
+                    <span className="sr-only">Actions</span>
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filtered.map((u) => (
+                  <UserRow
+                    key={u.id}
+                    user={u}
+                    isCurrentUser={u.id === currentUserId}
+                  />
+                ))}
+              </TableBody>
+            </Table>
           </CardContent>
         </Card>
       )}
@@ -731,17 +727,15 @@ function DeletionControl({
 function UserRow({
   user,
   isCurrentUser,
-  striped,
 }: {
   user: AdminUser;
   isCurrentUser: boolean;
-  striped: boolean;
 }) {
   const sub = subscriptionBadge(user);
 
   return (
-    <tr className={striped ? "bg-muted/20" : undefined}>
-      <td className="px-4 py-3 align-top">
+    <TableRow>
+      <TableCell>
         <div className="font-medium text-foreground">
           {user.name}
           {isCurrentUser && (
@@ -751,23 +745,44 @@ function UserRow({
           )}
         </div>
         <div className="text-xs text-muted-foreground">{user.email}</div>
-      </td>
-      <td className="px-4 py-3 align-top whitespace-nowrap text-muted-foreground">
+      </TableCell>
+      <TableCell className="whitespace-nowrap text-muted-foreground">
         {formatDate(user.createdAt)}
-      </td>
-      <td className="px-4 py-3 align-top">
+      </TableCell>
+      <TableCell>
         <Badge variant={sub.variant}>{sub.label}</Badge>
-      </td>
-      <td className="px-4 py-3 align-top">
-        <RoleControl user={user} isCurrentUser={isCurrentUser} />
-      </td>
-      <td className="px-4 py-3 align-top">
-        <PremiumControl user={user} />
-      </td>
-      <td className="px-4 py-3 align-top">
-        <AccountControl user={user} isCurrentUser={isCurrentUser} />
-      </td>
-    </tr>
+      </TableCell>
+      <TableCell>
+        <Badge variant={user.isAdmin ? "secondary" : "outline"}>
+          {user.isAdmin ? "Administrateur" : "Parent"}
+        </Badge>
+      </TableCell>
+      <TableCell>
+        {user.premiumGranted ? (
+          <Badge variant="default">Premium accordé</Badge>
+        ) : (
+          <span className="text-xs text-muted-foreground">Non accordé</span>
+        )}
+      </TableCell>
+      <TableCell>
+        <div className="flex flex-wrap gap-1.5">
+          {user.deletionScheduledAt && (
+            <Badge variant="destructive">Suppression programmée</Badge>
+          )}
+          {user.isBlocked && <Badge variant="destructive">Bloqué</Badge>}
+          {!user.deletionScheduledAt && !user.isBlocked && (
+            <Badge variant="outline">Actif</Badge>
+          )}
+        </div>
+      </TableCell>
+      <TableCell className="text-right">
+        <ManageUserSheet
+          user={user}
+          isCurrentUser={isCurrentUser}
+          side="right"
+        />
+      </TableCell>
+    </TableRow>
   );
 }
 
@@ -788,26 +803,34 @@ function SheetSection({
   );
 }
 
-// Mobile-only: every per-user action grouped in a bottom sheet so the
-// touch targets stay large and only one decision is shown at a time.
+// Every per-user action grouped in a single sheet so only one decision is
+// shown at a time. The mobile card opens it from the bottom; a desktop
+// table row opens it from the right.
 function ManageUserSheet({
   user,
   isCurrentUser,
+  side = "bottom",
 }: {
   user: AdminUser;
   isCurrentUser: boolean;
+  side?: "bottom" | "right";
 }) {
+  const desktop = side === "right";
   return (
     <Sheet>
       <SheetTrigger
         render={
-          <Button variant="outline" className="w-full">
+          <Button
+            variant="outline"
+            size={desktop ? "sm" : "default"}
+            className={desktop ? undefined : "w-full"}
+          >
             <UserCog className="h-4 w-4" aria-hidden="true" />
             Gérer le compte
           </Button>
         }
       />
-      <SheetContent side="bottom" className="gap-0 overflow-y-auto">
+      <SheetContent side={side} className="gap-0 overflow-y-auto">
         <SheetHeader className="pr-10">
           <SheetTitle>{user.name}</SheetTitle>
           <SheetDescription className="break-all">


### PR DESCRIPTION
Replace the raw HTML table on the admin users page with a proper
shadcn-style Table component. Each desktop row now shows status
badges across columns plus a single "Gérer le compte" action that
opens the existing management sheet — matching the mobile pattern
and cutting the per-row cognitive load.

https://claude.ai/code/session_01NKkxr53MwR3RZDfNqNR2wX