### PR TITLE
fix(api): compute calendar dates in the user's timezone, not UTC

### DIFF
--- a/apps/api/src/__tests__/local-date.test.ts
+++ b/apps/api/src/__tests__/local-date.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { toLocalISODate, localISODateDaysAgo } from "../lib/local-date";
+
+describe("toLocalISODate", () => {
+  it("returns the local calendar day for Europe/Paris just past local midnight", () => {
+    // 2026-06-03T23:30:00Z is 2026-06-04 01:30 in Europe/Paris (UTC+2 summer).
+    const d = new Date("2026-06-03T23:30:00Z");
+    expect(toLocalISODate("Europe/Paris", d)).toBe("2026-06-04");
+  });
+
+  it("returns the previous day for Europe/Paris right before local midnight", () => {
+    // 2026-06-03T21:00:00Z is 2026-06-03 23:00 in Europe/Paris.
+    const d = new Date("2026-06-03T21:00:00Z");
+    expect(toLocalISODate("Europe/Paris", d)).toBe("2026-06-03");
+  });
+
+  it("uses UTC when timezone is UTC", () => {
+    const d = new Date("2026-06-03T23:30:00Z");
+    expect(toLocalISODate("UTC", d)).toBe("2026-06-03");
+  });
+
+  it("falls back to UTC slice for an invalid timezone", () => {
+    const d = new Date("2026-06-03T23:30:00Z");
+    expect(toLocalISODate("Mars/Olympus", d)).toBe("2026-06-03");
+  });
+});
+
+describe("localISODateDaysAgo", () => {
+  it("subtracts whole calendar days in the local timezone", () => {
+    // Local "today" in Paris is 2026-06-04 at this instant.
+    const d = new Date("2026-06-03T23:30:00Z");
+    expect(localISODateDaysAgo("Europe/Paris", 0, d)).toBe("2026-06-04");
+    expect(localISODateDaysAgo("Europe/Paris", 7, d)).toBe("2026-05-28");
+  });
+
+  it("crosses a DST transition without drifting by an hour", () => {
+    // 2026-03-29 is the spring-forward day in Europe/Paris (02:00 → 03:00).
+    // Anchor at 2026-04-01 10:00Z (12:00 Paris, after DST) and step back 7
+    // days — the result must still be 2026-03-25 (a clean calendar week),
+    // not 2026-03-24 or anything DST-shifted.
+    const d = new Date("2026-04-01T10:00:00Z");
+    expect(localISODateDaysAgo("Europe/Paris", 7, d)).toBe("2026-03-25");
+  });
+});

--- a/apps/api/src/jobs/email-jobs.ts
+++ b/apps/api/src/jobs/email-jobs.ts
@@ -22,6 +22,7 @@ import {
   computeSignals,
   pickSuggestedArticle,
 } from "../lib/knowledge-suggestions";
+import { toLocalISODate } from "../lib/local-date";
 
 export type JobResult = {
   processed: number;
@@ -78,19 +79,10 @@ function localWeekdayIn(timezone: string, now: Date = new Date()): number {
   }
 }
 
-function todayInTimezone(timezone: string, now: Date = new Date()): string {
-  try {
-    const parts = new Intl.DateTimeFormat("en-CA", {
-      timeZone: timezone,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-    }).format(now);
-    return parts; // en-CA formats as YYYY-MM-DD
-  } catch {
-    return now.toISOString().split("T")[0]!;
-  }
-}
+// Re-exported under the historical name so callers in this file read
+// cleanly. The implementation lives in `lib/local-date.ts` because
+// route handlers need it too.
+const todayInTimezone = toLocalISODate;
 
 function hoursSince(date: Date | null, now: Date = new Date()): number {
   if (!date) return Number.POSITIVE_INFINITY;
@@ -278,10 +270,6 @@ export async function runWeeklyDigests(
     .innerJoin(userPreferences, eq(userPreferences.userId, user.id))
     .where(eq(userPreferences.weeklyDigestOptIn, true));
 
-  const weekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .split("T")[0]!;
-
   for (const row of rows) {
     result.processed++;
     if (localWeekdayIn(row.timezone, now) !== 0) {
@@ -306,6 +294,15 @@ export async function runWeeklyDigests(
       result.skipped++;
       continue;
     }
+
+    const localToday = todayInTimezone(row.timezone, now);
+    // Preserves the historical 7-days-back lower bound (a trailing
+    // 8-calendar-day window inclusive of today) — only the anchor moves
+    // from UTC to the recipient's local day.
+    const localTodayDate = new Date(`${localToday}T00:00:00Z`);
+    const weekAgoDate = new Date(localTodayDate);
+    weekAgoDate.setUTCDate(weekAgoDate.getUTCDate() - 7);
+    const weekAgo = weekAgoDate.toISOString().slice(0, 10);
 
     const weekSymptoms = await db
       .select()
@@ -372,11 +369,9 @@ export async function runWeeklyDigests(
       .where(eq(symptoms.childId, firstChild.id));
     const symptomDates = new Set(allChildSymptoms.map((s) => s.date));
     let streak = 0;
-    const localToday = todayInTimezone(row.timezone, now);
-    const todayDate = new Date(localToday);
     for (let i = 0; i < 365; i++) {
-      const checkDate = new Date(todayDate);
-      checkDate.setDate(checkDate.getDate() - i);
+      const checkDate = new Date(localTodayDate);
+      checkDate.setUTCDate(checkDate.getUTCDate() - i);
       const dateStr = checkDate.toISOString().split("T")[0]!;
       if (symptomDates.has(dateStr)) streak++;
       else break;

--- a/apps/api/src/lib/local-date.ts
+++ b/apps/api/src/lib/local-date.ts
@@ -1,0 +1,65 @@
+import { eq } from "drizzle-orm";
+import { db, userPreferences } from "@focusflow/db";
+
+// Toko's userbase is French; the user_preferences default and the scheduler
+// env default both pin this. Routes that compute calendar dates fall back
+// here when a per-user timezone is unavailable.
+export const DEFAULT_TIMEZONE = "Europe/Paris";
+
+/**
+ * Formats `date` as `YYYY-MM-DD` in the given IANA timezone. The frontend
+ * writes symptom/journal/mood `date` columns using the user's local
+ * calendar day; the backend must read them back the same way or queries
+ * around midnight (UTC+1/+2 in France) silently miss or duplicate rows.
+ *
+ * Falls back to UTC on an invalid timezone — matches the email-jobs
+ * helper this replaces.
+ */
+export function toLocalISODate(
+  timezone: string,
+  date: Date = new Date(),
+): string {
+  try {
+    // en-CA renders as `YYYY-MM-DD`.
+    return new Intl.DateTimeFormat("en-CA", {
+      timeZone: timezone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(date);
+  } catch {
+    return date.toISOString().split("T")[0]!;
+  }
+}
+
+/**
+ * Returns the calendar date `days` before today in `timezone`, formatted
+ * as `YYYY-MM-DD`. Subtraction happens in calendar-day space (UTC math on
+ * a midnight-UTC anchor) so DST transitions don't shift the result by an
+ * hour. With `days = 0` this is equivalent to `toLocalISODate`.
+ */
+export function localISODateDaysAgo(
+  timezone: string,
+  days: number,
+  from: Date = new Date(),
+): string {
+  const today = toLocalISODate(timezone, from);
+  const anchor = new Date(`${today}T00:00:00Z`);
+  anchor.setUTCDate(anchor.getUTCDate() - days);
+  return anchor.toISOString().slice(0, 10);
+}
+
+/**
+ * Loads the user's preferred timezone, falling back to {@link DEFAULT_TIMEZONE}
+ * when no preferences row exists. Called once per request that needs to do
+ * date math; the extra round-trip is negligible relative to the queries
+ * that follow.
+ */
+export async function getUserTimezone(userId: string): Promise<string> {
+  const [row] = await db
+    .select({ timezone: userPreferences.timezone })
+    .from(userPreferences)
+    .where(eq(userPreferences.userId, userId))
+    .limit(1);
+  return row?.timezone ?? DEFAULT_TIMEZONE;
+}

--- a/apps/api/src/routes/barkley.ts
+++ b/apps/api/src/routes/barkley.ts
@@ -21,6 +21,11 @@ import {
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess } from "../lib/child-access";
+import {
+  getUserTimezone,
+  localISODateDaysAgo,
+  toLocalISODate,
+} from "../lib/local-date";
 
 export const barkleyRoutes = new Hono<AppEnv>();
 
@@ -249,18 +254,19 @@ barkleyRoutes.get("/logs/:childId", async (c) => {
 
   const behaviorIds = behaviors.map((b) => b.id);
 
-  // Compute week range (Monday to Sunday)
-  function toDateString(d: Date): string {
-    return d.toISOString().slice(0, 10);
-  }
-
-  const ref = week ? new Date(week) : new Date();
-  const day = ref.getDay();
+  // Compute Monday–Sunday range in the user's local timezone. Anchoring on
+  // UTC midnight of the local calendar day lets us reuse UTC `setUTCDate`
+  // math without DST drift, and keeps the result expressed as the same
+  // `YYYY-MM-DD` strings the logs table stores.
+  const tz = await getUserTimezone(user.id);
+  const refDate = week ?? toLocalISODate(tz);
+  const ref = new Date(`${refDate}T00:00:00Z`);
+  const day = ref.getUTCDay();
   const diff = day === 0 ? -6 : 1 - day;
-  ref.setDate(ref.getDate() + diff);
-  const monday = toDateString(ref);
-  ref.setDate(ref.getDate() + 6);
-  const sunday = toDateString(ref);
+  ref.setUTCDate(ref.getUTCDate() + diff);
+  const monday = ref.toISOString().slice(0, 10);
+  ref.setUTCDate(ref.getUTCDate() + 6);
+  const sunday = ref.toISOString().slice(0, 10);
 
   const logs = await db
     .select()
@@ -447,9 +453,8 @@ barkleyRoutes.get("/stars/:childId", async (c) => {
     totalStars = result?.total ?? 0;
 
     // Stars earned in the past 7 days (for reachability hints)
-    const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-      .toISOString()
-      .split("T")[0]!;
+    const tz = await getUserTimezone(user.id);
+    const weekAgo = localISODateDaysAgo(tz, 7);
     const [weeklyResult] = await db
       .select({ total: count() })
       .from(barkleyBehaviorLogs)

--- a/apps/api/src/routes/medications.ts
+++ b/apps/api/src/routes/medications.ts
@@ -11,6 +11,11 @@ import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess, childIsShared } from "../lib/child-access";
 import { logAudit, getCreatorNames } from "../lib/audit";
+import {
+  getUserTimezone,
+  localISODateDaysAgo,
+  toLocalISODate,
+} from "../lib/local-date";
 
 export const medicationsRoutes = new Hono<AppEnv>();
 
@@ -153,9 +158,8 @@ medicationsRoutes.get("/:childId/adherence", async (c) => {
   const childId = c.req.param("childId");
   await assertChildAccess(user.id, childId);
 
-  const sinceDate = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .split("T")[0]!;
+  const tz = await getUserTimezone(user.id);
+  const sinceDate = localISODateDaysAgo(tz, 30);
 
   const activeMeds = await db
     .select()
@@ -184,7 +188,7 @@ medicationsRoutes.get("/:childId/adherence", async (c) => {
     else logsByMed.set(log.medicationId, [log]);
   }
 
-  const today = new Date().toISOString().split("T")[0]!;
+  const today = toLocalISODate(tz);
   const result = activeMeds.map((med) => {
     const medLogs = logsByMed.get(med.id) ?? [];
     const taken = medLogs.filter((l) => l.taken).length;

--- a/apps/api/src/routes/parent-mood.ts
+++ b/apps/api/src/routes/parent-mood.ts
@@ -4,6 +4,7 @@ import type { AppEnv } from "../types";
 import { db, parentMoodLogs } from "@focusflow/db";
 import { upsertParentMoodSchema } from "@focusflow/validators";
 import { authMiddleware } from "../middleware/auth";
+import { getUserTimezone, localISODateDaysAgo } from "../lib/local-date";
 
 export const parentMoodRoutes = new Hono<AppEnv>();
 
@@ -15,9 +16,9 @@ parentMoodRoutes.use("*", authMiddleware);
 parentMoodRoutes.get("/", async (c) => {
   const user = c.get("user");
   const days = Math.min(Math.max(Number(c.req.query("days")) || 14, 1), 90);
-  const since = new Date();
-  since.setDate(since.getDate() - days + 1);
-  const sinceIso = since.toISOString().slice(0, 10);
+  // Inclusive of "today" — days=14 returns the trailing 14 calendar days.
+  const tz = await getUserTimezone(user.id);
+  const sinceIso = localISODateDaysAgo(tz, days - 1);
 
   const rows = await db
     .select()

--- a/apps/api/src/routes/report.ts
+++ b/apps/api/src/routes/report.ts
@@ -19,6 +19,11 @@ import { AppError } from "../middleware/error-handler";
 import { assertChildAccess, getChildOwnerId } from "../lib/child-access";
 import { getPremiumAccess } from "../lib/premium";
 import { sendEmail } from "../lib/email";
+import {
+  getUserTimezone,
+  localISODateDaysAgo,
+  toLocalISODate,
+} from "../lib/local-date";
 import { z } from "zod";
 
 export const reportRoutes = new Hono<AppEnv>();
@@ -75,7 +80,10 @@ reportRoutes.post("/send-email", async (c) => {
     await assertChildAccess(user.id, childId);
     await assertOwnerHasFamillePlan(childId);
 
-    const range = resolveDateRange({ period, from, to });
+    const range = resolveDateRange(
+        { period, from, to },
+        await getUserTimezone(user.id),
+    );
     if ("error" in range) {
         return c.json({ error: range.error }, 422);
     }
@@ -137,7 +145,10 @@ reportRoutes.post("/pdf", async (c) => {
     await assertChildAccess(user.id, childId);
     await assertOwnerHasFamillePlan(childId);
 
-    const range = resolveDateRange({ period, from, to });
+    const range = resolveDateRange(
+        { period, from, to },
+        await getUserTimezone(user.id),
+    );
     if ("error" in range) {
         return c.json({ error: range.error }, 422);
     }
@@ -195,14 +206,18 @@ type ResolvedRange =
     | { sinceDate: string; untilDate: string }
     | { error: string };
 
-function resolveDateRange(input: {
-    period?: "week" | "month" | "quarter";
-    from?: string;
-    to?: string;
-}): ResolvedRange {
+function resolveDateRange(
+    input: {
+        period?: "week" | "month" | "quarter";
+        from?: string;
+        to?: string;
+    },
+    timezone: string,
+): ResolvedRange {
+    const today = toLocalISODate(timezone);
     if (input.from) {
         const sinceDate = input.from;
-        const untilDate = input.to ?? new Date().toISOString().split("T")[0]!;
+        const untilDate = input.to ?? today;
         if (sinceDate > untilDate) {
             return { error: "La date de début doit précéder la date de fin." };
         }
@@ -210,10 +225,8 @@ function resolveDateRange(input: {
     }
     const days = PERIOD_DAYS[input.period ?? "quarter"] ?? 90;
     return {
-        sinceDate: new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-            .toISOString()
-            .split("T")[0]!,
-        untilDate: new Date().toISOString().split("T")[0]!,
+        sinceDate: localISODateDaysAgo(timezone, days),
+        untilDate: today,
     };
 }
 

--- a/apps/api/src/routes/stats.ts
+++ b/apps/api/src/routes/stats.ts
@@ -12,6 +12,11 @@ import { authMiddleware } from "../middleware/auth";
 import { requirePlan } from "../middleware/require-plan";
 import { assertChildAccess } from "../lib/child-access";
 import { aggregateDailyCalmMinutes, CALM_MINUTES_DAILY_CAP } from "../lib/calm-minutes";
+import {
+  getUserTimezone,
+  localISODateDaysAgo,
+  toLocalISODate,
+} from "../lib/local-date";
 
 export const statsRoutes = new Hono<AppEnv>();
 
@@ -38,13 +43,13 @@ statsRoutes.get("/:childId", async (c) => {
 
   await assertChildAccess(user.id, childId);
 
-  const today = new Date().toISOString().split("T")[0]!;
-  const sinceDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .split("T")[0]!;
-  const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .split("T")[0]!;
+  // Calendar dates are compared against `s.date` columns the frontend writes
+  // in the user's local day, so resolve them in the same timezone — UTC math
+  // would skew the window by a day around midnight in France.
+  const tz = await getUserTimezone(user.id);
+  const today = toLocalISODate(tz);
+  const sinceDate = localISODateDaysAgo(tz, days);
+  const weekAgo = localISODateDaysAgo(tz, 7);
 
   // Period symptoms (for chart)
   const periodSymptoms = await db
@@ -68,9 +73,7 @@ statsRoutes.get("/:childId", async (c) => {
 
   // Streak: consecutive days with at least one symptom entry.
   // Bounded to the last 365 days — the loop below only looks that far back anyway.
-  const yearAgo = new Date(Date.now() - 365 * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .split("T")[0]!;
+  const yearAgo = localISODateDaysAgo(tz, 365);
   const streakSymptomDates = await db
     .select({ date: symptoms.date })
     .from(symptoms)
@@ -83,10 +86,13 @@ statsRoutes.get("/:childId", async (c) => {
 
   const symptomDates = new Set(streakSymptomDates.map((s) => s.date));
   let streak = 0;
-  const todayDate = new Date(today);
+  // Step through calendar days using UTC math anchored at midnight UTC of
+  // the local `today` — the dates produced are the same `YYYY-MM-DD`
+  // strings the symptoms table stores.
+  const todayDate = new Date(`${today}T00:00:00Z`);
   for (let i = 0; i < 365; i++) {
     const checkDate = new Date(todayDate);
-    checkDate.setDate(checkDate.getDate() - i);
+    checkDate.setUTCDate(checkDate.getUTCDate() - i);
     const dateStr = checkDate.toISOString().split("T")[0]!;
     if (symptomDates.has(dateStr)) {
       streak++;
@@ -105,7 +111,7 @@ statsRoutes.get("/:childId", async (c) => {
 
   let daysSinceLastEntry: number | null = null;
   if (latestSymptomDate) {
-    const lastDate = new Date(latestSymptomDate.date);
+    const lastDate = new Date(`${latestSymptomDate.date}T00:00:00Z`);
     daysSinceLastEntry = Math.floor(
       (todayDate.getTime() - lastDate.getTime()) / (24 * 60 * 60 * 1000)
     );
@@ -268,9 +274,8 @@ statsRoutes.get("/:childId/correlations", async (c) => {
 
   await assertChildAccess(user.id, childId);
 
-  const sinceDate = new Date(Date.now() - lookbackDays * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .split("T")[0]!;
+  const tz = await getUserTimezone(user.id);
+  const sinceDate = localISODateDaysAgo(tz, lookbackDays);
 
   const [rows, behaviorRows] = await Promise.all([
     db
@@ -390,9 +395,8 @@ statsRoutes.get("/:childId/calm-minutes", async (c) => {
 
   await assertChildAccess(user.id, childId);
 
-  const sinceDate = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
-    .toISOString()
-    .split("T")[0]!;
+  const tz = await getUserTimezone(user.id);
+  const sinceDate = localISODateDaysAgo(tz, days);
 
   const rows = await db
     .select({

--- a/apps/web/src/hooks/use-relevant-resources.ts
+++ b/apps/web/src/hooks/use-relevant-resources.ts
@@ -1,6 +1,7 @@
 import { useMemo } from "react";
 import { useSymptoms } from "@/hooks/use-symptoms";
 import { useStats } from "@/hooks/use-stats";
+import { toISODate } from "@/lib/date";
 import { articles } from "@/lib/resources-data";
 import type {
   ArticleTrigger,
@@ -79,10 +80,12 @@ export function useRelevantResources(childId: string): Recommendation[] {
   return useMemo(() => {
     if (!childId || !symptoms || symptoms.length === 0) return [];
 
-    const today = new Date();
-    const cutoff = new Date(today.getTime() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000)
-      .toISOString()
-      .split("T")[0]!;
+    // `s.date` is stored as the user's local calendar day (see lib/date.ts);
+    // compare against a cutoff computed the same way, otherwise the window
+    // shifts by a day around midnight Europe/Paris.
+    const cutoff = toISODate(
+      new Date(Date.now() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000),
+    );
     const recent = symptoms.filter((s) => s.date >= cutoff);
 
     const signals = evaluateSignals(


### PR DESCRIPTION
## Summary

The frontend writes `date` columns (symptoms, journal, parent mood, medication logs, Barkley logs) using the **user's local calendar day** — see `apps/web/src/lib/date.ts` and PR #282 for the rationale. The backend, however, was still deriving "today" and trailing-window boundaries from `new Date().toISOString().slice(0, 10)`, i.e. the server's UTC day. For a parent in Europe/Paris between local midnight and UTC midnight, the two no longer agree, which silently caused:

- `/api/stats/:childId` dropping late-evening symptoms from the period chart, streak, mood-trend, and consistency score
- `/api/medications/:childId/adherence` missing "today" and skewing the 30-day window
- `/api/parent-mood/?days=14` returning the wrong 14-day strip
- `/api/barkley/logs/:childId` shifting the Monday→Sunday range by a full week if the request hit between UTC and local midnight
- `/api/report/*` defaulting to the wrong end date
- `useRelevantResources` (frontend) comparing local-day `s.date` against a UTC cutoff

## Changes

- New `apps/api/src/lib/local-date.ts` with `toLocalISODate`, `localISODateDaysAgo`, and `getUserTimezone(userId)` — pulled from `user_preferences.timezone` with `Europe/Paris` as the documented default (matches the schema default and `SCHEDULER_TIMEZONE` env var).
- `stats`, `medications`, `parent-mood`, `barkley`, and `report` routes now compute every date string in the calling user's timezone. Streak/Monday math is anchored on UTC midnight of the local day so we can still use `setUTCDate` without DST drift.
- `jobs/email-jobs.ts` consolidates onto the shared helper, moves `weekAgo` inside the per-user loop (was a single UTC-day computed once for all recipients), and uses the same UTC-on-local-anchor pattern for the streak loop.
- Frontend `useRelevantResources` reuses the existing `toISODate` helper.
- New `apps/api/src/__tests__/local-date.test.ts` covers the Europe/Paris evening boundary, UTC passthrough, the invalid-timezone fallback, and a DST-week step.

Behavior is unchanged for users in UTC. For users east of UTC the trailing windows now match what the frontend wrote.

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm test` — 100 passed / 15 skipped (was 94 passed / 15 skipped; six new are from `local-date.test.ts`)
- [ ] Manual smoke at 23:30 → 00:30 Europe/Paris: log a symptom, refresh `/dashboard`, confirm it shows up in today's strip and the streak ticks up
- [ ] Manual `/api/report/pdf` with `period=quarter` from the same time window: confirm `untilDate` in the PDF header matches the user's local day

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtKiYSVi5zBddRorsKbXWZ)_