### PR TITLE
ci: generate Playwright HTML report so failure artifacts upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
       - name: Run E2E tests
         run: |
           set -o pipefail
-          pnpm test:e2e --project=chromium --reporter=list 2>&1 | tee /tmp/e2e.log
+          pnpm test:e2e --project=chromium --reporter=list,html 2>&1 | tee /tmp/e2e.log
 
       - name: Post e2e log as commit comment on failure
         if: failure()


### PR DESCRIPTION
The E2E job ran with --reporter=list, which overrides the config's
html reporter, so playwright-report/ was never created and the
"Upload test results" step always found nothing. Adding the html
reporter makes the artifact (traces, screenshots) actually upload on
failure while keeping list output for the on-failure commit comment.

https://claude.ai/code/session_01X8mvAwvW98hMBMAiUMUu1K