### PR TITLE
feat: Add Web Push notifications for co-parent activity

### DIFF
--- a/apps/api/src/routes/push.ts
+++ b/apps/api/src/routes/push.ts
@@ -4,6 +4,7 @@ import type { AppEnv } from "../types";
 import { authMiddleware } from "../middleware/auth";
 import { db, pushSubscriptions } from "@focusflow/db";
 import { pushSubscriptionSchema } from "@focusflow/validators";
+import { env } from "../lib/env";
 
 export const pushRoutes = new Hono<AppEnv>();
 
@@ -12,15 +13,21 @@ pushRoutes.use("*", authMiddleware);
 /**
  * Business rule B4: Web Push subscription management.
  *
+ * GET    /api/push/public-key    → VAPID public key for the browser's
+ *                                  PushManager.subscribe call, or null
+ *                                  when push is not configured server-side
  * POST   /api/push/subscribe     → register a PushSubscription for the
  *                                  current user (idempotent on endpoint)
  * DELETE /api/push/subscribe     → remove a single endpoint
  *
  * Broadcasting is handled out-of-band by the email-jobs-style cron and
  * gated by `isTunnelHourIn(tz)` before fanning out non-critical pushes.
- * VAPID keys live in env (`VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY`) and
- * are wired in a follow-up commit.
+ * VAPID keys live in env (`VAPID_PUBLIC_KEY` / `VAPID_PRIVATE_KEY`).
  */
+pushRoutes.get("/public-key", (c) => {
+  return c.json({ publicKey: env.VAPID_PUBLIC_KEY ?? null });
+});
+
 pushRoutes.post("/subscribe", async (c) => {
   const currentUser = c.get("user");
   const body = await c.req.json().catch(() => ({}));

--- a/apps/web/public/push-sw.js
+++ b/apps/web/public/push-sw.js
@@ -1,0 +1,48 @@
+// Web Push handlers, pulled into the Workbox-generated service worker via
+// vite-plugin-pwa's `workbox.importScripts`. The generated SW only handles
+// caching — these listeners add notification display and click routing.
+
+self.addEventListener("push", (event) => {
+  if (!event.data) return;
+
+  let payload;
+  try {
+    payload = event.data.json();
+  } catch {
+    payload = { title: "Tokō", body: event.data.text() };
+  }
+
+  const title = payload.title || "Tokō";
+  event.waitUntil(
+    self.registration.showNotification(title, {
+      body: payload.body || "",
+      icon: "/icon.svg",
+      badge: "/icon.svg",
+      // Same tag collapses rapid events on one child into the latest entry.
+      tag: payload.tag,
+      data: { url: payload.url || "/" },
+    }),
+  );
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = (event.notification.data && event.notification.data.url) || "/";
+
+  event.waitUntil(
+    self.clients
+      .matchAll({ type: "window", includeUncontrolled: true })
+      .then((clientList) => {
+        // Reuse an open tab when there is one, otherwise open a new window.
+        const existing = clientList.find((client) => "focus" in client);
+        if (existing) {
+          existing.focus();
+          if ("navigate" in existing) {
+            existing.navigate(url).catch(() => {});
+          }
+          return undefined;
+        }
+        return self.clients.openWindow(url);
+      }),
+  );
+});

--- a/apps/web/src/components/account/notifications-card.tsx
+++ b/apps/web/src/components/account/notifications-card.tsx
@@ -11,6 +11,8 @@ import {
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { usePreferences, useUpdatePreferences } from "@/hooks/use-preferences";
+import { usePush } from "@/hooks/use-push";
+import { reconcilePushSubscription, type PushEnableResult } from "@/lib/push";
 
 const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
 
@@ -18,9 +20,13 @@ export function NotificationsCard() {
   const { t } = useTranslation();
   const { data, isLoading } = usePreferences();
   const update = useUpdatePreferences();
+  const push = usePush();
 
   const [morningTime, setMorningTime] = useState("09:00");
   const [eveningTime, setEveningTime] = useState("20:30");
+  const [enableResult, setEnableResult] = useState<PushEnableResult | null>(
+    null,
+  );
 
   useEffect(() => {
     if (data) {
@@ -28,6 +34,12 @@ export function NotificationsCard() {
       setEveningTime(data.eveningReminderTime);
     }
   }, [data]);
+
+  useEffect(() => {
+    if (data?.coParentActivityOptIn) {
+      void reconcilePushSubscription(true);
+    }
+  }, [data?.coParentActivityOptIn]);
 
   if (isLoading || !data) return null;
 
@@ -46,6 +58,34 @@ export function NotificationsCard() {
     }
     update.mutate({ eveningReminderTime: eveningTime });
   };
+
+  // Single toggle: enabling requests browser permission + subscribes
+  // before the account preference flips, so the two never drift apart.
+  const toggleCoParentActivity = async (checked: boolean) => {
+    if (checked) {
+      const result = await push.enable();
+      setEnableResult(result);
+      if (result === "subscribed") {
+        update.mutate({ coParentActivityOptIn: true });
+      }
+    } else {
+      setEnableResult(null);
+      await push.disable();
+      update.mutate({ coParentActivityOptIn: false });
+    }
+  };
+
+  let coParentHint: "unsupported" | "blocked" | "unavailable" | null = null;
+  if (!push.isSupported) {
+    coParentHint = "unsupported";
+  } else if (
+    enableResult === "denied" ||
+    (data.coParentActivityOptIn && push.permission === "denied")
+  ) {
+    coParentHint = "blocked";
+  } else if (enableResult === "unconfigured") {
+    coParentHint = "unavailable";
+  }
 
   return (
     <Card>
@@ -165,28 +205,40 @@ export function NotificationsCard() {
             }
           />
         </label>
-        <label
-          htmlFor="co-parent-activity"
-          className="flex min-h-14 cursor-pointer items-center justify-between gap-4 rounded-lg border border-border/60 px-3 py-2.5"
-        >
-          <div className="space-y-0.5">
-            <span className="block text-sm font-medium">
-              {t("notifications.coParentActivity")}
-            </span>
-            <p className="text-xs text-muted-foreground">
-              {t("notifications.coParentActivityBody")}
+        <div className="rounded-lg border border-border/60 px-3 py-2.5">
+          <label
+            htmlFor="co-parent-activity"
+            className="flex min-h-10 cursor-pointer items-center justify-between gap-4"
+          >
+            <div className="space-y-0.5">
+              <span className="block text-sm font-medium">
+                {t("notifications.coParentActivity")}
+              </span>
+              <p className="text-xs text-muted-foreground">
+                {t("notifications.coParentActivityBody")}
+              </p>
+            </div>
+            <Checkbox
+              id="co-parent-activity"
+              className="h-5 w-5"
+              checked={data.coParentActivityOptIn}
+              disabled={!push.isSupported || push.isBusy || update.isPending}
+              onCheckedChange={(checked) =>
+                toggleCoParentActivity(checked === true)
+              }
+            />
+          </label>
+          {coParentHint && (
+            <p className="mt-2.5 border-t border-border/40 pt-2.5 text-xs text-muted-foreground">
+              {coParentHint === "unsupported" &&
+                t("notifications.coParentActivityUnsupported")}
+              {coParentHint === "blocked" &&
+                t("notifications.coParentActivityBlocked")}
+              {coParentHint === "unavailable" &&
+                t("notifications.coParentActivityUnavailable")}
             </p>
-          </div>
-          <Checkbox
-            id="co-parent-activity"
-            className="h-5 w-5"
-            checked={data.coParentActivityOptIn}
-            disabled={update.isPending}
-            onCheckedChange={(checked) =>
-              update.mutate({ coParentActivityOptIn: checked === true })
-            }
-          />
-        </label>
+          )}
+        </div>
       </CardContent>
     </Card>
   );

--- a/apps/web/src/hooks/use-push.ts
+++ b/apps/web/src/hooks/use-push.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from "react";
+import {
+  isPushSupported,
+  subscribeToPush,
+  unsubscribeFromPush,
+  type PushEnableResult,
+} from "@/lib/push";
+
+export interface UsePushResult {
+  isSupported: boolean;
+  permission: NotificationPermission;
+  isBusy: boolean;
+  enable: () => Promise<PushEnableResult>;
+  disable: () => Promise<void>;
+}
+
+function currentPermission(): NotificationPermission {
+  return typeof Notification !== "undefined" ? Notification.permission : "denied";
+}
+
+export function usePush(): UsePushResult {
+  const [isSupported] = useState(isPushSupported);
+  const [permission, setPermission] = useState<NotificationPermission>(
+    currentPermission,
+  );
+  const [isBusy, setIsBusy] = useState(false);
+
+  const enable = useCallback(async (): Promise<PushEnableResult> => {
+    setIsBusy(true);
+    try {
+      const result = await subscribeToPush();
+      setPermission(currentPermission());
+      return result;
+    } catch {
+      // A network or PushManager failure leaves the toggle off; the user
+      // can retry. Reported as "dismissed" to avoid a misleading message.
+      return "dismissed";
+    } finally {
+      setIsBusy(false);
+    }
+  }, []);
+
+  const disable = useCallback(async (): Promise<void> => {
+    setIsBusy(true);
+    try {
+      await unsubscribeFromPush();
+    } catch {
+      // The browser unsubscribe may have succeeded even if the API call
+      // failed — a dead endpoint gets pruned server-side on the next send.
+    } finally {
+      setIsBusy(false);
+    }
+  }, []);
+
+  return { isSupported, permission, isBusy, enable, disable };
+}

--- a/apps/web/src/lib/__tests__/push.test.ts
+++ b/apps/web/src/lib/__tests__/push.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { urlBase64ToUint8Array } from "../push";
+
+describe("urlBase64ToUint8Array", () => {
+  it("decodes url-safe characters and restores missing padding", () => {
+    // base64url "-_8" → base64 "+/8=" → bytes [0xFB, 0xFF]
+    expect(Array.from(urlBase64ToUint8Array("-_8"))).toEqual([0xfb, 0xff]);
+  });
+
+  it("decodes a standard base64url value", () => {
+    // "AQID" → bytes [1, 2, 3]
+    expect(Array.from(urlBase64ToUint8Array("AQID"))).toEqual([1, 2, 3]);
+  });
+
+  it("produces a 65-byte key from an 87-char VAPID public key", () => {
+    const key = "B" + "A".repeat(86);
+    expect(urlBase64ToUint8Array(key).length).toBe(65);
+  });
+});

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -576,7 +576,10 @@
     "weeklyDigest": "Weekly digest",
     "weeklyDigestBody": "Sunday at 6pm: consistency, trend, stars.",
     "coParentActivity": "Co-parent activity",
-    "coParentActivityBody": "Push when your co-parent logs a symptom, journal entry, or medication."
+    "coParentActivityBody": "Push when your co-parent logs a symptom, journal entry, or medication.",
+    "coParentActivityUnsupported": "Your browser does not support notifications.",
+    "coParentActivityBlocked": "Notifications are blocked by your browser. Allow them in the site settings to enable this option.",
+    "coParentActivityUnavailable": "Notifications are not available right now."
   },
   "resourceHint": {
     "title": "Suggested read this week",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -619,7 +619,10 @@
     "weeklyDigest": "Bilan hebdomadaire",
     "weeklyDigestBody": "Le dimanche à 18h : constance, tendance, étoiles.",
     "coParentActivity": "Activité du co-parent",
-    "coParentActivityBody": "Push quand votre co-parent ajoute un symptôme, un journal ou un médicament."
+    "coParentActivityBody": "Push quand votre co-parent ajoute un symptôme, un journal ou un médicament.",
+    "coParentActivityUnsupported": "Votre navigateur ne prend pas en charge les notifications.",
+    "coParentActivityBlocked": "Les notifications sont bloquées par votre navigateur. Autorisez-les dans les réglages du site pour activer cette option.",
+    "coParentActivityUnavailable": "Les notifications ne sont pas disponibles pour le moment."
   },
   "solidarity": {
     "title": "Tarif solidaire",

--- a/apps/web/src/lib/push.ts
+++ b/apps/web/src/lib/push.ts
@@ -1,0 +1,96 @@
+import { api } from "@/lib/api-client";
+
+// Outcome of an attempt to turn on co-parent push notifications.
+export type PushEnableResult =
+  | "subscribed"
+  | "denied"
+  | "dismissed"
+  | "unconfigured"
+  | "unsupported";
+
+// Converts the base64url VAPID public key into the Uint8Array shape
+// PushManager.subscribe expects for `applicationServerKey`.
+export function urlBase64ToUint8Array(base64: string): Uint8Array<ArrayBuffer> {
+  const padding = "=".repeat((4 - (base64.length % 4)) % 4);
+  const normalized = (base64 + padding).replace(/-/g, "+").replace(/_/g, "/");
+  const raw = atob(normalized);
+  const output = new Uint8Array(new ArrayBuffer(raw.length));
+  for (let i = 0; i < raw.length; i += 1) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}
+
+export function isPushSupported(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    "serviceWorker" in navigator &&
+    typeof window !== "undefined" &&
+    "PushManager" in window &&
+    "Notification" in window
+  );
+}
+
+async function getServerPublicKey(): Promise<string | null> {
+  const res = await api.get<{ publicKey: string | null }>("/push/public-key");
+  return res.publicKey;
+}
+
+// Requests notification permission, subscribes via PushManager and
+// registers the subscription with the API. The caller surfaces the
+// result so a blocked/unsupported state can be explained to the user.
+export async function subscribeToPush(): Promise<PushEnableResult> {
+  if (!isPushSupported()) return "unsupported";
+
+  const permission = await Notification.requestPermission();
+  if (permission === "denied") return "denied";
+  if (permission !== "granted") return "dismissed";
+
+  const publicKey = await getServerPublicKey();
+  if (!publicKey) return "unconfigured";
+
+  const registration = await navigator.serviceWorker.ready;
+  let subscription = await registration.pushManager.getSubscription();
+  if (!subscription) {
+    subscription = await registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(publicKey),
+    });
+  }
+
+  await api.post<{ subscribed: boolean }>(
+    "/push/subscribe",
+    subscription.toJSON(),
+  );
+  return "subscribed";
+}
+
+// Removes this device's subscription from the browser and the API.
+export async function unsubscribeFromPush(): Promise<void> {
+  if (!isPushSupported()) return;
+
+  const registration = await navigator.serviceWorker.ready;
+  const subscription = await registration.pushManager.getSubscription();
+  if (!subscription) return;
+
+  const { endpoint } = subscription;
+  await subscription.unsubscribe();
+  await api.delete<{ subscribed: boolean }>("/push/subscribe", { endpoint });
+}
+
+// Keeps the browser subscription consistent with the account preference.
+// Runs on load: if the user opted in and permission is granted but this
+// device lost its subscription (cleared storage, new device), resubscribe
+// silently. No-op in every other case.
+export async function reconcilePushSubscription(
+  optedIn: boolean,
+): Promise<void> {
+  if (!optedIn || !isPushSupported()) return;
+  if (Notification.permission !== "granted") return;
+
+  const registration = await navigator.serviceWorker.ready;
+  const existing = await registration.pushManager.getSubscription();
+  if (existing) return;
+
+  await subscribeToPush().catch(() => {});
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -34,6 +34,8 @@ export default defineConfig({
         maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
         navigateFallback: "/index.html",
         navigateFallbackDenylist: [/^\/api\//],
+        // Pulls the Web Push handlers into the generated service worker.
+        importScripts: ["push-sw.js"],
         runtimeCaching: [
           {
             urlPattern: ({ url }) => url.pathname.startsWith("/api/"),


### PR DESCRIPTION
## Summary

Implements Web Push notification support for co-parent activity alerts. Users can now opt in to receive browser push notifications when their co-parent logs symptoms, journal entries, or medications. The feature includes graceful degradation for unsupported browsers and clear messaging when notifications are blocked.

## Key Changes

- **Push library** (`apps/web/src/lib/push.ts`): Core Web Push functionality
  - `subscribeToPush()`: Requests notification permission, subscribes via PushManager, registers with API
  - `unsubscribeFromPush()`: Removes device subscription from browser and API
  - `reconcilePushSubscription()`: Silently resubscribes if user opted in but subscription was lost
  - `urlBase64ToUint8Array()`: Converts VAPID public key for PushManager
  - `isPushSupported()`: Detects browser capability

- **Push hook** (`apps/web/src/hooks/use-push.ts`): React integration
  - Manages subscription state, permission tracking, and loading state
  - Handles errors gracefully (network failures, PushManager errors)

- **Notifications UI** (`apps/web/src/components/account/notifications-card.tsx`): Updated toggle
  - Single toggle that orchestrates browser permission + API subscription before account preference flips
  - Displays contextual hints for unsupported browsers, blocked permissions, or unavailable service
  - Reconciles subscription on load if user opted in

- **Service Worker** (`apps/web/public/push-sw.js`): Push event handlers
  - Displays notifications with title, body, icon, and tag (collapses rapid events)
  - Routes notification clicks to the app with optional URL navigation

- **API endpoint** (`apps/api/src/routes/push.ts`): Public key exposure
  - `GET /api/push/public-key`: Returns VAPID public key or null if unconfigured

- **Localization**: Added French and English strings for unsupported, blocked, and unavailable states

- **Vite config**: Configured PWA plugin to import push handlers into generated service worker

- **Tests** (`apps/web/src/lib/__tests__/push.test.ts`): Unit tests for base64url decoding

## Implementation Details

- **State consistency**: The toggle disables browser subscription *before* updating the account preference, preventing drift between browser state and server preference
- **Error tolerance**: Network failures during subscribe/unsubscribe are caught and reported as "dismissed" to avoid misleading error messages; failed unsubscribes don't block the UI since the browser unsubscribe may have succeeded
- **Silent reconciliation**: On app load, if the user opted in but lost their subscription (cleared storage, new device), the app silently resubscribes without user interaction
- **Graceful degradation**: Unsupported browsers show the toggle as disabled with an explanatory message; blocked permissions show a different message directing users to browser settings

https://claude.ai/code/session_018BPo3i3r5jcRGipCxzyEX9