### PR TITLE
feat: integrate GoatCounter web analytics

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -5,6 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Toko — Guider votre enfant TDAH</title>
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <script>
+      window.goatcounter = { no_onload: true };
+    </script>
+    <script
+      data-goatcounter="https://toko-stats.battistella.ovh/count"
+      async
+      src="//toko-stats.battistella.ovh/count.js"
+    ></script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -1,0 +1,22 @@
+declare global {
+  interface Window {
+    goatcounter?: {
+      count?: (vars: { path: string }) => void;
+      no_onload?: boolean;
+    };
+  }
+}
+
+const MAX_ATTEMPTS = 20;
+
+// count.js loads async, so window.goatcounter.count may not exist on the
+// first route resolution — retry until it is ready, then give up silently
+// (e.g. when the script is blocked).
+export function trackPageview(path: string, attempt = 0): void {
+  const gc = window.goatcounter;
+  if (gc?.count) {
+    gc.count({ path });
+  } else if (attempt < MAX_ATTEMPTS) {
+    window.setTimeout(() => trackPageview(path, attempt + 1), 500);
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,10 +3,15 @@ import { createRoot } from "react-dom/client";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/lib/query-client";
+import { trackPageview } from "@/lib/analytics";
 import { routeTree } from "./routeTree.gen";
 import "./app.css";
 
 const router = createRouter({ routeTree });
+
+router.subscribe("onResolved", () => {
+  trackPageview(location.pathname);
+});
 
 declare module "@tanstack/react-router" {
   interface Register {


### PR DESCRIPTION
## Summary

The GoatCounter dashboard for `toko-stats.battistella.ovh` was showing *"No data received"* — the tracking script was never added to the app. This wires it up.

- Add the GoatCounter loader to `apps/web/index.html`, with `window.goatcounter = { no_onload: true }` set first so it does not auto-count on load.
- New `apps/web/src/lib/analytics.ts` — `trackPageview()` helper that retries until the async `count.js` is ready, then gives up silently (e.g. when blocked by an adblocker).
- Subscribe to the TanStack Router `onResolved` event in `main.tsx` to count a pageview on every navigation, including the initial load.

### Notes
- `no_onload` means the SPA counts each route exactly once — no double-count of the landing page.
- Counts `location.pathname` only (not search params), so views group cleanly per page instead of fragmenting by the child-ID UUIDs carried in query strings.

## Test plan

- [ ] CI passes (typecheck + tests)
- [ ] After deploy, navigate a few pages on `toko.battistella.ovh` and confirm pageviews appear in the `toko-stats.battistella.ovh` GoatCounter dashboard
- [ ] Confirm route changes (not just the landing page) are counted

🤖 Generated with [Claude Code](https://claude.com/claude-code)