### PR TITLE
Add Account navigation group and increase sidebar width

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -28,7 +28,7 @@ import { PanelLeftIcon } from "lucide-react"
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
-const SIDEBAR_WIDTH = "16rem"
+const SIDEBAR_WIDTH = "18rem"
 const SIDEBAR_WIDTH_MOBILE = "18rem"
 const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"

--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -74,6 +74,7 @@ export const navGroups: { key: NavItem["group"]; labelKey: string }[] = [
   { key: "knowledge", labelKey: "nav.groupKnowledge" },
   { key: "tracking", labelKey: "nav.groupTracking" },
   { key: "care", labelKey: "nav.groupCare" },
+  { key: "account", labelKey: "nav.groupAccount" },
   { key: "admin", labelKey: "nav.groupAdmin" },
 ];
 

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -278,6 +278,7 @@
     "groupKnowledge": "Resources",
     "groupTracking": "Tracking",
     "groupCare": "Care",
+    "groupAccount": "Account",
     "groupAdmin": "Admin",
     "breadcrumbHome": "Home"
   },

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -282,6 +282,7 @@
     "groupKnowledge": "Ressources",
     "groupTracking": "Suivi",
     "groupCare": "Soins",
+    "groupAccount": "Compte",
     "groupAdmin": "Administration",
     "breadcrumbHome": "Accueil"
   },


### PR DESCRIPTION
## Summary
This PR adds a new "Account" navigation group to the sidebar and increases the default sidebar width from 16rem to 18rem to accommodate additional navigation items.

## Changes
- **Sidebar width:** Increased `SIDEBAR_WIDTH` from `16rem` to `18rem` to provide more space for navigation labels
- **Navigation groups:** Added new `account` navigation group to `navGroups` in `apps/web/src/config/nav.ts`
- **Internationalization:** Added French and English translations for the new Account group:
  - English: "Account"
  - French: "Compte"

## Implementation Details
The Account group is positioned between the Care and Admin groups in the navigation hierarchy, following the existing pattern for navigation group organization. This prepares the navigation structure for account-related menu items (e.g., profile, settings, preferences) while maintaining the simplified, clear navigation structure required by the ADHD-friendly design principles.

https://claude.ai/code/session_01Y7U2Gp7w1Yf6e9x7oMBn6A