### PR TITLE
feat(web): show PWA install prompt app-wide and fix capture race

### DIFF
--- a/apps/web/src/hooks/use-install-prompt.ts
+++ b/apps/web/src/hooks/use-install-prompt.ts
@@ -1,13 +1,10 @@
-import { useCallback, useEffect, useState } from "react";
-
-interface BeforeInstallPromptEvent extends Event {
-  readonly platforms: string[];
-  readonly userChoice: Promise<{
-    outcome: "accepted" | "dismissed";
-    platform: string;
-  }>;
-  prompt(): Promise<void>;
-}
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
+import {
+  consumeDeferredInstallEvent,
+  getDeferredInstallEvent,
+  subscribeInstallState,
+  wasAppInstalled,
+} from "@/lib/install-prompt";
 
 const DISMISS_KEY = "toko:install-dismissed-at";
 // Re-prompt at most every 30 days after a dismissal.
@@ -53,36 +50,28 @@ export interface UseInstallPromptResult {
 }
 
 export function useInstallPrompt(): UseInstallPromptResult {
-  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null);
-  const [installed, setInstalled] = useState(() => isStandalone());
+  const deferred = useSyncExternalStore(
+    subscribeInstallState,
+    getDeferredInstallEvent,
+    () => null,
+  );
+  const appInstalled = useSyncExternalStore(
+    subscribeInstallState,
+    wasAppInstalled,
+    () => false,
+  );
+  const [standalone] = useState(() => isStandalone());
   const [dismissed, setDismissed] = useState(() => recentlyDismissed());
   const [iosEligible, setIosEligible] = useState(false);
 
+  const installed = standalone || appInstalled;
+
   useEffect(() => {
-    if (installed) return;
-
-    const onBeforeInstall = (e: Event) => {
-      e.preventDefault();
-      setDeferred(e as BeforeInstallPromptEvent);
-    };
-    const onInstalled = () => {
-      setInstalled(true);
-      setDeferred(null);
-    };
-
-    window.addEventListener("beforeinstallprompt", onBeforeInstall);
-    window.addEventListener("appinstalled", onInstalled);
-
     // iOS Safari never fires beforeinstallprompt — surface manual instructions.
     if (isIos() && !isStandalone()) {
       setIosEligible(true);
     }
-
-    return () => {
-      window.removeEventListener("beforeinstallprompt", onBeforeInstall);
-      window.removeEventListener("appinstalled", onInstalled);
-    };
-  }, [installed]);
+  }, []);
 
   const dismiss = useCallback(() => {
     try {
@@ -97,7 +86,7 @@ export function useInstallPrompt(): UseInstallPromptResult {
     if (!deferred) return "unsupported" as const;
     await deferred.prompt();
     const { outcome } = await deferred.userChoice;
-    setDeferred(null);
+    consumeDeferredInstallEvent();
     if (outcome === "dismissed") dismiss();
     return outcome;
   }, [deferred, dismiss]);

--- a/apps/web/src/lib/install-prompt.ts
+++ b/apps/web/src/lib/install-prompt.ts
@@ -1,0 +1,52 @@
+export interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{
+    outcome: "accepted" | "dismissed";
+    platform: string;
+  }>;
+  prompt(): Promise<void>;
+}
+
+// Chrome fires `beforeinstallprompt` once, very early in page load — often
+// before React has mounted the route tree. Capturing it here, at module
+// evaluation time, ensures the event is stashed instead of lost.
+let deferredEvent: BeforeInstallPromptEvent | null = null;
+let installed = false;
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const listener of listeners) listener();
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("beforeinstallprompt", (e) => {
+    e.preventDefault();
+    deferredEvent = e as BeforeInstallPromptEvent;
+    emit();
+  });
+  window.addEventListener("appinstalled", () => {
+    installed = true;
+    deferredEvent = null;
+    emit();
+  });
+}
+
+export function getDeferredInstallEvent() {
+  return deferredEvent;
+}
+
+export function consumeDeferredInstallEvent() {
+  deferredEvent = null;
+  emit();
+}
+
+export function wasAppInstalled() {
+  return installed;
+}
+
+export function subscribeInstallState(listener: () => void) {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -7,6 +7,8 @@ import { queryClient } from "@/lib/query-client";
 import { loadGoatCounter } from "@/lib/goatcounter";
 import { routeTree } from "./routeTree.gen";
 import "@/lib/i18n";
+// Side-effect import: starts listening for `beforeinstallprompt` before React mounts.
+import "@/lib/install-prompt";
 import "./app.css";
 
 loadGoatCounter();

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Toaster } from "@/components/ui/sonner";
 import { NotFound } from "@/components/not-found";
 import { Button } from "@/components/ui/button";
+import { InstallPrompt } from "@/components/shared/install-prompt";
 import { useGoatCounterPageviews } from "@/lib/goatcounter";
 
 export const Route = createRootRoute({
@@ -41,6 +42,7 @@ function RootLayout() {
     <>
       <Outlet />
       <Toaster />
+      <InstallPrompt />
     </>
   );
 }

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -42,7 +42,6 @@ import { ChildSelector } from "@/components/shared/child-selector";
 import { ModeToggle } from "@/components/mode-toggle";
 import { KoeWidget, useKoeTrigger } from "@/components/koe-widget";
 import { FloatingTipButton } from "@/components/shared/floating-tip-button";
-import { InstallPrompt } from "@/components/shared/install-prompt";
 import { PWAUpdatePrompt } from "@/components/shared/pwa-update-prompt";
 import { SOSCrisisButton } from "@/components/shared/sos-crisis-button";
 import { LockOverlay } from "@/components/shared/lock-overlay";
@@ -143,7 +142,6 @@ function AuthenticatedShell() {
       </div>
       <KoeWidget />
       <LockOverlay />
-      <InstallPrompt />
       <PWAUpdatePrompt />
       <OnboardingTour />
     </>


### PR DESCRIPTION
Mount the install bottom sheet from the root layout so visitors on
public pages (landing, login, pricing) are prompted, not only
authenticated users.

Capture `beforeinstallprompt` at module load via a small global store
imported before React mounts. The deep authenticated layout attached
its listener too late, so Chrome's one-shot event was often missed and
the Android native install prompt never appeared.

https://claude.ai/code/session_01B4sKdjJbqpeJcwPTGweLGi