### PR TITLE
docs: document VAPID env vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,6 +79,18 @@ ENABLE_SCHEDULER=false
 # in compose.yml so morning/evening reminders fire at the local clock.
 SCHEDULER_TIMEZONE=Europe/Paris
 
+# ─── Web Push (VAPID — optional) ──────────────────────
+# Browser push notifications for co-parent activity (business rule B4).
+# Generate the key pair once: npx web-push generate-vapid-keys
+# Both keys must be set or push fan-out silently no-ops (see lib/push.ts).
+# Regenerating them invalidates every existing browser subscription —
+# treat them as long-lived secrets and keep them stable.
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+# Contact URI surfaced to push services so they can reach you about a
+# misbehaving sender. mailto: or https URL. Defaults to mailto:no-reply@toko.app.
+VAPID_SUBJECT=mailto:no-reply@toko.app
+
 # ─── E2E tests (optional) ─────────────────────────────
 E2E_WEB_PORT=5176
 


### PR DESCRIPTION
## Summary

The web push backend already reads three VAPID env vars but they were never documented in `.env.example`:

- `apps/api/src/lib/env.ts` declares `VAPID_PUBLIC_KEY`, `VAPID_PRIVATE_KEY` (optional) and `VAPID_SUBJECT` (default `mailto:no-reply@toko.app`).
- `apps/api/src/lib/push.ts` `ensureVapid()` configures `web-push` only when both keys are present; otherwise every `sendPushToUser` / `notifyCoParents` call silently no-ops.

This adds a `Web Push (VAPID — optional)` block so the keys needed to enable co-parent push (business rule B4) are discoverable.

Docs-only — no code change, no behaviour change.

## Note

Web push is still half-built: the frontend has no service-worker push handler or `pushManager.subscribe` flow yet (`routes/push.ts` notes the keys are "wired in a follow-up commit"). Configuring these keys alone won't make push work end-to-end until that frontend flow lands.

## Test plan

- [ ] `.env.example` parses / no stray syntax
- [ ] Comment block matches the file's existing section style

🤖 Generated with [Claude Code](https://claude.com/claude-code)