### PR TITLE
fix: prevent search icon interaction in behavior decoder

### DIFF
--- a/apps/web/src/routes/_authenticated/decodeur/index.tsx
+++ b/apps/web/src/routes/_authenticated/decodeur/index.tsx
@@ -57,7 +57,7 @@ function BehaviorDecoderPage() {
 
       <div className="relative">
         <Search
-          className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
           aria-hidden="true"
         />
         <Input


### PR DESCRIPTION
## Summary
Added `pointer-events-none` class to the search icon in the behavior decoder page to prevent unintended user interactions with the decorative icon element.

## Changes
- Added `pointer-events-none` utility class to the Search icon component in the behavior decoder page
  - The icon is marked as `aria-hidden="true"`, indicating it's purely decorative
  - Preventing pointer events ensures the icon cannot be accidentally clicked or focused, improving UX and reducing cognitive load for users with ADHD

## Implementation Details
The search icon is a visual indicator positioned absolutely within the input field. By disabling pointer events, we ensure that:
- Users cannot accidentally interact with the icon instead of the input field
- The input field remains the sole interactive element in that area
- The experience is simpler and more predictable, aligning with Tokō's design principles for ADHD-friendly interfaces

https://claude.ai/code/session_018XJUa63p3W4usVyfBaBtBo