### PR TITLE
refactor: update dark mode color palette from warm charcoal to slate

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -140,7 +140,7 @@
   --sidebar-ring: oklch(0.65 0.04 50);
 }
 
-/* ─── Dark Mode: Warm Charcoal ─── */
+/* ─── Dark Mode: Slate ─── */
 .dark {
   --color-info-surface: color-mix(in oklab, #3b82f6 18%, transparent);
   --color-info-border: color-mix(in oklab, #3b82f6 40%, transparent);
@@ -155,20 +155,20 @@
   --color-danger-border: color-mix(in oklab, #f43f5e 42%, transparent);
   --color-danger-foreground: color-mix(in oklab, #fda4af 95%, white);
 
-  --background: oklch(0.18 0.012 50);
-  --foreground: oklch(0.93 0.01 75);
-  --card: oklch(0.22 0.014 50);
-  --card-foreground: oklch(0.93 0.01 75);
-  --popover: oklch(0.22 0.014 50);
-  --popover-foreground: oklch(0.93 0.01 75);
+  --background: oklch(0.18 0.04 265);
+  --foreground: oklch(0.93 0.013 256);
+  --card: oklch(0.22 0.042 265);
+  --card-foreground: oklch(0.93 0.013 256);
+  --popover: oklch(0.22 0.042 265);
+  --popover-foreground: oklch(0.93 0.013 256);
   --primary: oklch(0.74 0.07 205);
   --primary-foreground: oklch(0.18 0.02 205);
   --secondary: oklch(0.30 0.02 155);
-  --secondary-foreground: oklch(0.90 0.01 75);
-  --muted: oklch(0.27 0.012 50);
-  --muted-foreground: oklch(0.65 0.02 50);
-  --accent: oklch(0.27 0.015 50);
-  --accent-foreground: oklch(0.90 0.01 75);
+  --secondary-foreground: oklch(0.90 0.015 256);
+  --muted: oklch(0.27 0.041 261);
+  --muted-foreground: oklch(0.65 0.04 257);
+  --accent: oklch(0.27 0.041 261);
+  --accent-foreground: oklch(0.90 0.015 256);
   --destructive: oklch(0.70 0.17 25);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
@@ -178,14 +178,14 @@
   --chart-3: oklch(0.75 0.09 75);
   --chart-4: oklch(0.65 0.07 285);
   --chart-5: oklch(0.62 0.05 195);
-  --sidebar: oklch(0.22 0.014 50);
-  --sidebar-foreground: oklch(0.93 0.01 75);
+  --sidebar: oklch(0.22 0.042 265);
+  --sidebar-foreground: oklch(0.93 0.013 256);
   --sidebar-primary: oklch(0.74 0.07 205);
   --sidebar-primary-foreground: oklch(0.18 0.02 205);
-  --sidebar-accent: oklch(0.27 0.015 50);
-  --sidebar-accent-foreground: oklch(0.90 0.01 75);
+  --sidebar-accent: oklch(0.27 0.041 261);
+  --sidebar-accent-foreground: oklch(0.90 0.015 256);
   --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.50 0.03 50);
+  --sidebar-ring: oklch(0.50 0.045 257);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary
Updates the dark mode color scheme from a warm charcoal palette to a cooler slate palette, improving visual consistency and reducing eye strain for extended use.

## Changes
- **Color palette shift:** Changed hue values across all dark mode CSS variables from warm tones (hue ~50°) to cool slate tones (hue ~256–265°)
- **Saturation adjustments:** Increased chroma/saturation values for better color definition and contrast:
  - Background, card, popover, sidebar: `0.012–0.014` → `0.04–0.042`
  - Foreground colors: `0.01` → `0.013–0.015`
  - Muted and accent colors: `0.012–0.015` → `0.041`
  - Muted foreground and sidebar ring: `0.02–0.03` → `0.04–0.045`
- **Comment update:** Changed dark mode section label from "Warm Charcoal" to "Slate"

## Implementation Details
All changes use the existing OKLch color space format, maintaining consistency with the current design system. The adjustments preserve the lightness (L) values while shifting hue and increasing chroma for a more vibrant, cooler appearance. This aligns with modern dark mode design practices and should improve readability and reduce eye fatigue for users with ADHD who may spend extended periods in the application.

https://claude.ai/code/session_01EKLtKfGccbnAfnYZkzFFL4