### PR TITLE
Bypass rate limiter in CI e2e test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,10 @@ jobs:
       GOOGLE_CLIENT_SECRET: ci-placeholder
       STRIPE_SECRET_KEY: sk_test_placeholder
       STRIPE_WEBHOOK_SECRET: whsec_placeholder
+      # All 74 e2e tests share one client IP, so the 120 req/min global
+      # cap in apps/api/src/middleware/rate-limiter.ts trips mid-suite
+      # and assertions land on /login instead of the page under test.
+      RATE_LIMIT_BYPASS: "1"
 
     steps:
       - name: Checkout code

--- a/apps/api/src/middleware/rate-limiter.ts
+++ b/apps/api/src/middleware/rate-limiter.ts
@@ -60,6 +60,15 @@ export function rateLimiter(opts: RateLimitOptions): MiddlewareHandler {
         : (c: Context) => `ip:${clientIp(c)}`;
 
   return async (c, next) => {
+    // CI e2e shares a single client IP across the full suite, so the
+    // 120 req/min global cap fires mid-run and tests see a redirect to
+    // /login instead of the page under test. Opt-out is gated by an
+    // explicit env var so dev + prod always keep the limiter active.
+    if (process.env.RATE_LIMIT_BYPASS === "1") {
+      await next();
+      return;
+    }
+
     const store = getStore(namespace);
     const key = keyFn(c);
     const now = Date.now();


### PR DESCRIPTION
## Summary
Adds a mechanism to bypass the global rate limiter during CI e2e test execution, preventing test failures caused by the 120 req/min cap being exceeded when all 74 tests share a single client IP.

## Changes
- **Rate limiter middleware:** Added an early return when `RATE_LIMIT_BYPASS=1` environment variable is set, allowing the full e2e test suite to run without hitting rate limits
- **CI workflow:** Set `RATE_LIMIT_BYPASS=1` in the e2e test job environment to activate the bypass during CI runs
- **Safety:** The bypass is explicitly gated by an environment variable, ensuring dev and production environments always keep the limiter active

## Implementation Details
The bypass check is placed at the very start of the rate limiter middleware handler, before any rate limit logic executes. This allows the e2e test suite to complete without assertions landing on the `/login` redirect that occurs when rate limits are exceeded, while maintaining full rate limiting protection in all other environments.

https://claude.ai/code/session_015VEA62cNyydVdpaALv9LZ6