### PR TITLE
fix: adjust user menu dropdown positioning and offset

### DIFF
--- a/apps/web/src/routes/_authenticated.tsx
+++ b/apps/web/src/routes/_authenticated.tsx
@@ -299,7 +299,12 @@ function UserMenu() {
         </span>
         <ChevronDown className="h-3.5 w-3.5 text-muted-foreground group-data-[collapsible=icon]:hidden" />
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" side="top" className="w-60">
+      <DropdownMenuContent
+        align="end"
+        side="right"
+        sideOffset={8}
+        className="w-60"
+      >
         <DropdownMenuLabel>
           <span className="flex min-w-0 items-center gap-1.5">
             <span className="truncate text-sm font-medium text-foreground">


### PR DESCRIPTION
## Summary
Adjusts the positioning and spacing of the user menu dropdown in the authenticated layout to improve visual alignment and usability.

## Changes
- Changed dropdown menu `side` prop from `"top"` to `"right"` for better positioning relative to the trigger
- Added `sideOffset={8}` to create consistent spacing between the dropdown and the trigger element
- Reformatted the `DropdownMenuContent` props for improved readability

## Implementation Details
This change ensures the user menu dropdown appears to the right of the trigger with an 8px offset, providing better visual hierarchy and preventing the menu from overlapping with the trigger element. The adjustment aligns with the principle of predictable interactions and avoiding layout surprises for users with ADHD.

https://claude.ai/code/session_01VkXZ8aTh3wc4fCv2BJJhAG