### PR TITLE
fix: harden password-reset flow and fix audit findings

### DIFF
--- a/apps/api/src/__tests__/email-templates.test.ts
+++ b/apps/api/src/__tests__/email-templates.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   dailyReminderTemplate,
   weeklyDigestTemplate,
+  resetPasswordEmail,
 } from "../lib/email-templates";
 
 describe("dailyReminderTemplate", () => {
@@ -51,5 +52,25 @@ describe("weeklyDigestTemplate", () => {
       hardestDay: null,
     });
     expect(html).toContain("—");
+  });
+});
+
+describe("resetPasswordEmail", () => {
+  const url = "https://toko.app/reset-password?token=abc123";
+
+  it("produces a French security email with the reset link", () => {
+    const { subject, html } = resetPasswordEmail({ url });
+    expect(subject).toMatch(/mot de passe/i);
+    expect(html).toContain(url);
+    expect(html).toContain("Choisir un nouveau mot de passe");
+  });
+
+  it("does not use the reminder-preferences footer", () => {
+    // A reset email is transactional/security — it must not claim the
+    // user "enabled reminders" or link to an opt-out they can't reach.
+    const { html } = resetPasswordEmail({ url });
+    expect(html).not.toContain("activé les rappels");
+    expect(html).not.toContain("Gérer mes notifications");
+    expect(html).toContain("sécurité de ton compte");
   });
 });

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -30,6 +30,12 @@ export const auth = betterAuth({
   },
   emailAndPassword: {
     enabled: true,
+    // Enforced server-side on sign-up and password reset — the SPA's
+    // minLength={8} is only a client hint and is trivially bypassed.
+    minPasswordLength: 8,
+    // A password reset is an account-recovery action: revoke every other
+    // session so a stale or attacker-held session can't outlive the reset.
+    revokeSessionsOnPasswordReset: true,
     // Better Auth appends ?token=... and uses this URL as the redirect target
     // emailed to the user. Pointed at the SPA route so the reset form opens
     // directly without a server round-trip.
@@ -61,7 +67,13 @@ export const auth = betterAuth({
     customRules: {
       "/sign-in/*": { window: 60, max: 10 },
       "/sign-up/*": { window: 60, max: 10 },
-      "/forget-password": { window: 60, max: 5 },
+      // Reset-request endpoint. The route is `/request-password-reset` in
+      // Better Auth 1.5 (the old `/forget-password` key matched nothing and
+      // left this on the default 100/min — a free email-spam amplifier).
+      "/request-password-reset": { window: 60, max: 5 },
+      // Token-submission endpoint — without this it falls back to the
+      // default 100/min, leaving the reset token open to rapid guessing.
+      "/reset-password": { window: 60, max: 10 },
     },
   },
   databaseHooks: {

--- a/apps/api/src/lib/email-templates.ts
+++ b/apps/api/src/lib/email-templates.ts
@@ -1,6 +1,16 @@
 import { env } from "./env";
 
-function layout(innerHtml: string): string {
+// Default footer for reminder/digest emails — these are opt-in, so the
+// footer explains why and links to notification preferences.
+const reminderFooter = `Vous recevez cet email parce que vous avez activé les rappels dans votre compte Tokō.
+          <a href="${env.APP_URL}/account" style="color: #78716c;">Gérer mes notifications</a>`;
+
+// Transactional/security emails (e.g. password reset) are NOT reminders:
+// they must not claim the user "enabled reminders" or offer an opt-out the
+// user can't actually use (the /account link needs a session they lack).
+const securityFooter = `Email automatique lié à la sécurité de ton compte Tokō. Merci de ne pas y répondre.`;
+
+function layout(innerHtml: string, footer: string = reminderFooter): string {
   return `<!doctype html>
 <html lang="fr">
   <body style="font-family: -apple-system, system-ui, sans-serif; background: #fafaf9; margin: 0; padding: 24px;">
@@ -10,8 +20,7 @@ function layout(innerHtml: string): string {
         ${innerHtml}
         <hr style="border: none; border-top: 1px solid #e7e5e4; margin: 32px 0 16px;" />
         <p style="font-size: 12px; color: #a8a29e; margin: 0;">
-          Vous recevez cet email parce que vous avez activé les rappels dans votre compte Tokō.
-          <a href="${env.APP_URL}/account" style="color: #78716c;">Gérer mes notifications</a>
+          ${footer}
         </p>
       </td></tr>
     </table>
@@ -273,7 +282,7 @@ export function resetPasswordEmail({ url }: { url: string }): {
         Si tu n'as rien demandé, ignore simplement ce message — ton mot de
         passe ne changera pas.
       </p>
-    `),
+    `, securityFooter),
   };
 }
 

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -218,6 +218,7 @@
     "submit": "Send link",
     "submitting": "Sending…",
     "confirmation": "If an account exists for this address, an email is on its way. Check your inbox (and spam folder).",
+    "errorNetwork": "Couldn't connect. Check your internet connection and try again.",
     "backToLogin": "Back to sign in"
   },
   "resetPassword": {
@@ -227,7 +228,11 @@
     "submitting": "Saving…",
     "success": "Done. Sign in with your new password.",
     "goToLogin": "Sign in",
-    "errorInvalid": "Link expired or invalid. Request a new one."
+    "errorInvalid": "Link expired or invalid. Request a new one.",
+    "errorNetwork": "Couldn't connect. Check your internet connection and try again.",
+    "requestNewLink": "Request a new link",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -209,6 +209,7 @@
     "googleLoading": "Signing in...",
     "errorInvalid": "Invalid credentials",
     "errorRegister": "Registration error",
+    "errorNetwork": "Couldn't connect. Check your internet connection and try again.",
     "backToHome": "Home",
     "forgotPassword": "Forgot password?"
   },

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -209,6 +209,7 @@
     "googleLoading": "Connexion...",
     "errorInvalid": "Identifiants incorrects",
     "errorRegister": "Erreur lors de l'inscription",
+    "errorNetwork": "Connexion impossible. Vérifie ta connexion internet et réessaie.",
     "backToHome": "Accueil",
     "forgotPassword": "Nouveau mot de passe ?"
   },

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -218,6 +218,7 @@
     "submit": "Envoyer le lien",
     "submitting": "Envoi…",
     "confirmation": "Si un compte existe pour cette adresse, un email est parti. Vérifie ta boîte (et les spams).",
+    "errorNetwork": "Connexion impossible. Vérifie ta connexion internet et réessaie.",
     "backToLogin": "Retour à la connexion"
   },
   "resetPassword": {
@@ -227,7 +228,11 @@
     "submitting": "Enregistrement…",
     "success": "C'est fait. Connecte-toi avec ton nouveau mot de passe.",
     "goToLogin": "Se connecter",
-    "errorInvalid": "Lien expiré ou invalide. Demande un nouveau lien."
+    "errorInvalid": "Lien expiré ou invalide. Demande un nouveau lien.",
+    "errorNetwork": "Connexion impossible. Vérifie ta connexion internet et réessaie.",
+    "requestNewLink": "Demander un nouveau lien",
+    "showPassword": "Afficher le mot de passe",
+    "hidePassword": "Masquer le mot de passe"
   },
   "nav": {
     "dashboard": "Tableau de bord",

--- a/apps/web/src/routes/forgot-password.tsx
+++ b/apps/web/src/routes/forgot-password.tsx
@@ -16,17 +16,26 @@ export const Route = createFileRoute("/forgot-password")({
 function ForgotPasswordPage() {
   const { t } = useTranslation();
   const [email, setEmail] = useState("");
+  const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [sent, setSent] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    setError("");
     setLoading(true);
-    // Better Auth always returns the same response whether the account
-    // exists or not (anti-enumeration), so we don't surface the result.
-    await forgetPassword({ email, redirectTo: "/reset-password" });
-    setSent(true);
-    setLoading(false);
+    try {
+      // Better Auth always returns the same response whether the account
+      // exists or not (anti-enumeration), so we don't surface the result.
+      await forgetPassword({ email, redirectTo: "/reset-password" });
+      setSent(true);
+    } catch {
+      // Network/transport failure — surface it instead of leaving the
+      // button stuck on "Envoi…" or falsely showing the sent state.
+      setError(t("forgotPassword.errorNetwork"));
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
@@ -90,6 +99,15 @@ function ForgotPasswordPage() {
                     required
                   />
                 </div>
+                {error && (
+                  <p
+                    role="alert"
+                    aria-live="polite"
+                    className="text-sm text-destructive"
+                  >
+                    {error}
+                  </p>
+                )}
                 <Button
                   type="submit"
                   className="w-full shadow-sm shadow-primary/20"

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -79,16 +79,23 @@ function LoginForm() {
     setError("");
     setLoading(true);
 
-    const result = await signIn.email({ email, password });
-
-    if (result.error) {
-      setError(result.error.message ?? t("login.errorInvalid"));
+    try {
+      const result = await signIn.email({ email, password });
+      if (result.error) {
+        // Better Auth error messages are English — the audience is
+        // French, so always surface our own translated copy.
+        setError(t("login.errorInvalid"));
+        return;
+      }
+      // Navigation pleine page : évite la course entre cookie de session et beforeLoad (getSession) en SPA
+      window.location.assign("/dashboard");
+    } catch {
+      // Network/transport failure — without this catch the button would
+      // stay stuck on "Connexion..." with no feedback.
+      setError(t("login.errorNetwork"));
+    } finally {
       setLoading(false);
-      return;
     }
-
-    // Navigation pleine page : évite la course entre cookie de session et beforeLoad (getSession) en SPA
-    window.location.assign("/dashboard");
   };
 
   return (
@@ -134,7 +141,13 @@ function LoginForm() {
             />
           </div>
           {error && (
-            <p className="text-sm text-destructive">{error}</p>
+            <p
+              role="alert"
+              aria-live="polite"
+              className="text-sm text-destructive"
+            >
+              {error}
+            </p>
           )}
           <Button
             type="submit"
@@ -162,16 +175,19 @@ function RegisterForm() {
     setError("");
     setLoading(true);
 
-    const result = await signUp.email({ name, email, password });
-
-    if (result.error) {
-      setError(result.error.message ?? t("login.errorRegister"));
+    try {
+      const result = await signUp.email({ name, email, password });
+      if (result.error) {
+        setError(t("login.errorRegister"));
+        return;
+      }
+      trackEvent("signup_completed");
+      window.location.assign("/dashboard");
+    } catch {
+      setError(t("login.errorNetwork"));
+    } finally {
       setLoading(false);
-      return;
     }
-
-    trackEvent("signup_completed");
-    window.location.assign("/dashboard");
   };
 
   return (
@@ -221,7 +237,13 @@ function RegisterForm() {
             />
           </div>
           {error && (
-            <p className="text-sm text-destructive">{error}</p>
+            <p
+              role="alert"
+              aria-live="polite"
+              className="text-sm text-destructive"
+            >
+              {error}
+            </p>
           )}
           <Button
             type="submit"
@@ -241,41 +263,61 @@ function RegisterForm() {
 function GoogleSignInButton() {
   const { t } = useTranslation();
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
 
   const handleGoogleSignIn = async () => {
+    setError("");
     setLoading(true);
-    await authClient.signIn.social({
-      provider: "google",
-      callbackURL: "/dashboard",
-    });
+    try {
+      await authClient.signIn.social({
+        provider: "google",
+        callbackURL: "/dashboard",
+      });
+      // On success the browser redirects to Google — keep the button in
+      // its loading state until that navigation happens.
+    } catch {
+      setError(t("login.errorNetwork"));
+      setLoading(false);
+    }
   };
 
   return (
-    <Button
-      variant="outline"
-      className="w-full border-border/60"
-      onClick={handleGoogleSignIn}
-      disabled={loading}
-    >
-      <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
-        <path
-          d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
-          fill="#4285F4"
-        />
-        <path
-          d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-          fill="#34A853"
-        />
-        <path
-          d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-          fill="#FBBC05"
-        />
-        <path
-          d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-          fill="#EA4335"
-        />
-      </svg>
-      {loading ? t("login.googleLoading") : t("login.googleContinue")}
-    </Button>
+    <div className="space-y-2">
+      <Button
+        variant="outline"
+        className="w-full border-border/60"
+        onClick={handleGoogleSignIn}
+        disabled={loading}
+      >
+        <svg className="mr-2 h-4 w-4" viewBox="0 0 24 24">
+          <path
+            d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+            fill="#4285F4"
+          />
+          <path
+            d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+            fill="#34A853"
+          />
+          <path
+            d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+            fill="#FBBC05"
+          />
+          <path
+            d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+            fill="#EA4335"
+          />
+        </svg>
+        {loading ? t("login.googleLoading") : t("login.googleContinue")}
+      </Button>
+      {error && (
+        <p
+          role="alert"
+          aria-live="polite"
+          className="text-sm text-destructive"
+        >
+          {error}
+        </p>
+      )}
+    </div>
   );
 }

--- a/apps/web/src/routes/reset-password.tsx
+++ b/apps/web/src/routes/reset-password.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, Eye, EyeOff } from "lucide-react";
 import { BrandLogo } from "@/components/shared/brand-logo";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -13,7 +13,10 @@ type ResetPasswordSearch = { token: string };
 
 export const Route = createFileRoute("/reset-password")({
   validateSearch: (search: Record<string, unknown>): ResetPasswordSearch => {
-    const token = typeof search.token === "string" ? search.token : "";
+    // Trim so a whitespace-only token (e.g. `?token=%20`) is treated as
+    // absent and redirected, not rendered as a form that fails on submit.
+    const token =
+      typeof search.token === "string" ? search.token.trim() : "";
     return { token };
   },
   beforeLoad: ({ search }) => {
@@ -28,26 +31,35 @@ function ResetPasswordPage() {
   const { t } = useTranslation();
   const { token } = Route.useSearch();
   const [password, setPassword] = useState("");
+  const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState("");
+  const [linkInvalid, setLinkInvalid] = useState(false);
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!token) return;
     setError("");
+    setLinkInvalid(false);
     setLoading(true);
 
-    const result = await resetPassword({ newPassword: password, token });
-
-    if (result.error) {
-      setError(result.error.message ?? t("resetPassword.errorInvalid"));
+    try {
+      const result = await resetPassword({ newPassword: password, token });
+      if (result.error) {
+        // Better Auth error messages are English — the audience is
+        // French, so always surface our own translated copy.
+        setError(t("resetPassword.errorInvalid"));
+        setLinkInvalid(true);
+        return;
+      }
+      setDone(true);
+    } catch {
+      // Network/transport failure — without this catch the button would
+      // stay stuck on "Enregistrement…" with no feedback.
+      setError(t("resetPassword.errorNetwork"));
+    } finally {
       setLoading(false);
-      return;
     }
-
-    setDone(true);
-    setLoading(false);
   };
 
   return (
@@ -97,20 +109,49 @@ function ResetPasswordPage() {
                   <Label htmlFor="reset-password">
                     {t("resetPassword.newPassword")}
                   </Label>
-                  <Input
-                    id="reset-password"
-                    type="password"
-                    autoComplete="new-password"
-                    autoFocus
-                    placeholder={t("login.passwordPlaceholder")}
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    minLength={8}
-                    required
-                  />
+                  <div className="relative">
+                    <Input
+                      id="reset-password"
+                      type={showPassword ? "text" : "password"}
+                      autoComplete="new-password"
+                      autoFocus
+                      placeholder={t("login.passwordPlaceholder")}
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      minLength={8}
+                      required
+                      className="pr-10"
+                    />
+                    <button
+                      type="button"
+                      onClick={() => setShowPassword((v) => !v)}
+                      aria-label={
+                        showPassword
+                          ? t("resetPassword.hidePassword")
+                          : t("resetPassword.showPassword")
+                      }
+                      className="absolute inset-y-0 right-0 flex w-10 items-center justify-center text-muted-foreground transition-colors hover:text-foreground"
+                    >
+                      {showPassword ? (
+                        <EyeOff className="h-4 w-4" />
+                      ) : (
+                        <Eye className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
                 </div>
                 {error && (
-                  <p className="text-sm text-destructive">{error}</p>
+                  <div role="alert" aria-live="polite" className="space-y-1">
+                    <p className="text-sm text-destructive">{error}</p>
+                    {linkInvalid && (
+                      <Link
+                        to="/forgot-password"
+                        className="inline-block text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+                      >
+                        {t("resetPassword.requestNewLink")}
+                      </Link>
+                    )}
+                  </div>
                 )}
                 <Button
                   type="submit"

--- a/packages/validators/src/account.ts
+++ b/packages/validators/src/account.ts
@@ -5,16 +5,3 @@ export const deleteAccountSchema = z.object({
 });
 
 export type DeleteAccount = z.infer<typeof deleteAccountSchema>;
-
-export const forgotPasswordSchema = z.object({
-  email: z.string().email(),
-});
-
-export type ForgotPassword = z.infer<typeof forgotPasswordSchema>;
-
-export const resetPasswordSchema = z.object({
-  token: z.string().min(1),
-  password: z.string().min(8),
-});
-
-export type ResetPassword = z.infer<typeof resetPasswordSchema>;


### PR DESCRIPTION
Persona review of the reset-password feature surfaced several bugs:

- Reset email used the shared reminder footer ("you enabled
  reminders" + an opt-out link) — wrong for a security email. Add a
  dedicated security footer for transactional mail.
- Better Auth rate-limit customRules keyed "/forget-password", which
  matches no endpoint in Better Auth 1.5 (route is
  /request-password-reset) — the strict 5/min limit was dead. Re-key
  it and add a limit on /reset-password (token submission).
- Sessions were not revoked on password reset; set
  revokeSessionsOnPasswordReset and pin minPasswordLength explicitly.
- Reset/forgot forms awaited the auth client with no try/catch — a
  network failure left the button stuck with no feedback. Wrap in
  try/catch/finally and show a translated error.
- English Better Auth error text leaked to French users; always
  surface our own translated copy plus a "request a new link" CTA.
- Add a show/hide password toggle and aria-live error regions.
- Trim whitespace-only reset tokens so they redirect instead of
  rendering a form that fails on submit.
- Remove unused forgot/reset Zod validators (field name mismatched
  Better Auth's newPassword).
- Add regression tests for resetPasswordEmail.

https://claude.ai/code/session_01KnAz47foDzfvejRe8K9FFp