### PR TITLE
Enable same-origin framing for admin vault PDF preview

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -54,8 +54,10 @@ app.use(
       defaultSrc: ["'self'"],
       baseUri: ["'self'"],
       formAction: ["'self'", "https://checkout.stripe.com"],
-      frameAncestors: ["'none'"],
-      frameSrc: ["https://js.stripe.com", "https://hooks.stripe.com"],
+      // 'self' so the app can frame its own same-origin responses — the
+      // admin-vault PDF preview renders the document in an <iframe>.
+      frameAncestors: ["'self'"],
+      frameSrc: ["'self'", "https://js.stripe.com", "https://hooks.stripe.com"],
       scriptSrc: ["'self'", "https://js.stripe.com"],
       styleSrc: ["'self'", "'unsafe-inline'"],
       // Business rule C5: img-src restricted to local + data URIs so no

--- a/apps/web/src/routes/_authenticated/admin-vault/index.tsx
+++ b/apps/web/src/routes/_authenticated/admin-vault/index.tsx
@@ -213,7 +213,7 @@ function AdminVaultPage() {
         open={!!previewing}
         onOpenChange={(open) => !open && setPreviewing(null)}
       >
-        <DialogContent className="flex h-[85vh] max-w-5xl flex-col gap-3 p-4 sm:p-6">
+        <DialogContent className="flex h-[85vh] max-w-5xl flex-col gap-3 p-4 sm:h-[85vh] sm:max-w-5xl sm:p-6">
           <DialogHeader className="space-y-0.5 pr-8">
             <DialogTitle className="truncate">{previewing?.title}</DialogTitle>
             <p className="text-xs text-muted-foreground truncate">


### PR DESCRIPTION
## Summary
Updates Content Security Policy (CSP) and dialog styling to support embedding PDF documents in an iframe within the admin vault preview feature.

## Changes
- **CSP policy (`apps/api/src/app.ts`)**
  - Changed `frameAncestors` from `"'none'"` to `"'self'"` to allow the app to frame its own same-origin responses
  - Added `"'self'"` to `frameSrc` directive alongside existing Stripe domains
  - Added clarifying comment explaining the rationale: admin-vault PDF preview renders documents in an `<iframe>`

- **Dialog styling (`apps/web/src/routes/_authenticated/admin-vault/index.tsx`)**
  - Fixed responsive Tailwind classes on `DialogContent` to properly apply `h-[85vh]`, `max-w-5xl`, and `p-6` on small screens and above (`sm:` breakpoint)
  - Ensures consistent dialog dimensions across all viewport sizes

## Implementation Details
The CSP changes are minimal and scoped — only allowing same-origin framing, which maintains security while enabling the PDF preview iframe functionality. The dialog styling fix ensures the preview modal displays correctly on all screen sizes without layout shifts.

https://claude.ai/code/session_0171DEQ9chaD2b1aaWswbBfW