### PR TITLE
fix(dark-mode): neutralize warm accent tints on card surfaces

### DIFF
--- a/apps/web/src/components/article/article-elements.tsx
+++ b/apps/web/src/components/article/article-elements.tsx
@@ -109,7 +109,7 @@ export function ArticleHero({
       <div
         aria-hidden
         className={cn(
-          "pointer-events-none absolute inset-0 bg-gradient-to-br",
+          "pointer-events-none absolute inset-0 bg-gradient-to-br dark:hidden",
           theme.gradient,
         )}
       />

--- a/apps/web/src/components/dashboard/daily-tip-card.tsx
+++ b/apps/web/src/components/dashboard/daily-tip-card.tsx
@@ -84,7 +84,7 @@ export function DailyTipCard() {
 function TipBody({ tipKey }: { tipKey: string }) {
   const { t } = useTranslation();
   return (
-    <Card className="border-accent-200 bg-accent-50/60 dark:bg-accent-900/20 dark:border-accent-800">
+    <Card className="border-accent-200 bg-accent-50/60 dark:border-accent-800 dark:bg-card">
       <CardContent className="flex items-start gap-3 p-5">
         <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-background/70 text-accent-700 dark:text-accent-200">
           <Lightbulb className="h-5 w-5" aria-hidden="true" />

--- a/apps/web/src/components/strengths/strength-card.tsx
+++ b/apps/web/src/components/strengths/strength-card.tsx
@@ -24,7 +24,7 @@ export const categoryConfig: Record<
     labelKey: "strengths.categories.talent",
     fallbackEmoji: "🌟",
     surfaceClass:
-      "bg-sage-50 ring-sage-200 dark:bg-sage-900/30 dark:ring-sage-800",
+      "bg-sage-50 ring-sage-200 dark:bg-card dark:ring-sage-800",
     badgeClass:
       "bg-sage-100 text-sage-800 dark:bg-sage-900/60 dark:text-sage-100",
   },
@@ -32,7 +32,7 @@ export const categoryConfig: Record<
     labelKey: "strengths.categories.achievement",
     fallbackEmoji: "🏆",
     surfaceClass:
-      "bg-accent-50 ring-accent-200 dark:bg-accent-900/30 dark:ring-accent-800",
+      "bg-accent-50 ring-accent-200 dark:bg-card dark:ring-accent-800",
     badgeClass:
       "bg-accent-100 text-accent-900 dark:bg-accent-900/60 dark:text-accent-100",
   },

--- a/apps/web/src/routes/_authenticated/achievements/index.tsx
+++ b/apps/web/src/routes/_authenticated/achievements/index.tsx
@@ -50,13 +50,13 @@ const TONE_CLASSES: Record<
 > = {
   warmth: {
     unlockedSurface:
-      "bg-accent-50 ring-2 ring-accent-300 dark:bg-accent-900/30 dark:ring-accent-700",
+      "bg-accent-50 ring-2 ring-accent-300 dark:bg-card dark:ring-accent-700",
     badgeClass:
       "bg-accent-100 text-accent-900 dark:bg-accent-900/60 dark:text-accent-100",
   },
   growth: {
     unlockedSurface:
-      "bg-sage-50 ring-2 ring-sage-300 dark:bg-sage-900/30 dark:ring-sage-700",
+      "bg-sage-50 ring-2 ring-sage-300 dark:bg-card dark:ring-sage-700",
     badgeClass:
       "bg-sage-100 text-sage-800 dark:bg-sage-900/60 dark:text-sage-100",
   },

--- a/apps/web/src/routes/_authenticated/care-pathway/index.tsx
+++ b/apps/web/src/routes/_authenticated/care-pathway/index.tsx
@@ -219,7 +219,7 @@ function StepCard({
     <Card
       className={cn(
         "transition-colors",
-        status === "done" && "bg-sage-50/60 ring-1 ring-sage-200 dark:bg-sage-900/20 dark:ring-sage-800",
+        status === "done" && "bg-sage-50/60 ring-1 ring-sage-200 dark:bg-card dark:ring-sage-800",
       )}
     >
       <CardContent className="flex items-start gap-4 p-5">

--- a/apps/web/src/routes/_authenticated/connaissances/index.tsx
+++ b/apps/web/src/routes/_authenticated/connaissances/index.tsx
@@ -64,7 +64,7 @@ function ConnaissancesIndex() {
               <div
                 aria-hidden
                 className={cn(
-                  "pointer-events-none absolute inset-0 bg-gradient-to-br",
+                  "pointer-events-none absolute inset-0 bg-gradient-to-br dark:hidden",
                   fTheme.gradient,
                 )}
               />

--- a/apps/web/src/routes/_authenticated/strengths/index.tsx
+++ b/apps/web/src/routes/_authenticated/strengths/index.tsx
@@ -132,7 +132,7 @@ function StrengthsPage() {
       ) : isLoading ? (
         <PageLoader />
       ) : !strengths?.length ? (
-        <Card className="bg-accent-50/40 ring-1 ring-accent-200/60 dark:bg-accent-900/20 dark:ring-accent-800/60">
+        <Card className="bg-accent-50/40 ring-1 ring-accent-200/60 dark:bg-card dark:ring-accent-800/60">
           <CardContent className="flex flex-col items-center gap-3 py-12 text-center">
             <Sparkles className="h-10 w-10 text-accent-500" />
             <p className="font-heading text-lg font-semibold">

--- a/apps/web/src/routes/ressources/$slug.tsx
+++ b/apps/web/src/routes/ressources/$slug.tsx
@@ -224,7 +224,7 @@ function ArticlePage() {
         {/* Share-with-entourage block — hidden for incoming shared visitors */}
         {!incomingShareId && (
           <section className="mt-12">
-            <Card className="border-sage-200/60 bg-sage-50/40 dark:border-sage-700/30 dark:bg-sage-900/10">
+            <Card className="border-sage-200/60 bg-sage-50/40 dark:border-sage-700/30 dark:bg-card">
               <CardContent className="flex flex-col gap-4 py-6 sm:flex-row sm:items-center sm:justify-between">
                 <div className="flex items-start gap-3">
                   <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-sage-100 text-sage-700 dark:bg-sage-800/40 dark:text-sage-300">

--- a/apps/web/src/routes/ressources/index.tsx
+++ b/apps/web/src/routes/ressources/index.tsx
@@ -129,7 +129,7 @@ function ResourcesIndex() {
       {/* For the entourage */}
       {entourageArticles.length > 0 && (
         <section className="mx-auto max-w-6xl px-4 py-8">
-          <div className="rounded-2xl border border-sage-200/60 bg-sage-50/40 p-6 dark:border-sage-700/30 dark:bg-sage-900/10 lg:p-10">
+          <div className="rounded-2xl border border-sage-200/60 bg-sage-50/40 p-6 dark:border-sage-700/30 dark:bg-card lg:p-10">
             <div className="flex items-start gap-3">
               <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-sage-100 text-sage-700 dark:bg-sage-800/40 dark:text-sage-300">
                 <MessageCircle className="h-5 w-5" />


### PR DESCRIPTION
The dark mode palette was refactored from warm charcoal to cool slate,
but tinted card backgrounds built from the warm honey/sage accents and
the per-cluster article gradients were left unchanged — so they read as
muddy warm patches against the slate background.

In dark mode, accent-tinted card surfaces (daily tip, strengths empty
state and cards, achievements, care-pathway steps, entourage callouts)
now use the neutral --card background, and the article cluster gradient
overlay is hidden. Colour is kept on icons, badges and thin borders, and
light mode is unchanged.

https://claude.ai/code/session_01JtiQ9fqKuxtqwjFrGXq3Fh