### PR TITLE
fix(admin-users): center search loupe icon vertically in the field

### DIFF
--- a/apps/web/src/routes/_authenticated/admin-users/index.tsx
+++ b/apps/web/src/routes/_authenticated/admin-users/index.tsx
@@ -241,10 +241,10 @@ function AdminUsersPage() {
         }`}
       />
 
-      <div className="relative flex max-w-sm items-center">
+      <div className="relative max-w-sm">
         <Search
-          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
           aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 left-3 my-auto h-4 w-4 text-muted-foreground"
         />
         <Input
           type="search"


### PR DESCRIPTION
Replace the flex-container workaround with the inset-y-0 + my-auto
centering pattern already used by the journal search field, so the
magnifying-glass icon sits at the exact vertical middle of the input.

https://claude.ai/code/session_019n7Ereb5isD6Qz56gMXC8z