### PR TITLE
fix: label status badges on the mobile user-admin card

### DIFF
--- a/apps/web/src/routes/_authenticated/admin-users/index.tsx
+++ b/apps/web/src/routes/_authenticated/admin-users/index.tsx
@@ -857,6 +857,26 @@ function ManageUserSheet({
   );
 }
 
+// A labelled status row for the mobile card. The desktop table conveys
+// each badge's meaning through a column header; the stacked card has none,
+// so every badge gets an explicit label to the left of it.
+function CardField({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      <div className="flex flex-wrap justify-end gap-1.5">{children}</div>
+    </div>
+  );
+}
+
 function UserCard({
   user,
   isCurrentUser,
@@ -882,18 +902,31 @@ function UserCard({
             {user.email}
           </div>
         </div>
-        <div className="flex flex-wrap gap-1.5">
-          <Badge variant={sub.variant}>{sub.label}</Badge>
-          <Badge variant={user.isAdmin ? "secondary" : "outline"}>
-            {user.isAdmin ? "Administrateur" : "Parent"}
-          </Badge>
-          {user.premiumGranted && (
-            <Badge variant="default">Premium accordé</Badge>
-          )}
-          {user.isBlocked && <Badge variant="destructive">Bloqué</Badge>}
-          {user.deletionScheduledAt && (
-            <Badge variant="destructive">Suppression programmée</Badge>
-          )}
+        <div className="space-y-2 border-t border-border/60 pt-3">
+          <CardField label="Abonnement">
+            <Badge variant={sub.variant}>{sub.label}</Badge>
+          </CardField>
+          <CardField label="Rôle">
+            <Badge variant={user.isAdmin ? "secondary" : "outline"}>
+              {user.isAdmin ? "Administrateur" : "Parent"}
+            </Badge>
+          </CardField>
+          <CardField label="Accès premium">
+            {user.premiumGranted ? (
+              <Badge variant="default">Premium accordé</Badge>
+            ) : (
+              <span className="text-xs text-muted-foreground">Non accordé</span>
+            )}
+          </CardField>
+          <CardField label="Compte">
+            {user.isBlocked && <Badge variant="destructive">Bloqué</Badge>}
+            {user.deletionScheduledAt && (
+              <Badge variant="destructive">Suppression programmée</Badge>
+            )}
+            {!user.isBlocked && !user.deletionScheduledAt && (
+              <Badge variant="outline">Actif</Badge>
+            )}
+          </CardField>
         </div>
         <p className="text-xs text-muted-foreground">
           Inscrit le {formatDate(user.createdAt)}


### PR DESCRIPTION
The stacked mobile card showed subscription, role, premium and account
badges in an unlabelled cluster, so an admin could not tell what a value
like "Aucun" referred to. The desktop table conveys this through column
headers; the card now mirrors them with an explicit label per badge.

https://claude.ai/code/session_01XDYkX96qYLaRkuZeNubGpZ