### PR TITLE
feat: show who created each item when a child is shared with a co-parent

### DIFF
--- a/apps/api/src/lib/audit.ts
+++ b/apps/api/src/lib/audit.ts
@@ -120,6 +120,43 @@ export async function listAuditForChild(
   }));
 }
 
+// Maps each entity id to the display name of whoever first recorded it
+// ("create" action) for a given child + entity type. Powers the "Ajouté
+// par …" hint on list cards so co-parents can see who logged what.
+//
+// Prefers the write-time snapshot (resilient to user deletion), falls back
+// to the user's current name for rows that predate the snapshot. Entities
+// created before the audit feature simply have no entry — callers treat a
+// missing key as "creator unknown" and show nothing.
+export async function getCreatorNames(
+  childId: string,
+  entityType: EntityType,
+): Promise<Map<string, string>> {
+  const rows = await db
+    .select({
+      entityId: auditLog.entityId,
+      snapshotName: auditLog.actorName,
+      currentName: userTable.name,
+    })
+    .from(auditLog)
+    .leftJoin(userTable, eq(userTable.id, auditLog.actorId))
+    .where(
+      and(
+        eq(auditLog.childId, childId),
+        eq(auditLog.entityType, entityType),
+        eq(auditLog.action, "create"),
+      ),
+    );
+
+  const byEntity = new Map<string, string>();
+  for (const r of rows) {
+    if (!r.entityId) continue;
+    const name = r.snapshotName ?? r.currentName;
+    if (name) byEntity.set(r.entityId, name);
+  }
+  return byEntity;
+}
+
 // Used when a row is being inserted on a child the actor already has
 // access to, but the route handler hasn't yet re-fetched the actor's
 // display name from the session. Cheap call.

--- a/apps/api/src/lib/child-access.ts
+++ b/apps/api/src/lib/child-access.ts
@@ -42,6 +42,17 @@ export async function userIsChildOwner(
   return (await userChildRole(userId, childId)) === "owner";
 }
 
+// True when the child is managed by more than one adult (owner + at least
+// one co-parent). Drives the "Ajouté par …" attribution: for a solo parent
+// the label is noise, so callers omit it entirely when this is false.
+export async function childIsShared(childId: string): Promise<boolean> {
+  const rows = await db
+    .select({ userId: childAccess.userId })
+    .from(childAccess)
+    .where(eq(childAccess.childId, childId));
+  return rows.length > 1;
+}
+
 // Throws NOT_FOUND (not 403) on miss, deliberately — we don't leak whether
 // the child exists to a user without access.
 export async function assertChildAccess(

--- a/apps/api/src/routes/journal.ts
+++ b/apps/api/src/routes/journal.ts
@@ -9,7 +9,7 @@ import {
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess } from "../lib/child-access";
-import { logAudit } from "../lib/audit";
+import { logAudit, getCreatorNames } from "../lib/audit";
 
 function formatFrDate(value: Date | string | null | undefined): string {
   if (!value) return "";
@@ -43,7 +43,11 @@ journalRoutes.get("/:childId", async (c) => {
     .limit(limit)
     .offset(offset);
 
-  return c.json(result);
+  const creators = await getCreatorNames(childId, "journal");
+
+  return c.json(
+    result.map((e) => ({ ...e, createdByName: creators.get(e.id) ?? null })),
+  );
 });
 
 journalRoutes.post("/", async (c) => {

--- a/apps/api/src/routes/journal.ts
+++ b/apps/api/src/routes/journal.ts
@@ -8,7 +8,7 @@ import {
 } from "@focusflow/validators";
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
-import { assertChildAccess } from "../lib/child-access";
+import { assertChildAccess, childIsShared } from "../lib/child-access";
 import { logAudit, getCreatorNames } from "../lib/audit";
 
 function formatFrDate(value: Date | string | null | undefined): string {
@@ -43,10 +43,14 @@ journalRoutes.get("/:childId", async (c) => {
     .limit(limit)
     .offset(offset);
 
-  const creators = await getCreatorNames(childId, "journal");
+  // Creator attribution is only meaningful — and only shown — when the
+  // child is co-managed. Skip the audit lookup entirely for a solo parent.
+  const creators = (await childIsShared(childId))
+    ? await getCreatorNames(childId, "journal")
+    : null;
 
   return c.json(
-    result.map((e) => ({ ...e, createdByName: creators.get(e.id) ?? null })),
+    result.map((e) => ({ ...e, createdByName: creators?.get(e.id) ?? null })),
   );
 });
 

--- a/apps/api/src/routes/medications.ts
+++ b/apps/api/src/routes/medications.ts
@@ -10,7 +10,7 @@ import {
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess } from "../lib/child-access";
-import { logAudit } from "../lib/audit";
+import { logAudit, getCreatorNames } from "../lib/audit";
 
 export const medicationsRoutes = new Hono<AppEnv>();
 
@@ -37,7 +37,11 @@ medicationsRoutes.get("/:childId", async (c) => {
     .where(eq(medications.childId, childId))
     .orderBy(desc(medications.active), desc(medications.createdAt));
 
-  return c.json(result);
+  const creators = await getCreatorNames(childId, "medication");
+
+  return c.json(
+    result.map((m) => ({ ...m, createdByName: creators.get(m.id) ?? null })),
+  );
 });
 
 medicationsRoutes.post("/", async (c) => {

--- a/apps/api/src/routes/medications.ts
+++ b/apps/api/src/routes/medications.ts
@@ -9,7 +9,7 @@ import {
 } from "@focusflow/validators";
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
-import { assertChildAccess } from "../lib/child-access";
+import { assertChildAccess, childIsShared } from "../lib/child-access";
 import { logAudit, getCreatorNames } from "../lib/audit";
 
 export const medicationsRoutes = new Hono<AppEnv>();
@@ -37,10 +37,14 @@ medicationsRoutes.get("/:childId", async (c) => {
     .where(eq(medications.childId, childId))
     .orderBy(desc(medications.active), desc(medications.createdAt));
 
-  const creators = await getCreatorNames(childId, "medication");
+  // Creator attribution is only meaningful — and only shown — when the
+  // child is co-managed. Skip the audit lookup entirely for a solo parent.
+  const creators = (await childIsShared(childId))
+    ? await getCreatorNames(childId, "medication")
+    : null;
 
   return c.json(
-    result.map((m) => ({ ...m, createdByName: creators.get(m.id) ?? null })),
+    result.map((m) => ({ ...m, createdByName: creators?.get(m.id) ?? null })),
   );
 });
 

--- a/apps/api/src/routes/routines.ts
+++ b/apps/api/src/routes/routines.ts
@@ -17,7 +17,7 @@ import {
 import type { AppEnv } from "../types";
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
-import { assertChildAccess } from "../lib/child-access";
+import { assertChildAccess, childIsShared } from "../lib/child-access";
 import { logAudit, getCreatorNames } from "../lib/audit";
 
 export const routinesRoutes = new Hono<AppEnv>();
@@ -73,9 +73,13 @@ routinesRoutes.get("/:childId", async (c) => {
   await assertChildAccess(user.id, childId);
 
   const list = await loadRoutinesWithSteps(childId);
-  const creators = await getCreatorNames(childId, "routine");
+  // Creator attribution is only meaningful — and only shown — when the
+  // child is co-managed. Skip the audit lookup entirely for a solo parent.
+  const creators = (await childIsShared(childId))
+    ? await getCreatorNames(childId, "routine")
+    : null;
   return c.json(
-    list.map((r) => ({ ...r, createdByName: creators.get(r.id) ?? null })),
+    list.map((r) => ({ ...r, createdByName: creators?.get(r.id) ?? null })),
   );
 });
 

--- a/apps/api/src/routes/routines.ts
+++ b/apps/api/src/routes/routines.ts
@@ -18,7 +18,7 @@ import type { AppEnv } from "../types";
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess } from "../lib/child-access";
-import { logAudit } from "../lib/audit";
+import { logAudit, getCreatorNames } from "../lib/audit";
 
 export const routinesRoutes = new Hono<AppEnv>();
 
@@ -73,7 +73,10 @@ routinesRoutes.get("/:childId", async (c) => {
   await assertChildAccess(user.id, childId);
 
   const list = await loadRoutinesWithSteps(childId);
-  return c.json(list);
+  const creators = await getCreatorNames(childId, "routine");
+  return c.json(
+    list.map((r) => ({ ...r, createdByName: creators.get(r.id) ?? null })),
+  );
 });
 
 // ─── Today's completions for a child ────────────────────────────────────────

--- a/apps/api/src/routes/symptoms.ts
+++ b/apps/api/src/routes/symptoms.ts
@@ -9,7 +9,7 @@ import {
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess } from "../lib/child-access";
-import { logAudit } from "../lib/audit";
+import { logAudit, getCreatorNames } from "../lib/audit";
 
 function formatFrDate(value: Date | string | null | undefined): string {
   if (!value) return "";
@@ -43,7 +43,11 @@ symptomsRoutes.get("/:childId", async (c) => {
     .limit(limit)
     .offset(offset);
 
-  return c.json(result);
+  const creators = await getCreatorNames(childId, "symptom");
+
+  return c.json(
+    result.map((s) => ({ ...s, createdByName: creators.get(s.id) ?? null })),
+  );
 });
 
 symptomsRoutes.post("/", async (c) => {

--- a/apps/api/src/routes/symptoms.ts
+++ b/apps/api/src/routes/symptoms.ts
@@ -8,7 +8,7 @@ import {
 } from "@focusflow/validators";
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
-import { assertChildAccess } from "../lib/child-access";
+import { assertChildAccess, childIsShared } from "../lib/child-access";
 import { logAudit, getCreatorNames } from "../lib/audit";
 
 function formatFrDate(value: Date | string | null | undefined): string {
@@ -43,10 +43,14 @@ symptomsRoutes.get("/:childId", async (c) => {
     .limit(limit)
     .offset(offset);
 
-  const creators = await getCreatorNames(childId, "symptom");
+  // Creator attribution is only meaningful — and only shown — when the
+  // child is co-managed. Skip the audit lookup entirely for a solo parent.
+  const creators = (await childIsShared(childId))
+    ? await getCreatorNames(childId, "symptom")
+    : null;
 
   return c.json(
-    result.map((s) => ({ ...s, createdByName: creators.get(s.id) ?? null })),
+    result.map((s) => ({ ...s, createdByName: creators?.get(s.id) ?? null })),
   );
 });
 

--- a/apps/web/src/components/journal/journal-card.tsx
+++ b/apps/web/src/components/journal/journal-card.tsx
@@ -51,10 +51,7 @@ export function JournalCard({
                 month: "long",
               })}
             </CardTitle>
-            <CreatedByLabel
-              childId={entry.childId}
-              name={entry.createdByName}
-            />
+            <CreatedByLabel name={entry.createdByName} />
           </div>
           <div className="flex items-center gap-1">
             {hasActions && (

--- a/apps/web/src/components/journal/journal-card.tsx
+++ b/apps/web/src/components/journal/journal-card.tsx
@@ -8,6 +8,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { CreatedByLabel } from "@/components/shared/created-by-label";
 import type { JournalTag, JournalEntry } from "@focusflow/validators";
 
 export const tagConfig: Record<
@@ -42,13 +43,19 @@ export function JournalCard({
     <Card>
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between gap-2">
-          <CardTitle className="text-sm font-medium capitalize">
-            {new Date(entry.date).toLocaleDateString(locale, {
-              weekday: "long",
-              day: "numeric",
-              month: "long",
-            })}
-          </CardTitle>
+          <div className="min-w-0">
+            <CardTitle className="text-sm font-medium capitalize">
+              {new Date(entry.date).toLocaleDateString(locale, {
+                weekday: "long",
+                day: "numeric",
+                month: "long",
+              })}
+            </CardTitle>
+            <CreatedByLabel
+              childId={entry.childId}
+              name={entry.createdByName}
+            />
+          </div>
           <div className="flex items-center gap-1">
             {hasActions && (
               <Popover>

--- a/apps/web/src/components/shared/created-by-label.tsx
+++ b/apps/web/src/components/shared/created-by-label.tsx
@@ -1,0 +1,27 @@
+import { useTranslation } from "react-i18next";
+import { UserRound } from "lucide-react";
+import { useChildAccess } from "@/hooks/use-child-access";
+
+// Shows who first recorded an item — but only when the child is shared with a
+// co-parent. For a solo parent the attribution is pure noise, so we render
+// nothing and keep the card minimal (cf. design principles in CLAUDE.md).
+export function CreatedByLabel({
+  childId,
+  name,
+}: {
+  childId: string | null | undefined;
+  name: string | null | undefined;
+}) {
+  const { t } = useTranslation();
+  const { data: members } = useChildAccess(childId ?? "");
+  const isShared = (members?.length ?? 0) > 1;
+
+  if (!isShared || !name) return null;
+
+  return (
+    <p className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
+      <UserRound className="h-3 w-3 shrink-0" aria-hidden="true" />
+      {t("common.addedBy", { name })}
+    </p>
+  );
+}

--- a/apps/web/src/components/shared/created-by-label.tsx
+++ b/apps/web/src/components/shared/created-by-label.tsx
@@ -1,22 +1,14 @@
 import { useTranslation } from "react-i18next";
 import { UserRound } from "lucide-react";
-import { useChildAccess } from "@/hooks/use-child-access";
 
-// Shows who first recorded an item — but only when the child is shared with a
-// co-parent. For a solo parent the attribution is pure noise, so we render
-// nothing and keep the card minimal (cf. design principles in CLAUDE.md).
-export function CreatedByLabel({
-  childId,
-  name,
-}: {
-  childId: string | null | undefined;
-  name: string | null | undefined;
-}) {
+// Shows who first recorded an item. The API only sends `createdByName` when
+// the child is shared with a co-parent — for a solo parent it is always
+// null, so this renders nothing and keeps the card minimal (cf. design
+// principles in CLAUDE.md).
+export function CreatedByLabel({ name }: { name: string | null | undefined }) {
   const { t } = useTranslation();
-  const { data: members } = useChildAccess(childId ?? "");
-  const isShared = (members?.length ?? 0) > 1;
 
-  if (!isShared || !name) return null;
+  if (!name) return null;
 
   return (
     <p className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">

--- a/apps/web/src/components/symptoms/symptom-card.tsx
+++ b/apps/web/src/components/symptoms/symptom-card.tsx
@@ -96,10 +96,7 @@ export function SymptomCard({
                 month: "long",
               })}
             </CardTitle>
-            <CreatedByLabel
-              childId={symptom.childId}
-              name={symptom.createdByName}
-            />
+            <CreatedByLabel name={symptom.createdByName} />
           </div>
           <div className="flex items-center gap-1">
             {symptom.context && (

--- a/apps/web/src/components/symptoms/symptom-card.tsx
+++ b/apps/web/src/components/symptoms/symptom-card.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useDeleteSymptom } from "@/hooks/use-symptoms";
 import { useUiStore } from "@/stores/ui-store";
+import { CreatedByLabel } from "@/components/shared/created-by-label";
 import { cn } from "@/lib/utils";
 import type { Symptom } from "@focusflow/validators";
 
@@ -87,13 +88,19 @@ export function SymptomCard({
     <Card>
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
-          <CardTitle className="text-sm font-medium">
-            {new Date(symptom.date).toLocaleDateString(locale, {
-              weekday: "long",
-              day: "numeric",
-              month: "long",
-            })}
-          </CardTitle>
+          <div className="min-w-0">
+            <CardTitle className="text-sm font-medium">
+              {new Date(symptom.date).toLocaleDateString(locale, {
+                weekday: "long",
+                day: "numeric",
+                month: "long",
+              })}
+            </CardTitle>
+            <CreatedByLabel
+              childId={symptom.childId}
+              name={symptom.createdByName}
+            />
+          </div>
           <div className="flex items-center gap-1">
             {symptom.context && (
               <Badge variant="secondary">{symptom.context}</Badge>

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -12,7 +12,8 @@
     "french": "French",
     "english": "English",
     "add": "Add",
-    "viewAll": "View all"
+    "viewAll": "View all",
+    "addedBy": "Added by {{name}}"
   },
   "errors": {
     "generic": "An error occurred",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -12,7 +12,8 @@
     "french": "Français",
     "english": "Anglais",
     "add": "Ajouter",
-    "viewAll": "Voir tout"
+    "viewAll": "Voir tout",
+    "addedBy": "Ajouté par {{name}}"
   },
   "errors": {
     "generic": "Une erreur est survenue",

--- a/apps/web/src/routes/_authenticated/medications/index.tsx
+++ b/apps/web/src/routes/_authenticated/medications/index.tsx
@@ -24,6 +24,7 @@ import {
 } from "@/components/ui/select";
 import { PageLoader } from "@/components/ui/page-loader";
 import { PageHeader } from "@/components/layout/page-header";
+import { CreatedByLabel } from "@/components/shared/created-by-label";
 import {
   useMedications,
   useCreateMedication,
@@ -127,6 +128,10 @@ function MedicationsPage() {
                     {SCHEDULE_LABELS[med.schedule as MedicationSchedule]}
                     {med.notes ? ` · ${med.notes}` : ""}
                   </p>
+                  <CreatedByLabel
+                    childId={med.childId}
+                    name={med.createdByName}
+                  />
                 </div>
                 <div className="flex shrink-0 gap-1">
                   <Button

--- a/apps/web/src/routes/_authenticated/medications/index.tsx
+++ b/apps/web/src/routes/_authenticated/medications/index.tsx
@@ -128,10 +128,7 @@ function MedicationsPage() {
                     {SCHEDULE_LABELS[med.schedule as MedicationSchedule]}
                     {med.notes ? ` · ${med.notes}` : ""}
                   </p>
-                  <CreatedByLabel
-                    childId={med.childId}
-                    name={med.createdByName}
-                  />
+                  <CreatedByLabel name={med.createdByName} />
                 </div>
                 <div className="flex shrink-0 gap-1">
                   <Button

--- a/apps/web/src/routes/_authenticated/routines/routines-page.tsx
+++ b/apps/web/src/routes/_authenticated/routines/routines-page.tsx
@@ -69,6 +69,7 @@ import {
 } from "@/components/ui/select";
 import { PageLoader } from "@/components/ui/page-loader";
 import { PageHeader } from "@/components/layout/page-header";
+import { CreatedByLabel } from "@/components/shared/created-by-label";
 import { EmojiPicker, ROUTINE_STEP_EMOJIS } from "@/components/emoji-picker";
 import { useUiStore } from "@/stores/ui-store";
 import {
@@ -484,6 +485,10 @@ function RoutineCard({
                 </span>
               )}
             </p>
+            <CreatedByLabel
+              childId={routine.childId}
+              name={routine.createdByName}
+            />
           </div>
           <ChevronDown
             aria-hidden="true"

--- a/apps/web/src/routes/_authenticated/routines/routines-page.tsx
+++ b/apps/web/src/routes/_authenticated/routines/routines-page.tsx
@@ -485,10 +485,7 @@ function RoutineCard({
                 </span>
               )}
             </p>
-            <CreatedByLabel
-              childId={routine.childId}
-              name={routine.createdByName}
-            />
+            <CreatedByLabel name={routine.createdByName} />
           </div>
           <ChevronDown
             aria-hidden="true"

--- a/packages/validators/src/journal.ts
+++ b/packages/validators/src/journal.ts
@@ -25,6 +25,10 @@ export const journalEntrySchema = createJournalEntrySchema.extend({
   id: z.string().uuid(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+  // Display name of the parent who first recorded this entry. Surfaced on the
+  // card when the child is shared with a co-parent so the family can see who
+  // logged what.
+  createdByName: z.string().nullable().optional(),
 });
 
 export type JournalTag = z.infer<typeof journalTagSchema>;

--- a/packages/validators/src/medication.ts
+++ b/packages/validators/src/medication.ts
@@ -27,6 +27,10 @@ export const medicationSchema = createMedicationSchema.extend({
   id: z.string().uuid(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+  // Display name of the parent who added this treatment. Surfaced on the card
+  // when the child is shared with a co-parent so the family can see who
+  // logged what.
+  createdByName: z.string().nullable().optional(),
 });
 
 export const createMedicationLogSchema = z.object({

--- a/packages/validators/src/routine.ts
+++ b/packages/validators/src/routine.ts
@@ -86,6 +86,10 @@ export const routineSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   steps: z.array(routineStepSchema),
+  // Display name of the parent who created this routine. Surfaced on the card
+  // when the child is shared with a co-parent so the family can see who
+  // logged what.
+  createdByName: z.string().nullable().optional(),
 });
 
 export const routineCompletionSchema = z.object({

--- a/packages/validators/src/symptom.ts
+++ b/packages/validators/src/symptom.ts
@@ -23,6 +23,10 @@ export const symptomSchema = createSymptomSchema.extend({
   id: z.string().uuid(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
+  // Display name of the parent who first recorded this entry. Surfaced on the
+  // card when the child is shared with a co-parent so the family can see who
+  // logged what.
+  createdByName: z.string().nullable().optional(),
 });
 
 export type CreateSymptom = z.infer<typeof createSymptomSchema>;


### PR DESCRIPTION
Symptom, journal, medication and routine cards now display "Ajouté par …"
so families managing a child together can see who logged what. The label
is sourced from the existing audit ledger (no migration needed) and only
appears when the child actually has a co-parent — for a solo parent it
would be noise.

https://claude.ai/code/session_01MZtfea7Av3KwLR5rW3L3Uy