### PR TITLE
feat: localize Koe feedback widget to the active app locale

### DIFF
--- a/apps/web/src/components/koe-widget.tsx
+++ b/apps/web/src/components/koe-widget.tsx
@@ -1,4 +1,4 @@
-import { KoeWidget as KoeWidgetBase } from "@wifsimster/koe";
+import { KoeWidget as KoeWidgetBase, type WidgetLocale } from "@wifsimster/koe";
 import "@wifsimster/koe/style.css";
 import { create } from "zustand";
 import { useTranslation } from "react-i18next";
@@ -32,9 +32,11 @@ export function KoeWidget() {
   const user = session.data?.user;
   const { data: hashData } = useKoeHash(Boolean(user && apiUrl && projectKey));
   const openCount = useKoeWidgetStore((s) => s.openCount);
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   if (!apiUrl || !projectKey || !user || !hashData?.hash) return null;
+
+  const locale = t("koe", { returnObjects: true }) as WidgetLocale;
 
   return (
     <KoeWidgetBase
@@ -45,6 +47,7 @@ export function KoeWidget() {
       userHash={hashData.hash}
       position="bottom-right"
       theme={{ accentColor: "#c2410c", mode: "auto" }}
+      locale={locale}
       defaultOpen={openCount > 0}
     />
   );

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -2027,5 +2027,64 @@
     "updating": "Updating…",
     "later": "Later",
     "close": "Dismiss update"
+  },
+  "koe": {
+    "launcherLabel": "Help & feedback",
+    "title": "How can we help?",
+    "subtitle": "We read every message.",
+    "picker": {
+      "prompt": "What would you like to do?",
+      "bug": "Report a bug",
+      "bugHint": "Something broken or confusing",
+      "feature": "Suggest an idea",
+      "featureHint": "New features, improvements",
+      "vote": "Browse ideas",
+      "voteHint": "Upvote requests from other parents"
+    },
+    "browse": {
+      "title": "Community ideas",
+      "loading": "Loading ideas…",
+      "empty": "No ideas yet.",
+      "error": "Couldn't load ideas.",
+      "retry": "Retry",
+      "voteAriaLabel": "Upvote this idea",
+      "unvoteAriaLabel": "Remove your vote",
+      "signInToVote": "Sign in to vote"
+    },
+    "back": "Back",
+    "tabs": {
+      "bug": "Bug",
+      "feature": "Idea",
+      "chat": "Chat"
+    },
+    "bugForm": {
+      "title": "Report a bug",
+      "description": "Describe the problem",
+      "reproduce": "How to reproduce it",
+      "steps": "Steps to reproduce",
+      "expected": "What should have happened",
+      "actual": "What actually happened",
+      "email": "Your email (optional)",
+      "submit": "Send report",
+      "success": "Thanks! We received your report."
+    },
+    "featureForm": {
+      "title": "Suggest an idea",
+      "description": "Describe your idea",
+      "email": "Your email (optional)",
+      "submit": "Send idea",
+      "success": "Thanks! Your idea has been sent."
+    },
+    "chat": {
+      "placeholder": "Type your message…",
+      "empty": "No messages yet.",
+      "send": "Send"
+    },
+    "errors": {
+      "required": "This field is required.",
+      "invalidEmail": "Invalid email address.",
+      "network": "Network error. Please try again.",
+      "generic": "Something went wrong. Please try again."
+    }
   }
 }

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -2453,5 +2453,64 @@
     "updating": "Mise à jour…",
     "later": "Plus tard",
     "close": "Ignorer la mise à jour"
+  },
+  "koe": {
+    "launcherLabel": "Aide et commentaires",
+    "title": "Comment pouvons-nous aider ?",
+    "subtitle": "Nous lisons chaque message.",
+    "picker": {
+      "prompt": "Que souhaitez-vous faire ?",
+      "bug": "Signaler un problème",
+      "bugHint": "Quelque chose est cassé ou prête à confusion",
+      "feature": "Proposer une idée",
+      "featureHint": "Nouvelles fonctionnalités, améliorations",
+      "vote": "Parcourir les idées",
+      "voteHint": "Votez pour les demandes d'autres parents"
+    },
+    "browse": {
+      "title": "Idées de la communauté",
+      "loading": "Chargement des idées…",
+      "empty": "Aucune idée pour le moment.",
+      "error": "Impossible de charger les idées.",
+      "retry": "Réessayer",
+      "voteAriaLabel": "Voter pour cette idée",
+      "unvoteAriaLabel": "Retirer mon vote",
+      "signInToVote": "Connectez-vous pour voter"
+    },
+    "back": "Retour",
+    "tabs": {
+      "bug": "Problème",
+      "feature": "Idée",
+      "chat": "Message"
+    },
+    "bugForm": {
+      "title": "Signaler un problème",
+      "description": "Décrivez le problème",
+      "reproduce": "Comment le reproduire",
+      "steps": "Étapes pour le reproduire",
+      "expected": "Ce qui devait se passer",
+      "actual": "Ce qui s'est passé",
+      "email": "Votre e-mail (facultatif)",
+      "submit": "Envoyer le signalement",
+      "success": "Merci ! Nous avons bien reçu votre signalement."
+    },
+    "featureForm": {
+      "title": "Proposer une idée",
+      "description": "Décrivez votre idée",
+      "email": "Votre e-mail (facultatif)",
+      "submit": "Envoyer l'idée",
+      "success": "Merci ! Votre idée a bien été envoyée."
+    },
+    "chat": {
+      "placeholder": "Écrivez votre message…",
+      "empty": "Aucun message pour le moment.",
+      "send": "Envoyer"
+    },
+    "errors": {
+      "required": "Ce champ est obligatoire.",
+      "invalidEmail": "Adresse e-mail invalide.",
+      "network": "Erreur réseau. Veuillez réessayer.",
+      "generic": "Une erreur est survenue. Veuillez réessayer."
+    }
   }
 }


### PR DESCRIPTION
The Koe widget rendered its UI in English regardless of the user's
language. Add fr/en translations for all widget strings and pass them
through the `locale` prop so the widget follows the i18n language.

https://claude.ai/code/session_01R4pixhDM66VVmZFJABJ3Hy