### PR TITLE
feat: improve SEO meta coverage on public routes

### DIFF
--- a/apps/web/public/sitemap.xml
+++ b/apps/web/public/sitemap.xml
@@ -2,96 +2,139 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://toko.battistella.ovh/</loc>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/login</loc>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/tarifs</loc>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/contact</loc>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/mentions-legales</loc>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/confidentialite</loc>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/ressources</loc>
+    <lastmod>2026-05-16</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/ressources/plan-de-crise</loc>
+    <lastmod>2026-05-18</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/ressources/crise-tdah-enfant-guide-complet</loc>
+    <lastmod>2026-02-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/ressources/dysregulation-emotionnelle-tdah</loc>
+    <lastmod>2026-02-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/ressources/co-regulation-parent-enfant-tdah</loc>
+    <lastmod>2026-02-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/ressources/deconnexion-emotionnelle-tdah</loc>
+    <lastmod>2026-02-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/ressources/fonctions-executives-tdah-enfant</loc>
+    <lastmod>2026-02-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/ressources/hypersensibilite-sensorielle-tdah</loc>
+    <lastmod>2026-02-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/ressources/troubles-sommeil-tdah-enfant</loc>
+    <lastmod>2026-02-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/ressources/mini-guide-grands-parents-tdah</loc>
+    <lastmod>2026-02-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/ressources/mini-guide-co-parent-tdah</loc>
+    <lastmod>2026-02-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/ressources/mini-guide-parrains-marraines-tdah</loc>
+    <lastmod>2026-02-01</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://toko.battistella.ovh/ressources/apres-le-diagnostic-tdah-parcours-de-soins</loc>
+    <lastmod>2026-04-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://toko.battistella.ovh/ressources/medication-tdah-mythes-parents</loc>
+    <lastmod>2026-04-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://toko.battistella.ovh/ressources/tdah-ecrans-ne-causent-pas</loc>
+    <lastmod>2026-04-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://toko.battistella.ovh/ressources/motivation-delai-tdah-pourquoi-punition-echoue</loc>
+    <lastmod>2026-04-07</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://toko.battistella.ovh/ressources/parent-tdah-gerer-mes-propres-crises</loc>
+    <lastmod>2026-04-07</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/apps/web/src/routes/confidentialite.tsx
+++ b/apps/web/src/routes/confidentialite.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft } from "lucide-react";
+import { useSeoHead } from "@/hooks/use-seo-head";
 
 export const Route = createFileRoute("/confidentialite")({
   component: Confidentialite,
@@ -8,6 +9,12 @@ export const Route = createFileRoute("/confidentialite")({
 
 function Confidentialite() {
   const { t } = useTranslation();
+  useSeoHead({
+    title: "Politique de confidentialité — Tokō",
+    description:
+      "Comment Tokō protège vos données : données collectées, usage, durée de conservation et vos droits RGPD — accès, suppression, portabilité.",
+    canonical: "https://toko.battistella.ovh/confidentialite",
+  });
   return (
     <div className="mx-auto max-w-3xl px-4 py-16">
       <Link

--- a/apps/web/src/routes/contact.tsx
+++ b/apps/web/src/routes/contact.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft, Mail } from "lucide-react";
+import { useSeoHead } from "@/hooks/use-seo-head";
 
 export const Route = createFileRoute("/contact")({
   component: Contact,
@@ -8,6 +9,12 @@ export const Route = createFileRoute("/contact")({
 
 function Contact() {
   const { t } = useTranslation();
+  useSeoHead({
+    title: "Contacter Tokō — aide et support",
+    description:
+      "Une question sur Tokō ou sur vos données ? Écrivez-nous par email. Nous aidons les parents qui utilisent l'application au quotidien.",
+    canonical: "https://toko.battistella.ovh/contact",
+  });
   return (
     <div className="mx-auto max-w-3xl px-4 py-16">
       <Link

--- a/apps/web/src/routes/developers.tsx
+++ b/apps/web/src/routes/developers.tsx
@@ -29,6 +29,7 @@ import { Callout } from "@/components/ui/callout";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
+import { useSeoHead } from "@/hooks/use-seo-head";
 
 // Section "Développeurs" de Tokō. Page publique, accessible depuis le pied
 // de page. Elle permet à un parent de connecter son propre assistant IA
@@ -76,6 +77,12 @@ function CodeBlock({ code }: { code: string }) {
 }
 
 function DevelopersPage() {
+  useSeoHead({
+    title: "Développeurs — connecter un assistant IA | Tokō",
+    description:
+      "Connectez votre assistant IA à vos données Tokō en lecture seule via le serveur MCP ou la ligne de commande. Générez une clé d'accès, gardez le contrôle.",
+    canonical: "https://toko.battistella.ovh/developers",
+  });
   const { data: session } = useSession();
   const isLoggedIn = Boolean(session?.user);
   const apiOrigin =

--- a/apps/web/src/routes/forgot-password.tsx
+++ b/apps/web/src/routes/forgot-password.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { forgetPassword } from "@/lib/auth-client";
+import { useSeoHead } from "@/hooks/use-seo-head";
 
 export const Route = createFileRoute("/forgot-password")({
   component: ForgotPasswordPage,
@@ -15,6 +16,12 @@ export const Route = createFileRoute("/forgot-password")({
 
 function ForgotPasswordPage() {
   const { t } = useTranslation();
+  useSeoHead({
+    title: "Mot de passe oublié — Tokō",
+    description:
+      "Réinitialisez le mot de passe de votre compte Tokō. Saisissez votre adresse email pour recevoir un lien de réinitialisation.",
+    canonical: "https://toko.battistella.ovh/forgot-password",
+  });
   const [email, setEmail] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -34,6 +34,7 @@ import {
 import { authClient } from "@/lib/auth-client";
 import { articles } from "@/lib/resources-data";
 import { PricingSection } from "@/components/landing/pricing-section";
+import { useSeoHead } from "@/hooks/use-seo-head";
 
 export const Route = createFileRoute("/")({
   beforeLoad: async () => {
@@ -60,6 +61,14 @@ const trustKeys = [
 const testimonialKeys = ["t1", "t2", "t3"] as const;
 
 function LandingPage() {
+  useSeoHead({
+    title:
+      "Tokō — App TDAH enfant pour parents épuisés | Routines, suivi, plan de crise",
+    description:
+      "Tokō aide les parents TDAH à gérer le quotidien de leurs enfants TDAH. Routines simplifiées, suivi des symptômes, plan de crise, récompenses. Sans charge mentale.",
+    canonical: "https://toko.battistella.ovh/",
+  });
+
   return (
     <div className="min-h-dvh bg-background">
       <Nav />

--- a/apps/web/src/routes/login.tsx
+++ b/apps/web/src/routes/login.tsx
@@ -11,6 +11,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Separator } from "@/components/ui/separator";
 import { authClient, signIn, signUp } from "@/lib/auth-client";
 import { trackEvent } from "@/lib/analytics";
+import { useSeoHead } from "@/hooks/use-seo-head";
 
 export const Route = createFileRoute("/login")({
   component: LoginPage,
@@ -18,6 +19,12 @@ export const Route = createFileRoute("/login")({
 
 function LoginPage() {
   const { t } = useTranslation();
+  useSeoHead({
+    title: "Connexion et inscription — Tokō",
+    description:
+      "Connectez-vous à Tokō ou créez votre compte gratuit. Journal, plan de crise et suivi du TDAH de votre enfant. Sans carte bancaire.",
+    canonical: "https://toko.battistella.ovh/login",
+  });
   return (
     <div className="relative flex min-h-dvh items-center justify-center bg-background px-4">
       {/* Warm ambient glow */}

--- a/apps/web/src/routes/mentions-legales.tsx
+++ b/apps/web/src/routes/mentions-legales.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft } from "lucide-react";
+import { useSeoHead } from "@/hooks/use-seo-head";
 
 export const Route = createFileRoute("/mentions-legales")({
   component: MentionsLegales,
@@ -8,6 +9,12 @@ export const Route = createFileRoute("/mentions-legales")({
 
 function MentionsLegales() {
   const { t } = useTranslation();
+  useSeoHead({
+    title: "Mentions légales — Tokō",
+    description:
+      "Mentions légales de Tokō : éditeur du site, hébergement, propriété intellectuelle et traitement des données personnelles.",
+    canonical: "https://toko.battistella.ovh/mentions-legales",
+  });
   return (
     <div className="mx-auto max-w-3xl px-4 py-16">
       <Link

--- a/apps/web/src/routes/reset-password.tsx
+++ b/apps/web/src/routes/reset-password.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { resetPassword } from "@/lib/auth-client";
+import { useSeoHead } from "@/hooks/use-seo-head";
 
 type ResetPasswordSearch = { token: string };
 
@@ -29,6 +30,13 @@ export const Route = createFileRoute("/reset-password")({
 
 function ResetPasswordPage() {
   const { t } = useTranslation();
+  // Explicit canonical so the one-time ?token= param never leaks into
+  // the canonical / og:url tags.
+  useSeoHead({
+    title: "Nouveau mot de passe — Tokō",
+    description: "Choisissez un nouveau mot de passe pour votre compte Tokō.",
+    canonical: "https://toko.battistella.ovh/reset-password",
+  });
   const { token } = Route.useSearch();
   const [password, setPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);

--- a/apps/web/src/routes/ressources/plan-de-crise.tsx
+++ b/apps/web/src/routes/ressources/plan-de-crise.tsx
@@ -13,6 +13,20 @@ function PlanDeCrisePage() {
         title: "Mon plan de crise TDAH — modèle à imprimer | Tokō",
         description:
             "Modèle gratuit de plan de crise TDAH à imprimer et afficher. Trois colonnes : signes de montée, mes gestes, ce que je ne fais plus.",
+        canonical: "https://toko.battistella.ovh/ressources/plan-de-crise",
+        jsonLd: {
+            "@context": "https://schema.org",
+            "@type": "WebPage",
+            name: "Mon plan de crise TDAH — modèle à imprimer",
+            description:
+                "Modèle gratuit de plan de crise TDAH à imprimer et afficher. Trois colonnes : signes de montée, mes gestes, ce que je ne fais plus.",
+            inLanguage: "fr-FR",
+            isPartOf: {
+                "@type": "WebSite",
+                name: "Tokō",
+                url: "https://toko.battistella.ovh/",
+            },
+        },
     });
 
     return (


### PR DESCRIPTION
Add per-route head tags via useSeoHead to the landing page and all
public/auth routes that previously inherited the generic index.html
title and description (landing, contact, mentions-légales,
confidentialité, développeurs, login, forgot/reset password). The
reset-password route gets an explicit canonical so the one-time
?token= param never leaks into canonical/og:url.

Add canonical + WebPage JSON-LD to the plan-de-crise resource page.

Add <lastmod> to every sitemap entry and list the four published
resource articles that were missing from sitemap.xml.

https://claude.ai/code/session_01RzsB9ioVU3b6TrKX4AKNq7