### PR TITLE
feat(admin): show email verification and sign-in method on users page

### DIFF
--- a/apps/api/src/routes/admin-users.ts
+++ b/apps/api/src/routes/admin-users.ts
@@ -9,7 +9,7 @@ import {
   updateUserPremiumSchema,
   blockUserSchema,
 } from "@focusflow/validators";
-import { db, user, subscription, session } from "@focusflow/db";
+import { db, user, subscription, session, account } from "@focusflow/db";
 
 export const adminUsersRoutes = new Hono<AppEnv>();
 
@@ -41,7 +41,8 @@ const accountColumns = {
 } as const;
 
 // GET /api/admin/users — full account list for the admin console, with
-// each user's Stripe subscription state joined in (read-only).
+// each user's Stripe subscription state and Better Auth sign-in methods
+// joined in (read-only).
 adminUsersRoutes.get("/", async (c) => {
   const me = c.get("user");
   await assertAdmin(me.id);
@@ -57,7 +58,30 @@ adminUsersRoutes.get("/", async (c) => {
     .leftJoin(subscription, eq(subscription.userId, user.id))
     .orderBy(desc(user.createdAt));
 
-  return c.json(rows);
+  // Sign-in methods live in the Better Auth `account` table — one row per
+  // linked provider ("credential" for e-mail/password, "google" for
+  // Google). Fetched separately and grouped here so the per-user provider
+  // list doesn't multiply the subscription-joined rows above.
+  const accountRows = await db
+    .select({ userId: account.userId, providerId: account.providerId })
+    .from(account);
+
+  const providersByUser = new Map<string, string[]>();
+  for (const a of accountRows) {
+    const list = providersByUser.get(a.userId);
+    if (list) {
+      if (!list.includes(a.providerId)) list.push(a.providerId);
+    } else {
+      providersByUser.set(a.userId, [a.providerId]);
+    }
+  }
+
+  return c.json(
+    rows.map((r) => ({
+      ...r,
+      authProviders: providersByUser.get(r.id) ?? [],
+    })),
+  );
 });
 
 // PATCH /api/admin/users/:id/role — grant or revoke the admin role.

--- a/apps/web/src/hooks/use-admin-users.ts
+++ b/apps/web/src/hooks/use-admin-users.ts
@@ -12,6 +12,8 @@ export type AdminUser = {
   name: string;
   email: string;
   emailVerified: boolean;
+  // Better Auth sign-in methods: "credential" (e-mail/password), "google".
+  authProviders: string[];
   isAdmin: boolean;
   premiumGranted: boolean;
   isBlocked: boolean;

--- a/apps/web/src/routes/_authenticated/admin-users/index.tsx
+++ b/apps/web/src/routes/_authenticated/admin-users/index.tsx
@@ -12,6 +12,8 @@ import {
   UserCog,
   Trash2,
   RotateCcw,
+  MailCheck,
+  MailWarning,
 } from "lucide-react";
 import {
   AlertDialog,
@@ -137,6 +139,51 @@ function subscriptionBadge(u: AdminUser): {
   }
 }
 
+// Maps a Better Auth provider id to a human label.
+function signInMethodLabel(providerId: string): string {
+  switch (providerId) {
+    case "credential":
+      return "Mot de passe";
+    case "google":
+      return "Google";
+    default:
+      return providerId;
+  }
+}
+
+// Read-only Better Auth account details: how the user signs in and
+// whether their e-mail address has been verified.
+function AuthInfo({ user }: { user: AdminUser }) {
+  return (
+    <div className="flex flex-col items-start gap-1.5">
+      <div className="flex flex-wrap gap-1">
+        {user.authProviders.length > 0 ? (
+          user.authProviders.map((p) => (
+            <Badge key={p} variant="outline">
+              {signInMethodLabel(p)}
+            </Badge>
+          ))
+        ) : (
+          <span className="text-xs text-muted-foreground">
+            Aucune méthode
+          </span>
+        )}
+      </div>
+      {user.emailVerified ? (
+        <span className="flex items-center gap-1 text-xs text-muted-foreground">
+          <MailCheck className="h-3.5 w-3.5" aria-hidden="true" />
+          E-mail vérifié
+        </span>
+      ) : (
+        <span className="flex items-center gap-1 text-xs font-medium text-amber-600 dark:text-amber-500">
+          <MailWarning className="h-3.5 w-3.5" aria-hidden="true" />
+          E-mail non vérifié
+        </span>
+      )}
+    </div>
+  );
+}
+
 function AdminUsersPage() {
   const { data, isLoading, error } = useAdminUsers();
   const session = useSession();
@@ -236,6 +283,7 @@ function AdminUsersPage() {
               <TableHeader>
                 <TableRow className="bg-muted/40">
                   <TableHead>Utilisateur</TableHead>
+                  <TableHead>Connexion</TableHead>
                   <TableHead>Inscrit le</TableHead>
                   <TableHead>Abonnement</TableHead>
                   <TableHead>Rôle</TableHead>
@@ -746,6 +794,9 @@ function UserRow({
         </div>
         <div className="text-xs text-muted-foreground">{user.email}</div>
       </TableCell>
+      <TableCell>
+        <AuthInfo user={user} />
+      </TableCell>
       <TableCell className="whitespace-nowrap text-muted-foreground">
         {formatDate(user.createdAt)}
       </TableCell>
@@ -838,6 +889,9 @@ function ManageUserSheet({
           </SheetDescription>
         </SheetHeader>
         <div className="flex flex-col gap-5 px-4 pb-4">
+          <SheetSection label="Connexion">
+            <AuthInfo user={user} />
+          </SheetSection>
           <SheetSection label="Rôle">
             <RoleControl user={user} isCurrentUser={isCurrentUser} fullWidth />
           </SheetSection>
@@ -895,6 +949,7 @@ function UserCard({
             <Badge variant="destructive">Suppression programmée</Badge>
           )}
         </div>
+        <AuthInfo user={user} />
         <p className="text-xs text-muted-foreground">
           Inscrit le {formatDate(user.createdAt)}
         </p>


### PR DESCRIPTION
The users administration page now surfaces each account's Better Auth
details: whether the e-mail address is verified and which sign-in
methods (password, Google) are linked. The emailVerified flag was
already fetched but unused; sign-in methods are joined from the
account table.

https://claude.ai/code/session_011SDY2VR4ACPddx6quqwqYV