### PR TITLE
feat(routines): launch the timer in sequence mode from a routine card

### DIFF
--- a/apps/web/src/components/timer/__tests__/sequences.test.ts
+++ b/apps/web/src/components/timer/__tests__/sequences.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import type { Routine } from "@focusflow/validators";
+import { routineToSequence } from "../sequences";
+
+function makeStep(
+  overrides: Partial<Routine["steps"][number]> & { id: string },
+): Routine["steps"][number] {
+  return {
+    routineId: "routine-1",
+    label: `Step ${overrides.id}`,
+    emoji: null,
+    durationMinutes: 5,
+    position: 0,
+    createdAt: "2026-06-03T00:00:00Z",
+    updatedAt: "2026-06-03T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeRoutine(steps: Routine["steps"]): Routine {
+  return {
+    id: "routine-1",
+    childId: "child-1",
+    name: "Routine du soir",
+    emoji: "🌙",
+    timeOfDay: "bedtime",
+    daysOfWeek: [],
+    position: 0,
+    active: true,
+    createdAt: "2026-06-03T00:00:00Z",
+    updatedAt: "2026-06-03T00:00:00Z",
+    steps,
+  };
+}
+
+describe("routineToSequence", () => {
+  it("orders steps by position and skips undurated ones", () => {
+    const r = makeRoutine([
+      makeStep({ id: "11111111-1111-1111-1111-111111111111", position: 2, durationMinutes: 3 }),
+      makeStep({ id: "22222222-2222-2222-2222-222222222222", position: 0, durationMinutes: 5 }),
+      makeStep({ id: "33333333-3333-3333-3333-333333333333", position: 1, durationMinutes: null }),
+    ]);
+    const seq = routineToSequence(r);
+    expect(seq).not.toBeNull();
+    expect(seq!.routineId).toBe("routine-1");
+    expect(seq!.steps).toHaveLength(2);
+    expect(seq!.steps[0]?.routineStepId).toBe("22222222-2222-2222-2222-222222222222");
+    expect(seq!.steps[0]?.durationSec).toBe(5 * 60);
+    expect(seq!.steps[1]?.routineStepId).toBe("11111111-1111-1111-1111-111111111111");
+  });
+
+  it("filters out already-completed steps when the set is provided", () => {
+    const r = makeRoutine([
+      makeStep({ id: "11111111-1111-1111-1111-111111111111", position: 0, durationMinutes: 5 }),
+      makeStep({ id: "22222222-2222-2222-2222-222222222222", position: 1, durationMinutes: 5 }),
+    ]);
+    const seq = routineToSequence(
+      r,
+      new Set(["11111111-1111-1111-1111-111111111111"]),
+    );
+    expect(seq).not.toBeNull();
+    expect(seq!.steps).toHaveLength(1);
+    expect(seq!.steps[0]?.routineStepId).toBe(
+      "22222222-2222-2222-2222-222222222222",
+    );
+  });
+
+  it("returns null when every timed step is already completed", () => {
+    const r = makeRoutine([
+      makeStep({ id: "11111111-1111-1111-1111-111111111111", durationMinutes: 5 }),
+      makeStep({ id: "22222222-2222-2222-2222-222222222222", durationMinutes: 5 }),
+    ]);
+    const seq = routineToSequence(
+      r,
+      new Set([
+        "11111111-1111-1111-1111-111111111111",
+        "22222222-2222-2222-2222-222222222222",
+      ]),
+    );
+    expect(seq).toBeNull();
+  });
+
+  it("returns null when the routine has no timed steps", () => {
+    const r = makeRoutine([
+      makeStep({ id: "11111111-1111-1111-1111-111111111111", durationMinutes: null }),
+    ]);
+    expect(routineToSequence(r)).toBeNull();
+  });
+});

--- a/apps/web/src/components/timer/sequences.ts
+++ b/apps/web/src/components/timer/sequences.ts
@@ -6,7 +6,9 @@
 //
 // Sequences are built from the user's own routines (created in the
 // Routines tab), where each step that has a duration becomes a chained
-// timer step.
+// timer step. When `completedStepIds` is supplied, already-checked steps
+// for the day are skipped so a routine launched in the evening doesn't
+// replay the morning items.
 
 import type { Routine } from "@focusflow/validators";
 
@@ -14,6 +16,12 @@ export type SequenceStep = {
   label: string;
   emoji?: string;
   durationSec: number;
+  /**
+   * Routine step row this timer step maps back to. When present the
+   * timer can mark the step complete via the existing routines API as
+   * each step finishes, keeping the routines page in sync.
+   */
+  routineStepId?: string;
 };
 
 export type SequenceTemplate = {
@@ -21,27 +29,40 @@ export type SequenceTemplate = {
   label: string;
   emoji: string;
   steps: SequenceStep[];
+  /** Set when the sequence was derived from a user routine. */
+  routineId?: string;
 };
 
 const FALLBACK_ROUTINE_EMOJI = "📋";
 
-// Convert a user routine into a runnable sequence. Only steps with a
-// duration become timer steps — steps without a duration are checklist
-// items only, not timer-friendly. Returns null when no step is usable.
-export function routineToSequence(routine: Routine): SequenceTemplate | null {
+/**
+ * Convert a user routine into a runnable sequence. Only steps with a
+ * duration become timer steps — steps without a duration are checklist
+ * items only, not timer-friendly. When `completedStepIds` is provided,
+ * already-completed steps are filtered out so an evening run of the
+ * bedtime routine doesn't replay items the kid already ticked at
+ * snack-time. Returns null when nothing remains to run.
+ */
+export function routineToSequence(
+  routine: Routine,
+  completedStepIds?: ReadonlySet<string>,
+): SequenceTemplate | null {
   const usable = routine.steps
     .slice()
     .sort((a, b) => a.position - b.position)
-    .filter((s) => (s.durationMinutes ?? 0) > 0);
+    .filter((s) => (s.durationMinutes ?? 0) > 0)
+    .filter((s) => !completedStepIds?.has(s.id));
   if (usable.length === 0) return null;
   return {
     id: `user-${routine.id}`,
     label: routine.name,
     emoji: routine.emoji ?? FALLBACK_ROUTINE_EMOJI,
+    routineId: routine.id,
     steps: usable.map((s) => ({
       label: s.label,
       emoji: s.emoji ?? undefined,
       durationSec: (s.durationMinutes ?? 0) * 60,
+      routineStepId: s.id,
     })),
   };
 }

--- a/apps/web/src/components/timer/visual-timer.tsx
+++ b/apps/web/src/components/timer/visual-timer.tsx
@@ -35,12 +35,31 @@ export function VisualTimer({
   defaultMinutes = 10,
   userSequences = EMPTY_SEQUENCES,
   childId,
+  autoStartSequenceId,
+  onSequenceStepComplete,
+  onSequenceFinished,
 }: {
   defaultMinutes?: number;
   /** User-defined routines converted to runnable sequences. */
   userSequences?: SequenceTemplate[];
   /** Active child — hatched companions are saved to this child's collection. */
   childId?: string;
+  /**
+   * When set, the matching user sequence starts automatically on mount
+   * (used when the timer is launched from the Routines page).
+   */
+  autoStartSequenceId?: string;
+  /**
+   * Fired when a sequence step's countdown reaches zero on its own.
+   * Receives the `routineStepId` if the step came from a real routine.
+   * Not fired on user reset/cancel — only natural completion.
+   */
+  onSequenceStepComplete?: (info: {
+    routineStepId: string | undefined;
+    stepIndex: number;
+  }) => void;
+  /** Fired once when the last step of a sequence finishes naturally. */
+  onSequenceFinished?: (info: { sequence: SequenceTemplate }) => void;
 }) {
   const { t } = useTranslation();
   const { mutate: recordCompanion } = useRecordCompanion();
@@ -86,6 +105,15 @@ export function VisualTimer({
     // Mid-sequence: show transition screen and queue the next step.
     // Last step or standalone timer: reveal the companion critter.
     if (activeSequence) {
+      const finishedStep = activeSequence.steps[currentStepIndex];
+      // Notify before transitioning so the caller can persist progress —
+      // by the time the next step starts the index will have moved on.
+      if (finishedStep && onSequenceStepComplete) {
+        onSequenceStepComplete({
+          routineStepId: finishedStep.routineStepId,
+          stepIndex: currentStepIndex,
+        });
+      }
       const isLastStep = currentStepIndex >= activeSequence.steps.length - 1;
       if (!isLastStep && !transitioning) {
         setTransitioning(true);
@@ -100,6 +128,9 @@ export function VisualTimer({
           setRunning(true);
         }, STEP_TRANSITION_MS);
         return;
+      }
+      if (isLastStep && onSequenceFinished) {
+        onSequenceFinished({ sequence: activeSequence });
       }
     }
 
@@ -149,6 +180,32 @@ export function VisualTimer({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [fullscreen, setFullscreen]);
+
+  // Auto-start a sequence when the routes page deep-links into the timer
+  // with `?routineId=…`. Guarded by `autoStartedRef` so a re-render or a
+  // sequence list refetch never restarts an already-running routine —
+  // that would yank Tom back to step one mid-way through.
+  const autoStartedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!autoStartSequenceId) return;
+    if (autoStartedRef.current === autoStartSequenceId) return;
+    const seq = userSequences.find((s) => s.id === autoStartSequenceId);
+    if (!seq) return;
+    autoStartedRef.current = autoStartSequenceId;
+    primeAudio();
+    setActiveSequence(seq);
+    setCurrentStepIndex(0);
+    const firstStep = seq.steps[0];
+    if (firstStep) {
+      setDurationSec(firstStep.durationSec);
+      setRemainingSec(firstStep.durationSec);
+    }
+    setFullscreen(true);
+    setRunning(true);
+    // setters and primeAudio are stable; we deliberately exclude them so this
+    // effect only re-fires when the deep-link target id actually changes.
+    // eslint-disable-next-line react-doctor/exhaustive-deps
+  }, [autoStartSequenceId, userSequences]);
 
   const clearCompanion = () => {
     if (abandonTimeoutRef.current) {

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -865,7 +865,8 @@
     "stepCounter": "Step {{current}}/{{total}}",
     "nextStep": "Next step",
     "sequenceFinished": "Routine finished!",
-    "cancelSequence": "Leave routine"
+    "cancelSequence": "Leave routine",
+    "routineAlreadyDoneToast": "Every timed step of this routine is already checked off for today."
   },
   "critters": {
     "chick": "The chick",
@@ -1262,6 +1263,9 @@
     "daysHint": "Leave empty for a daily routine.",
     "edit": "Edit routine",
     "editSteps": "Edit steps",
+    "launchTimerCta_one": "Start timer · {{count}} step",
+    "launchTimerCta_other": "Start timer · {{count}} steps",
+    "launchTimerAria": "Start the timer for the {{name}} routine",
     "delete": "Delete",
     "deleteTitle": "Delete this routine?",
     "deleteBody": "\"{{name}}\" and all its steps will be removed. This action is irreversible.",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -1276,7 +1276,8 @@
     "stepCounter": "Étape {{current}}/{{total}}",
     "nextStep": "Étape suivante",
     "sequenceFinished": "Routine terminée !",
-    "cancelSequence": "Quitter la routine"
+    "cancelSequence": "Quitter la routine",
+    "routineAlreadyDoneToast": "Toutes les étapes minutées de cette routine sont déjà cochées pour aujourd'hui."
   },
   "critters": {
     "chick": "Le poussin",
@@ -1683,6 +1684,9 @@
     "daysHint": "Laissez vide pour une routine quotidienne.",
     "edit": "Modifier la routine",
     "editSteps": "Modifier les étapes",
+    "launchTimerCta_one": "Lancer le minuteur · {{count}} étape",
+    "launchTimerCta_other": "Lancer le minuteur · {{count}} étapes",
+    "launchTimerAria": "Lancer le minuteur pour la routine {{name}}",
     "delete": "Supprimer",
     "deleteTitle": "Supprimer cette routine ?",
     "deleteBody": "« {{name}} » et toutes ses étapes seront supprimées. Cette action est irréversible.",

--- a/apps/web/src/routes/_authenticated/routines/routines-page.tsx
+++ b/apps/web/src/routes/_authenticated/routines/routines-page.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useId, useMemo, useReducer, useRef, useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { toast } from "sonner";
 
 import {
   Plus,
+  Play,
   ListChecks,
   Pencil,
   Trash2,
@@ -448,6 +450,7 @@ function RoutineCard({
   muted?: boolean;
 }) {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const activeChildId = useUiStore((s) => s.activeChildId)!;
   const completeStep = useCompleteStep();
   const uncompleteStep = useUncompleteStep();
@@ -458,6 +461,21 @@ function RoutineCard({
   const done = routine.steps.filter((s) => completedStepIds.has(s.id)).length;
   const percent = total > 0 ? Math.round((done / total) * 100) : 0;
   const allDone = total > 0 && done === total;
+  // The "Lancer le minuteur" CTA only shows up when there is at least
+  // one *timed* step still to run today — otherwise tapping it would
+  // either start an empty timer or replay items already checked at
+  // snack-time. Mirrors the filter in `routineToSequence`.
+  const runnableSteps = routine.steps.filter(
+    (s) => (s.durationMinutes ?? 0) > 0 && !completedStepIds.has(s.id),
+  ).length;
+  const canLaunchTimer = runnableSteps > 0;
+
+  const launchTimer = () => {
+    navigate({
+      to: "/timer",
+      search: { routineId: routine.id },
+    });
+  };
 
   // Default to expanded for today's actionable routines, collapsed otherwise
   // (other-days section, or routines already finished). Less to scroll past
@@ -578,6 +596,17 @@ function RoutineCard({
         className="space-y-3"
       >
         {total > 0 && <Progress value={percent} />}
+        {expanded && canLaunchTimer && (
+          <Button
+            type="button"
+            onClick={launchTimer}
+            className="w-full"
+            aria-label={t("routines.launchTimerAria", { name: routine.name })}
+          >
+            <Play className="mr-2 size-4" aria-hidden="true" />
+            {t("routines.launchTimerCta", { count: runnableSteps })}
+          </Button>
+        )}
         {expanded &&
           (total === 0 ? (
             <button

--- a/apps/web/src/routes/_authenticated/timer/index.tsx
+++ b/apps/web/src/routes/_authenticated/timer/index.tsx
@@ -1,13 +1,28 @@
-import { useMemo } from "react";
-import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useMemo } from "react";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
 import { PageHeader } from "@/components/layout/page-header";
 import { VisualTimer } from "@/components/timer/visual-timer";
 import { routineToSequence } from "@/components/timer/sequences";
-import { useRoutines } from "@/hooks/use-routines";
+import {
+  useCompleteStep,
+  useRoutineCompletions,
+  useRoutines,
+} from "@/hooks/use-routines";
+import { todayISO } from "@/lib/date";
 import { useUiStore } from "@/stores/ui-store";
 
+type TimerSearch = { routineId?: string };
+
 export const Route = createFileRoute("/_authenticated/timer/")({
+  validateSearch: (search: Record<string, unknown>): TimerSearch => {
+    const routineId =
+      typeof search.routineId === "string" && search.routineId.trim().length > 0
+        ? search.routineId.trim()
+        : undefined;
+    return { routineId };
+  },
   component: TimerPage,
   staticData: {
     crumb: "nav.timer",
@@ -16,18 +31,58 @@ export const Route = createFileRoute("/_authenticated/timer/")({
 
 function TimerPage() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { routineId } = Route.useSearch();
   const activeChildId = useUiStore((s) => s.activeChildId);
+  const today = todayISO();
   const { data: routines } = useRoutines(activeChildId ?? "");
+  const { data: completions } = useRoutineCompletions(
+    activeChildId ?? "",
+    today,
+  );
+  const completeStep = useCompleteStep();
+
+  // Steps already ticked earlier today must not replay — Léa launching
+  // the bedtime routine at 19h45 should not see Tom's snack-time items
+  // again. Snapshot at first render so newly-completed steps during the
+  // run don't reshape the sequence mid-flight.
+  const completedStepIds = useMemo(
+    () => new Set((completions ?? []).map((c) => c.stepId)),
+    [completions],
+  );
 
   const userSequences = useMemo(() => {
     if (!routines) return [];
-    return routines.reduce<NonNullable<ReturnType<typeof routineToSequence>>[]>((acc, r) => {
+    return routines.reduce<
+      NonNullable<ReturnType<typeof routineToSequence>>[]
+    >((acc, r) => {
       if (!r.active) return acc;
-      const seq = routineToSequence(r);
+      const seq = routineToSequence(r, completedStepIds);
       if (seq !== null) acc.push(seq);
       return acc;
     }, []);
-  }, [routines]);
+  }, [routines, completedStepIds]);
+
+  const autoStartSequenceId = routineId ? `user-${routineId}` : undefined;
+  const targetRoutine = routineId
+    ? (routines ?? []).find((r) => r.id === routineId)
+    : null;
+  const targetSequence = autoStartSequenceId
+    ? userSequences.find((s) => s.id === autoStartSequenceId) ?? null
+    : null;
+
+  // Deep-linked from /routines but every timed step is already done for
+  // today — there is nothing to run. Surface that as a toast, drop the
+  // search param, and stay on the timer page so the user can still pick
+  // another routine. Done in an effect so the side effects don't run
+  // during render (and don't fire on every render).
+  const deepLinkExhausted =
+    !!routineId && !!targetRoutine && targetSequence === null;
+  useEffect(() => {
+    if (!deepLinkExhausted) return;
+    toast.info(t("timer.routineAlreadyDoneToast"));
+    navigate({ to: "/timer", search: {} as TimerSearch, replace: true });
+  }, [deepLinkExhausted, navigate, t]);
 
   return (
     <div className="space-y-8">
@@ -39,6 +94,18 @@ function TimerPage() {
         <VisualTimer
           userSequences={userSequences}
           childId={activeChildId ?? undefined}
+          autoStartSequenceId={autoStartSequenceId}
+          onSequenceStepComplete={({ routineStepId }) => {
+            if (!routineStepId || !targetRoutine || !activeChildId) return;
+            // Idempotent on the server (uniqueIndex on routine_completions);
+            // a duplicate call from a fast double-tick is harmless.
+            completeStep.mutate({
+              routineId: targetRoutine.id,
+              childId: activeChildId,
+              stepId: routineStepId,
+              date: today,
+            });
+          }}
         />
       </div>
     </div>


### PR DESCRIPTION
## Pourquoi

Le minuteur en mode séquence (chaîner automatiquement les étapes d'une routine) existait déjà, mais le parent devait passer par `/timer` puis re-sélectionner la routine dans un sous-picker. Léa, parent épuisée à 19h45 : « je ne re-sélectionne pas une routine que je suis en train de regarder ». Tom, 8 ans, seul dans la salle de bain : la routine du soir ne doit pas rejouer le goûter qu'il a déjà coché à 16h.

Workflow personas exécuté avant l'implémentation (Léa / Tom / Inès / Marc / Sara). Verdict : un seul bouton « Lancer le minuteur » sur la carte de routine, aucun écran intermédiaire, persistance des étapes terminées via l'API existante, snapshot des étapes déjà cochées au démarrage.

## Ce que ça fait

- **`/routines`** : chaque `RoutineCard` affiche un bouton primaire « Lancer le minuteur · N étapes » dès qu'il reste au moins une étape minutée non cochée pour aujourd'hui. Tap → `/timer?routineId=…`.
- **`/timer`** : valide `routineId` en search param, snapshot des `completedStepIds` du jour, démarre la séquence en plein écran sans étape intermédiaire. À chaque fin d'étape naturelle, `useCompleteStep` est appelé → la carte de routine reflète la progression en live.
- **`routineToSequence`** : accepte un set `completedStepIds` optionnel et porte `routineId` + `routineStepId` sur le template — sans ça, impossible de re-mapper une étape terminée vers sa ligne en base.
- **`VisualTimer`** : trois nouvelles props optionnelles (`autoStartSequenceId`, `onSequenceStepComplete`, `onSequenceFinished`). Une `ref` interne bloque un redémarrage parasite si la liste des séquences se ré-hydrate pendant le run. Le mode Pomodoro autonome est intact (toutes les props sont optionnelles).
- **Edge case Sara** : si toutes les étapes minutées de la routine sont déjà cochées au moment du deep-link, le timer affiche un toast et nettoie le search param au lieu de démarrer un timer vide.

## Ce qui est explicitement reporté à v2

Reprise/pause entre navigations, historique des runs de routine, animation de célébration au-delà de l'écran de fin existant, attribution d'une routine à un enfant dans le timer (déjà géré par le store UI).

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm test` — 105 API / 30 web passent (4 nouveaux en `sequences.test.ts`)
- [ ] Manuel : depuis `/routines`, taper « Lancer le minuteur » sur une routine avec 3 étapes minutées, vérifier le passage en plein écran et le décompte de la 1ʳᵉ étape
- [ ] Manuel : laisser la séquence se terminer naturellement → les 3 étapes apparaissent cochées en revenant sur `/routines`
- [ ] Manuel : sur une routine dont toutes les étapes sont déjà cochées, vérifier le toast et que le search param est nettoyé
- [ ] Manuel : ouvrir `/timer` sans search param et vérifier que le Pomodoro standalone fonctionne comme avant

---
_Generated by [Claude Code](https://claude.ai/code/session_01NtKiYSVi5zBddRorsKbXWZ)_