### PR TITLE
fix(web): register service worker app-wide so the install prompt appears

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import { Toaster } from "@/components/ui/sonner";
 import { NotFound } from "@/components/not-found";
 import { Button } from "@/components/ui/button";
 import { InstallPrompt } from "@/components/shared/install-prompt";
+import { PWAUpdatePrompt } from "@/components/shared/pwa-update-prompt";
 import { useGoatCounterPageviews } from "@/lib/goatcounter";
 
 export const Route = createRootRoute({
@@ -43,6 +44,7 @@ function RootLayout() {
       <Outlet />
       <Toaster />
       <InstallPrompt />
+      <PWAUpdatePrompt />
     </>
   );
 }

--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -42,7 +42,6 @@ import { ChildSelector } from "@/components/shared/child-selector";
 import { ModeToggle } from "@/components/mode-toggle";
 import { KoeWidget, useKoeTrigger } from "@/components/koe-widget";
 import { FloatingTipButton } from "@/components/shared/floating-tip-button";
-import { PWAUpdatePrompt } from "@/components/shared/pwa-update-prompt";
 import { SOSCrisisButton } from "@/components/shared/sos-crisis-button";
 import { LockOverlay } from "@/components/shared/lock-overlay";
 import { OnboardingTour } from "@/components/shared/onboarding-tour";
@@ -142,7 +141,6 @@ function AuthenticatedShell() {
       </div>
       <KoeWidget />
       <LockOverlay />
-      <PWAUpdatePrompt />
       <OnboardingTour />
     </>
   );


### PR DESCRIPTION
The PWA install prompt (<InstallPrompt />) is mounted app-wide in the
root route, but its native mode depends on the browser's
`beforeinstallprompt` event, which Chrome only fires once a service
worker is registered. The service worker was registered solely through
`useRegisterSW()` inside `usePwaUpdate()`, consumed by <PWAUpdatePrompt />,
which was mounted only in the authenticated shell. First-time and
logged-out visitors therefore never got a service worker, so the install
prompt could never surface for them.

Move <PWAUpdatePrompt /> to the root route so the single service-worker
registration runs for every visitor. This lets the install prompt ask
the user to install Tokō at least once, and also enables offline caching
on public pages.