### PR TITLE
feat(mobile): architecture Android (Expo en monorepo) + scaffold + workflow EAS

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -1,0 +1,69 @@
+name: Android Release
+
+# Builds and submits the Expo / React Native Android app via EAS.
+# Intentionally decoupled from the backend CI/Release pipelines: it never runs
+# on routine pushes to main, only on a `mobile-v*` tag or a manual dispatch.
+# See docs/android-app.md.
+
+on:
+  push:
+    tags:
+      - "mobile-v*"
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: "EAS build profile"
+        required: false
+        type: choice
+        options:
+          - preview
+          - production
+        default: "production"
+      submit:
+        description: "Submit to the Play Internal Testing track after build"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: android-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: EAS Build (Android)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+
+      - name: Setup EAS
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build Android (AAB)
+        run: eas build --platform android --profile ${{ github.event.inputs.profile || 'production' }} --non-interactive --wait
+
+      - name: Submit to Play (Internal Testing)
+        if: ${{ github.event_name == 'push' || github.event.inputs.submit == 'true' }}
+        env:
+          GOOGLE_SERVICE_ACCOUNT_KEY_JSON: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_KEY_JSON }}
+        run: |
+          printf '%s' "$GOOGLE_SERVICE_ACCOUNT_KEY_JSON" > /tmp/play-service-account.json
+          eas submit --platform android --profile production --non-interactive \
+            --latest \
+            --service-account-key-path /tmp/play-service-account.json
+          rm -f /tmp/play-service-account.json

--- a/apps/mobile/.gitignore
+++ b/apps/mobile/.gitignore
@@ -1,0 +1,27 @@
+# Expo / React Native
+node_modules/
+.expo/
+dist/
+web-build/
+*.orig.*
+
+# Native
+/android
+/ios
+
+# Metro
+.metro-health-check*
+
+# Debug
+npm-debug.*
+yarn-debug.*
+yarn-error.*
+
+# macOS
+.DS_Store
+
+# Secrets / credentials (never commit signing keys)
+*.keystore
+*.jks
+google-services.json
+google-service-account*.json

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,0 +1,38 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { StatusBar } from "expo-status-bar";
+import { ActivityIndicator, SafeAreaView, StyleSheet, View } from "react-native";
+
+import { authClient } from "./src/lib/auth";
+import { queryClient } from "./src/lib/query";
+import { HomeScreen } from "./src/screens/HomeScreen";
+import { LoginScreen } from "./src/screens/LoginScreen";
+
+function Root() {
+  const { data: session, isPending } = authClient.useSession();
+
+  if (isPending) {
+    return (
+      <View style={styles.center}>
+        <ActivityIndicator />
+      </View>
+    );
+  }
+
+  return session ? <HomeScreen /> : <LoginScreen />;
+}
+
+export default function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <SafeAreaView style={styles.safe}>
+        <StatusBar style="auto" />
+        <Root />
+      </SafeAreaView>
+    </QueryClientProvider>
+  );
+}
+
+const styles = StyleSheet.create({
+  safe: { flex: 1, backgroundColor: "#ffffff" },
+  center: { flex: 1, justifyContent: "center", alignItems: "center" },
+});

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -1,0 +1,51 @@
+# @focusflow/mobile — App Android Tokō (Expo / React Native)
+
+Client mobile natif de Tokō. Consomme l'**API Hono déjà déployée** (même
+backend et même base que le web). Décision d'architecture complète :
+[`docs/android-app.md`](../../docs/android-app.md).
+
+## Pourquoi natif (Expo) et pas une TWA
+
+Le rappel du soir (16h30–21h00) est une fonction centrale qui doit être
+**fiable**. Une notification planifiée et sensible au temps n'est pas garantie
+par un PWA/TWA quand l'app est fermée — seul l'OS peut la posséder. D'où le
+choix natif via `expo-notifications`. Voir `src/lib/notifications.ts`.
+
+## Isolation monorepo
+
+Ce package est **exclu du `pnpm install` racine** (`!apps/mobile` dans
+`pnpm-workspace.yaml`) pour que ses dépendances natives ne touchent jamais le
+pipeline JS/Docker. Il a son propre install, géré par EAS au build. Les
+schémas Zod `@focusflow/validators` sont partagés **par la source** (lien
+`file:` + résolution Metro/TS), gardant une source de vérité unique.
+
+## Développement
+
+```bash
+cd apps/mobile
+pnpm install          # install isolé (hors workspace racine)
+pnpm start            # Metro / Expo Dev
+pnpm android          # build natif local (nécessite le SDK Android)
+```
+
+Configurer l'URL de l'API dans `app.json` → `expo.extra.apiUrl` (par défaut
+`https://toko.app`).
+
+## Build & release (EAS)
+
+```bash
+pnpm build:android    # eas build --profile production (AAB)
+pnpm submit:android   # eas submit --profile production (piste Internal Testing)
+```
+
+En CI : `.github/workflows/android-release.yml`, déclenché sur tag `mobile-v*`
+ou manuellement. Secrets requis : `EXPO_TOKEN`,
+`GOOGLE_SERVICE_ACCOUNT_KEY_JSON`.
+
+## Changements backend nécessaires (additifs, non cassants)
+
+Pour brancher l'auth mobile (voir `docs/android-app.md`) :
+
+1. Plugin serveur `expo()` dans `apps/api/src/lib/auth.ts`.
+2. Scheme `toko://` (et `exp://` en dev) dans `trustedOrigins`.
+3. Prédicat CORS tolérant au scheme de l'app.

--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -1,0 +1,36 @@
+{
+  "expo": {
+    "name": "Tokō",
+    "slug": "toko",
+    "scheme": "toko",
+    "version": "0.1.0",
+    "orientation": "portrait",
+    "userInterfaceStyle": "automatic",
+    "platforms": ["android"],
+    "android": {
+      "package": "app.toko.mobile",
+      "versionCode": 1,
+      "permissions": [
+        "POST_NOTIFICATIONS",
+        "SCHEDULE_EXACT_ALARM",
+        "RECEIVE_BOOT_COMPLETED"
+      ]
+    },
+    "plugins": [
+      [
+        "expo-notifications",
+        {
+          "color": "#ffffff"
+        }
+      ],
+      "expo-secure-store"
+    ],
+    "extra": {
+      "apiUrl": "https://toko.app",
+      "webUrl": "https://toko.app",
+      "eas": {
+        "projectId": "REPLACE_WITH_EAS_PROJECT_ID"
+      }
+    }
+  }
+}

--- a/apps/mobile/babel.config.js
+++ b/apps/mobile/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ["babel-preset-expo"],
+  };
+};

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -1,0 +1,35 @@
+{
+  "cli": {
+    "version": ">= 12.0.0",
+    "appVersionSource": "local"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "production": {
+      "autoIncrement": true,
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  },
+  "submit": {
+    "production": {
+      "android": {
+        "track": "internal",
+        "releaseStatus": "draft"
+      }
+    }
+  }
+}

--- a/apps/mobile/index.ts
+++ b/apps/mobile/index.ts
@@ -1,0 +1,7 @@
+import { registerRootComponent } from "expo";
+
+import App from "./App";
+
+// registerRootComponent calls AppRegistry.registerComponent('main', () => App)
+// and ensures the environment is set up appropriately for Expo.
+registerRootComponent(App);

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -1,0 +1,22 @@
+// Metro config for an Expo app living inside the Tokō monorepo while being
+// excluded from the root pnpm install graph (see docs/android-app.md).
+// We teach Metro to watch and resolve the shared `@focusflow/validators`
+// package from its source in `packages/validators`.
+const { getDefaultConfig } = require("expo/metro-config");
+const path = require("path");
+
+const projectRoot = __dirname;
+const monorepoRoot = path.resolve(projectRoot, "../..");
+
+const config = getDefaultConfig(projectRoot);
+
+// Watch the shared validators source so changes hot-reload into the app.
+config.watchFolders = [path.resolve(monorepoRoot, "packages/validators")];
+
+// Resolve dependencies from the app first, then fall back to the repo root.
+config.resolver.nodeModulesPaths = [
+  path.resolve(projectRoot, "node_modules"),
+  path.resolve(monorepoRoot, "node_modules"),
+];
+
+module.exports = config;

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@focusflow/mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "index.ts",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "prebuild": "expo prebuild --platform android",
+    "typecheck": "tsc --noEmit",
+    "build:android": "eas build --platform android --profile production",
+    "submit:android": "eas submit --platform android --profile production"
+  },
+  "dependencies": {
+    "@better-auth/expo": "^1.5.6",
+    "@focusflow/validators": "file:../../packages/validators",
+    "@tanstack/react-query": "^5.62.0",
+    "better-auth": "^1.5.6",
+    "expo": "~54.0.0",
+    "expo-constants": "~18.0.0",
+    "expo-device": "~8.0.0",
+    "expo-notifications": "~0.32.0",
+    "expo-secure-store": "~15.0.0",
+    "expo-status-bar": "~3.0.0",
+    "expo-web-browser": "~15.0.0",
+    "react": "19.1.0",
+    "react-native": "0.81.4",
+    "zod": "^3.24.0"
+  },
+  "devDependencies": {
+    "@types/react": "~19.1.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -1,0 +1,67 @@
+import { getSessionCookie } from "./auth";
+import { API_URL } from "./config";
+
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    message: string,
+    public code?: string,
+  ) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+async function request<T>(path: string, options?: RequestInit): Promise<T> {
+  const cookie = getSessionCookie();
+  const response = await fetch(`${API_URL}/api${path}`, {
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...(cookie ? { Cookie: cookie } : {}),
+      ...options?.headers,
+    },
+  });
+
+  if (!response.ok) {
+    const body = (await response.json().catch(() => ({}))) as {
+      error?: string;
+      code?: string;
+    };
+    throw new ApiError(
+      response.status,
+      body.error ?? `Erreur ${response.status}`,
+      body.code,
+    );
+  }
+
+  if (response.status === 204) return undefined as T;
+  return (await response.json()) as T;
+}
+
+/** REST client mirroring apps/web/src/lib/api-client.ts, but cookie-aware for mobile. */
+export const api = {
+  get: <T>(path: string) => request<T>(path),
+  post: <T>(path: string, data?: unknown) =>
+    request<T>(path, {
+      method: "POST",
+      body: data === undefined ? undefined : JSON.stringify(data),
+    }),
+  patch: <T>(path: string, data?: unknown) =>
+    request<T>(path, {
+      method: "PATCH",
+      body: data === undefined ? undefined : JSON.stringify(data),
+    }),
+  delete: <T>(path: string) => request<T>(path, { method: "DELETE" }),
+};
+
+/** Subscription/entitlement status — drives premium unlock (no Play Billing). */
+export type BillingStatus = {
+  status: string;
+  active: boolean;
+  granted: boolean;
+};
+
+export function fetchBillingStatus() {
+  return api.get<BillingStatus>("/billing/status");
+}

--- a/apps/mobile/src/lib/auth.ts
+++ b/apps/mobile/src/lib/auth.ts
@@ -1,0 +1,33 @@
+import { expoClient } from "@better-auth/expo/client";
+import { createAuthClient } from "better-auth/react";
+import * as SecureStore from "expo-secure-store";
+
+import { API_URL } from "./config";
+
+/**
+ * Better Auth client for the mobile app.
+ *
+ * The Expo plugin stores the session cookie in `expo-secure-store` and replays
+ * it on requests, so we keep the exact same session model as the web app — no
+ * breaking backend change. The backend only needs the additive `expo()` server
+ * plugin and the `toko://` scheme added to `trustedOrigins`
+ * (see docs/android-app.md).
+ */
+export const authClient = createAuthClient({
+  baseURL: API_URL,
+  plugins: [
+    expoClient({
+      scheme: "toko",
+      storagePrefix: "toko",
+      storage: SecureStore,
+    }),
+  ],
+});
+
+/**
+ * Returns the stored session cookie header to attach to raw API calls.
+ * Empty string when the user is signed out.
+ */
+export function getSessionCookie(): string {
+  return authClient.getCookie();
+}

--- a/apps/mobile/src/lib/config.ts
+++ b/apps/mobile/src/lib/config.ts
@@ -1,0 +1,14 @@
+import Constants from "expo-constants";
+
+type Extra = {
+  apiUrl?: string;
+  webUrl?: string;
+};
+
+const extra = (Constants.expoConfig?.extra ?? {}) as Extra;
+
+/** Base URL of the deployed Hono API (the same backend the web app uses). */
+export const API_URL = extra.apiUrl ?? "https://toko.app";
+
+/** Base URL of the web app, used to open the Stripe subscription flow. */
+export const WEB_URL = extra.webUrl ?? "https://toko.app";

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -1,0 +1,75 @@
+import * as Device from "expo-device";
+import * as Notifications from "expo-notifications";
+import { Platform } from "react-native";
+
+/**
+ * The evening check-in reminder is the decisive reason this app is native
+ * rather than a TWA: a *scheduled, time-sensitive* notification that must fire
+ * reliably even when the app is closed. PWAs cannot guarantee this; the OS can.
+ * See docs/android-app.md.
+ */
+
+const EVENING_CHECKIN_ID = "evening-checkin";
+const ANDROID_CHANNEL_ID = "checkin-reminders";
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+});
+
+/** Requests OS permission + sets up the Android notification channel. */
+export async function ensureNotificationPermissions(): Promise<boolean> {
+  if (!Device.isDevice) return false;
+
+  if (Platform.OS === "android") {
+    await Notifications.setNotificationChannelAsync(ANDROID_CHANNEL_ID, {
+      name: "Rappels du soir",
+      importance: Notifications.AndroidImportance.HIGH,
+      enableVibrate: true,
+    });
+  }
+
+  const { status: existing } = await Notifications.getPermissionsAsync();
+  if (existing === "granted") return true;
+
+  const { status } = await Notifications.requestPermissionsAsync();
+  return status === "granted";
+}
+
+/**
+ * Schedules (or replaces) the daily evening check-in reminder. Defaults to
+ * 18h30, inside the 16h30–21h00 window from the offline-strategy business rule.
+ */
+export async function scheduleEveningCheckin(hour = 18, minute = 30): Promise<void> {
+  const granted = await ensureNotificationPermissions();
+  if (!granted) return;
+
+  await Notifications.cancelScheduledNotificationAsync(EVENING_CHECKIN_ID).catch(
+    () => undefined,
+  );
+
+  await Notifications.scheduleNotificationAsync({
+    identifier: EVENING_CHECKIN_ID,
+    content: {
+      title: "C'est l'heure du point du soir",
+      body: "Prends un instant pour noter la journée.",
+    },
+    trigger: {
+      type: Notifications.SchedulableTriggerInputTypes.DAILY,
+      hour,
+      minute,
+      channelId: ANDROID_CHANNEL_ID,
+    },
+  });
+}
+
+/** Cancels the evening reminder. */
+export async function cancelEveningCheckin(): Promise<void> {
+  await Notifications.cancelScheduledNotificationAsync(EVENING_CHECKIN_ID).catch(
+    () => undefined,
+  );
+}

--- a/apps/mobile/src/lib/query.ts
+++ b/apps/mobile/src/lib/query.ts
@@ -1,0 +1,11 @@
+import { QueryClient } from "@tanstack/react-query";
+
+/** Shared React Query client, mirroring the web app's server-state approach. */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      staleTime: 30_000,
+    },
+  },
+});

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -1,0 +1,100 @@
+import { useQuery } from "@tanstack/react-query";
+import type { Child } from "@focusflow/validators";
+import { useEffect } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import * as WebBrowser from "expo-web-browser";
+
+import { api, fetchBillingStatus } from "../lib/api";
+import { authClient } from "../lib/auth";
+import { WEB_URL } from "../lib/config";
+import { scheduleEveningCheckin } from "../lib/notifications";
+
+/**
+ * Home screen: lists the parent's children (typed by the shared
+ * `@focusflow/validators` schema), schedules the native evening reminder, and
+ * routes subscription to the web (no in-app purchase).
+ */
+export function HomeScreen() {
+  const children = useQuery({
+    queryKey: ["children"],
+    queryFn: () => api.get<Child[]>("/children"),
+  });
+
+  const billing = useQuery({
+    queryKey: ["billing"],
+    queryFn: fetchBillingStatus,
+  });
+
+  // Arm the reliable evening reminder once the user is in the app.
+  useEffect(() => {
+    void scheduleEveningCheckin();
+  }, []);
+
+  const isPremium = billing.data?.active || billing.data?.granted;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Mes enfants</Text>
+        <Pressable onPress={() => authClient.signOut()}>
+          <Text style={styles.link}>Se déconnecter</Text>
+        </Pressable>
+      </View>
+
+      {children.isLoading ? (
+        <ActivityIndicator />
+      ) : (
+        <FlatList
+          data={children.data ?? []}
+          keyExtractor={(child) => child.id}
+          ListEmptyComponent={<Text style={styles.muted}>Aucun enfant pour l'instant.</Text>}
+          renderItem={({ item }) => (
+            <View style={styles.card}>
+              <Text style={styles.cardTitle}>{item.name}</Text>
+              <Text style={styles.muted}>{item.ageRange} ans</Text>
+            </View>
+          )}
+        />
+      )}
+
+      {billing.isSuccess && !isPremium ? (
+        <Pressable
+          style={styles.button}
+          onPress={() => WebBrowser.openBrowserAsync(`${WEB_URL}/abonnement`)}
+        >
+          <Text style={styles.buttonText}>S'abonner sur le site</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, gap: 16 },
+  header: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
+  title: { fontSize: 24, fontWeight: "600" },
+  link: { color: "#4f46e5" },
+  muted: { color: "#71717a" },
+  card: {
+    borderWidth: 1,
+    borderColor: "#e4e4e7",
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+  },
+  cardTitle: { fontSize: 18, fontWeight: "500" },
+  button: {
+    backgroundColor: "#4f46e5",
+    borderRadius: 12,
+    padding: 16,
+    alignItems: "center",
+  },
+  buttonText: { color: "#fff", fontSize: 16, fontWeight: "600" },
+});

--- a/apps/mobile/src/screens/LoginScreen.tsx
+++ b/apps/mobile/src/screens/LoginScreen.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+
+import { authClient } from "../lib/auth";
+
+/**
+ * Minimal email/password sign-in against the existing Better Auth backend.
+ * One primary action per screen, per the ADHD-simple UX principles.
+ */
+export function LoginScreen() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit() {
+    setLoading(true);
+    setError(null);
+    const { error: signInError } = await authClient.signIn.email({
+      email,
+      password,
+    });
+    setLoading(false);
+    if (signInError) {
+      setError("Connexion impossible. Vérifie ton e-mail et ton mot de passe.");
+    }
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Se connecter à Tokō</Text>
+
+      <TextInput
+        style={styles.input}
+        placeholder="E-mail"
+        autoCapitalize="none"
+        keyboardType="email-address"
+        value={email}
+        onChangeText={setEmail}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Mot de passe"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+      />
+
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+
+      <Pressable style={styles.button} onPress={onSubmit} disabled={loading}>
+        {loading ? (
+          <ActivityIndicator color="#fff" />
+        ) : (
+          <Text style={styles.buttonText}>Se connecter</Text>
+        )}
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: "center", padding: 24, gap: 16 },
+  title: { fontSize: 24, fontWeight: "600", marginBottom: 8 },
+  input: {
+    borderWidth: 1,
+    borderColor: "#d4d4d8",
+    borderRadius: 12,
+    padding: 14,
+    fontSize: 16,
+  },
+  button: {
+    backgroundColor: "#4f46e5",
+    borderRadius: 12,
+    padding: 16,
+    alignItems: "center",
+  },
+  buttonText: { color: "#fff", fontSize: 16, fontWeight: "600" },
+  error: { color: "#dc2626" },
+});

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true,
+    "paths": {
+      "@focusflow/validators": ["../../packages/validators/src/index.ts"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/docs/android-app.md
+++ b/docs/android-app.md
@@ -1,0 +1,220 @@
+# Application Android (décision d'architecture)
+
+Document de décision pour la déclinaison Android de Tokō et la production
+d'un APK / AAB publiable sur le Play Store.
+
+> **Statut** : proposition (à valider). Issue d'un atelier d'analyse
+> codebase + recherche menée par sous-agents.
+
+## Question posée
+
+Faut-il ajouter l'application Android **directement dans le monorepo**, ou
+créer un **dépôt séparé** qui attaque le backend et la base de données déjà
+déployés de la version web ?
+
+## Décision en une ligne
+
+**TWA d'abord** (le PWA est déjà prêt), **monorepo toujours**, **abonnement
+Stripe sur le web d'abord**, **Expo uniquement si une fonctionnalité native
+l'impose.**
+
+## Recommandation
+
+| Sujet | Décision |
+|-------|----------|
+| Technologie | **Trusted Web Activity (TWA)** enrobant le PWA existant |
+| Emplacement | **Monorepo** : nouveau package `apps/android` |
+| Backend | Inchangé — l'app mobile est **un client de plus** de l'API déployée |
+| Auth | **Aucun changement** (cookies de session, comme sur le web) |
+| Paiement | Abonnement **sur le web (Stripe)** ; l'app lit le droit d'accès |
+| Repli | **Expo / React Native** si un besoin natif concret apparaît |
+
+## Pourquoi le monorepo plutôt qu'un dépôt séparé
+
+1. **Réutilisation des validateurs** — `@focusflow/validators` est un package
+   `private`, non publié, exporté en `./src/index.ts` et résolu par les
+   workspaces pnpm. Un client mobile TypeScript ne peut le réutiliser
+   « gratuitement » que **dans le monorepo** (dépendance `workspace:*`). Un
+   dépôt séparé imposerait de publier le package sur un registre privé →
+   machinerie de release et risque de désynchronisation de versions.
+2. **Source de vérité unique** — règles de validation et types TS restent
+   partagés entre web, API et mobile, sans dérive.
+3. **Backend déjà déployé** — c'est le facteur décisif : pas de réarchitecture,
+   pas de nouveau déploiement, pas de nouvelle base. Le mobile pointe sur
+   l'origine API existante.
+4. **CI isolée** — l'outillage natif (Gradle, SDK Android) **ne rejoint pas**
+   le graphe Turborepo. Il vit dans un job GitHub Actions dédié, déclenché sur
+   tag/`workflow_dispatch`, qui ne ralentit jamais le pipeline JS/Docker.
+
+**Un dépôt séparé ne se justifierait que** si le mobile était confié à une
+autre équipe/prestataire, ou pour une isolation de build stricte assumée (avec
+publication de `@focusflow/validators` sur un registre privé). Pour une petite
+équipe interne, c'est du surcoût net.
+
+## Pourquoi une TWA plutôt qu'un développement natif
+
+Le web de Tokō est **déjà un vrai PWA** :
+
+- `apps/web/vite.config.ts` — service worker (Workbox), cache offline runtime,
+  Web Push via `push-sw.js`.
+- `apps/web/public/manifest.webmanifest` — `display: standalone`, icônes
+  maskables 192/512, couleur de thème, `start_url: /dashboard`.
+
+Une TWA affiche ce site en plein écran (Chrome Custom Tabs), validé par un
+**Digital Asset Link** (`.well-known/assetlinks.json`). Outils :
+**Bubblewrap** (CLI) ou **PWABuilder** (GUI) produisent un APK signé (test) +
+un AAB (Play Store).
+
+| Option | Réutilisation types/validateurs | Réutilisation UI | Vélocité | Maintenance petite équipe |
+|--------|-------------------------------|-----------------|----------|---------------------------|
+| **TWA / PWA** | 100 % | 100 % | ★★★★★ | ★★★★★ (un seul code) |
+| Expo / React Native | Haute (monorepo) | Nulle (réécriture) | ★★★ | ★★★ (2ᵉ frontend) |
+| React Native nu | Haute | Nulle | ★★ | ★★ |
+| Kotlin natif | Nulle | Nulle | ★ | ★ (compétence absente) |
+| Kotlin Multiplatform | Nulle (TS ≠ Kotlin) | Nulle | ★ | ★ |
+
+**Pourquoi la TWA gagne ici** : l'UI est faite de formulaires, listes et
+graphiques Recharts — aucun besoin natif (caméra, Bluetooth, capteurs) dans la
+surface API. Réutilisation totale, **zéro réécriture**, **zéro divergence**
+avec l'UX « TDAH-simple » déjà auditée (charge cognitive minimale, cohérence).
+shadcn/ui, TailwindCSS-web, TanStack Router et Recharts sont des librairies DOM
+qui **ne tournent pas** en React Native — passer à Expo signifierait réécrire
+tous les écrans.
+
+> **Garde-fou Play Store** : la revue « minimum functionality » rejette les
+> simples WebView. Un vrai PWA installable avec offline + push (ce que nous
+> avons déjà) passe ce seuil ; un wrapper naïf non.
+
+## Authentification mobile
+
+Backend actuel (`apps/api/src/lib/auth.ts`) : Better Auth 1.5.6, **sessions par
+cookie** (30 j), `trustedOrigins`, plugins 2FA + passkey. CORS Hono
+(`apps/api/src/app.ts`) : `credentials: true`, `CORS_ORIGIN` unique.
+
+- **En TWA : aucun changement.** La TWA exécute le vrai site dans un contexte
+  navigateur, cookies first-party sur notre propre origine. Cookies, 2FA,
+  passkeys, Google OAuth : tout fonctionne comme sur le web. **Zéro travail
+  backend d'auth.**
+- **En Expo (repli) : changements additifs, non cassants.**
+  1. Ajouter le plugin serveur `expo()` (cookies stockés via
+     `expo-secure-store`, rejoués en en-têtes — même modèle de session).
+  2. Ajouter le scheme de l'app (`toko://`, + `exp://` en dev) à
+     `trustedOrigins`.
+  3. Client : `@better-auth/expo` + `expo-secure-store`.
+  4. CORS : rendre `cors.origin` tolérant au scheme de l'app (additif).
+  - Échappatoire pour clients non-navigateur : plugin **Bearer** de Better Auth
+    (jetons `Authorization: Bearer …`).
+
+## Paiement / facturation (point sensible)
+
+Facturation actuelle : **Stripe Checkout** (abonnements « Famille »
+mensuel/annuel, `apps/api/src/lib/stripe.ts`). Le web reste 100 % Stripe.
+
+**Règle générale Play** : la vente de biens numériques *dans* l'app doit passer
+par **Google Play Billing** (frais 15–30 %). Contexte 2025/2026 en évolution :
+
+- **EEA / DMA** (pertinent — app française) : *external offers program*, on peut
+  informer/lier vers une offre externe, conditions et frais évolutifs.
+- **US** (post-injonction Epic, oct. 2025) : ouverture au billing tiers,
+  enrôlement requis avant **28 janv. 2026** ; régime transitoire jusqu'à
+  **nov. 2027**, susceptible d'évoluer (audience règlement **22 janv. 2026**).
+
+**Stratégie retenue (par ordre de simplicité) :**
+
+1. **Abonnement web uniquement, app « reader »** *(point de départ recommandé)*
+   — ne rien vendre dans l'app Android. L'utilisateur s'abonne sur le web
+   (Stripe), l'app **lit le droit d'accès** et débloque le premium. Sans frais,
+   sans complexité. Message neutre « gérez votre abonnement sur le site », sans
+   incitation in-app agressive tant que l'enrôlement au programme adéquat n'est
+   pas confirmé.
+2. **Enrôlement au programme *external offers* (EEA)** — garde Stripe, permet de
+   lier/informer légalement, frais réduits mais non nuls.
+3. **Intégrer Google Play Billing** — conformité maximale et meilleure UX
+   d'achat in-app, mais 15–30 %, second système à réconcilier avec Stripe,
+   vérification serveur des achats. Sur-ingénierie tant que la conversion
+   in-app n'est pas un levier prouvé.
+
+> ⚠️ **Incertitude à lever à l'implémentation** : les règles exactes de
+> *steering* in-app et les frais sont en mouvement (audience US 22 janv. 2026 ;
+> conditions EEA changeantes). Revérifier les pages Play Console et idéalement
+> obtenir un avis juridique avant toute incitation in-app.
+
+## Release & distribution de l'APK / AAB (TWA)
+
+1. **Génération** : `bubblewrap init --manifest https://<domaine>/manifest.webmanifest`
+   puis `bubblewrap build` → `app-release-signed.apk` (test) +
+   `app-release-bundle.aab` (Play).
+2. **Digital Asset Links** : héberger `assetlinks.json` à
+   `https://<domaine>/.well-known/assetlinks.json` (empreinte SHA-256 du
+   certificat de signature). À placer dans `apps/web/public/.well-known/` pour
+   qu'il soit livré avec le frontend déployé (Hono/Traefik le sert déjà).
+3. **Signature** : keystore + mots de passe en **secrets GitHub Actions**,
+   jamais dans le repo. Activer **Play App Signing**.
+4. **CI** : workflow dédié (`setup-java`, SDK Android, Bubblewrap), déclenché
+   sur tag `mobile-v*` ou `workflow_dispatch` — **jamais** sur les push de
+   routine.
+5. **Distribution** : piste **Internal Testing** (≤ 100 testeurs) pour valider
+   la revue Play, puis Closed/Open → Production. Note : un **AAB ne se
+   distribue que via Play** ; l'APK direct (sideload) reste pour démo/interne.
+
+> En repli Expo : **EAS Build** (AAB/APK signés) + **EAS Submit** (clé de
+> compte de service Google en secret GH) pour publier sur la piste `internal`.
+
+## Architecture cible
+
+```
+toko/  (monorepo existant — backend inchangé)
+├── apps/
+│   ├── api/        # Hono — déjà déployé ; le mobile est juste un client
+│   ├── web/        # PWA React — manifest + SW + Web Push déjà en place
+│   │   └── public/.well-known/assetlinks.json   # NOUVEAU : Digital Asset Link
+│   └── android/    # NOUVEAU : projet TWA Bubblewrap (généré, rarement édité)
+│                   #          exclu du `turbo build` par défaut
+├── packages/
+│   ├── validators/ # @focusflow/validators — inchangé, source de vérité unique
+│   └── db/
+└── .github/workflows/
+    ├── ci.yml / release.yml   # pipeline backend inchangé
+    └── android-release.yml     # NOUVEAU : build mobile, gated sur tag mobile-v*
+```
+
+```mermaid
+graph TD
+    A[App Android TWA] -->|enrobe| B[PWA web déployé]
+    B -->|Fetch REST + cookie| C[API Hono déployée]
+    C -->|Drizzle| D[PostgreSQL]
+    C -->|Webhooks| E[Stripe]
+    A -.assetlinks.json.-> B
+    F[apps/android Bubblewrap] -->|génère| G[APK / AAB]
+    G -->|Internal Testing| H[Play Store]
+```
+
+## Plan de mise en œuvre (TWA)
+
+1. **Préparer le PWA pour la TWA** — vérifier que le manifest est complet
+   (déjà le cas) et choisir un `start_url` adapté à l'ouverture mobile.
+2. **Publier `assetlinks.json`** — ajouter `apps/web/public/.well-known/assetlinks.json`
+   avec l'empreinte SHA-256 du certificat de signature (Play App Signing).
+3. **Générer le projet** — `apps/android/` via Bubblewrap, exclu du
+   `turbo build` par défaut, avec son propre `versionCode`/`versionName`.
+4. **Workflow `android-release.yml`** — déclenché sur tag `mobile-v*`, secrets
+   keystore, sortie AAB téléversée sur la piste Internal Testing.
+5. **Abonnement** — laisser l'achat sur le web ; l'app lit `GET /api/billing/status`
+   pour débloquer le premium. Enrôler le compte au programme *external offers*
+   EEA avant toute incitation in-app.
+6. **Repli Expo** — décider à l'avance de migrer la cible Android vers Expo
+   (toujours en monorepo, validateurs réutilisés, `@better-auth/expo`)
+   **uniquement** si un besoin natif concret bloque la TWA.
+
+## Sources
+
+- Better Auth — [Expo](https://better-auth.com/docs/integrations/expo),
+  [Bearer plugin](https://better-auth.com/docs/plugins/bearer)
+- Google Play — [Payments policy](https://support.google.com/googleplay/android-developer/answer/10281818),
+  [US billing update](https://support.google.com/googleplay/android-developer/answer/15582165),
+  [EEA external offers](https://support.google.com/googleplay/android-developer/answer/16505463)
+- Expo — [EAS Build](https://docs.expo.dev/build/introduction/),
+  [App signing](https://docs.expo.dev/app-signing/app-credentials/)
+- [Bubblewrap](https://github.com/GoogleChromeLabs/bubblewrap),
+  [Trusted Web Activities](https://developer.android.com/develop/ui/views/layout/webapps/guide-trusted-web-activities-version2),
+  [PWA in Play (codelab)](https://developers.google.com/codelabs/pwa-in-play)

--- a/docs/android-app.md
+++ b/docs/android-app.md
@@ -3,87 +3,91 @@
 Document de décision pour la déclinaison Android de Tokō et la production
 d'un APK / AAB publiable sur le Play Store.
 
-> **Statut** : proposition (à valider). Issue d'un atelier d'analyse
-> codebase + recherche menée par sous-agents.
+> **Statut** : adopté. Issu d'un atelier d'analyse codebase + recherche
+> (sous-agents), puis d'un « grill » contradictoire qui a fait évoluer la
+> décision (voir _Historique de décision_ en fin de document).
 
 ## Question posée
 
 Faut-il ajouter l'application Android **directement dans le monorepo**, ou
 créer un **dépôt séparé** qui attaque le backend et la base de données déjà
-déployés de la version web ?
+déployés de la version web ? Et avec quelle technologie ?
 
 ## Décision en une ligne
 
-**TWA d'abord** (le PWA est déjà prêt), **monorepo toujours**, **abonnement
-Stripe sur le web d'abord**, **Expo uniquement si une fonctionnalité native
-l'impose.**
+**Expo / React Native, dans le monorepo**, client de l'API déjà déployée,
+notifications natives, abonnement sur le web.
 
 ## Recommandation
 
 | Sujet | Décision |
 |-------|----------|
-| Technologie | **Trusted Web Activity (TWA)** enrobant le PWA existant |
-| Emplacement | **Monorepo** : nouveau package `apps/android` |
+| Technologie | **Expo / React Native** (UI native) |
+| Emplacement | **Monorepo** : package `apps/mobile`, isolé du graphe JS racine |
 | Backend | Inchangé — l'app mobile est **un client de plus** de l'API déployée |
-| Auth | **Aucun changement** (cookies de session, comme sur le web) |
+| Auth | Plugin **`@better-auth/expo`** (cookies en SecureStore) — additif, non cassant |
+| Notifications | **`expo-notifications`** (locales planifiées + FCM) — l'OS possède l'horaire |
 | Paiement | Abonnement **sur le web (Stripe)** ; l'app lit le droit d'accès |
-| Repli | **Expo / React Native** si un besoin natif concret apparaît |
+| Build / release | **EAS Build** → AAB/APK, piste Play Internal Testing |
+
+## Le facteur décisif : le rappel du soir doit être fiable
+
+La règle métier (`docs/offline-strategy.md`) place le check-in du soir entre
+**16h30 et 21h00** au cœur du produit. Un rappel programmé à cette heure-là est
+une **notification planifiée et sensible au temps** — précisément l'angle mort
+du web :
+
+- Les PWA/TWA **ne garantissent pas la planification** quand l'app est en
+  arrière-plan ou fermée ; les navigateurs privilégient la batterie. Conseil
+  unanime des sources : _« si les notifications sont une promesse centrale,
+  laissez l'OS posséder la planification. »_
+- En TWA, des bugs documentés font que la notification atterrit sur le PWA
+  installé, **pas** sur la TWA.
+
+Comme la fiabilité de ce rappel est **non négociable**, l'OS doit posséder la
+planification → **app native**. `expo-notifications` fournit les notifications
+locales planifiées (horaire garanti par l'OS) + FCM, avec canal Android dédié,
+niveau d'importance et `SCHEDULE_EXACT_ALARM` (Android 14). C'est ce point, et
+lui seul, qui élimine la voie TWA.
+
+## Pourquoi Expo plutôt que natif Kotlin / KMP
+
+| Option | Réutilisation types/validateurs | Compétence équipe | Notif. natives | Verdict |
+|--------|-------------------------------|-------------------|----------------|---------|
+| **Expo / React Native** | Haute (monorepo, TS) | React/TS ✅ | ✅ | **Retenu** |
+| Kotlin / Jetpack Compose | Nulle (réécriture Kotlin) | absente | ✅ | Rejeté |
+| Kotlin Multiplatform | Nulle (logique en TS) | absente | ✅ | Rejeté |
+| TWA / PWA enrobé | 100 % mais **0 code natif** | React/TS ✅ | ❌ (web push) | **Rejeté** (rappel non fiable) |
+
+Pour une équipe React/TypeScript, Expo donne les notifications natives **et**
+réutilise `@focusflow/validators` + les types via le monorepo. Kotlin/KMP
+jettent ce capital sans bénéfice ici (UI = formulaires + listes + graphes,
+aucun besoin natif exotique).
+
+> **iOS** : hors périmètre (produit Android-only assumé). Expo garde toutefois
+> la porte iOS ouverte sans réécriture si la décision change.
 
 ## Pourquoi le monorepo plutôt qu'un dépôt séparé
 
 1. **Réutilisation des validateurs** — `@focusflow/validators` est un package
-   `private`, non publié, exporté en `./src/index.ts` et résolu par les
-   workspaces pnpm. Un client mobile TypeScript ne peut le réutiliser
-   « gratuitement » que **dans le monorepo** (dépendance `workspace:*`). Un
-   dépôt séparé imposerait de publier le package sur un registre privé →
-   machinerie de release et risque de désynchronisation de versions.
-2. **Source de vérité unique** — règles de validation et types TS restent
-   partagés entre web, API et mobile, sans dérive.
-3. **Backend déjà déployé** — c'est le facteur décisif : pas de réarchitecture,
-   pas de nouveau déploiement, pas de nouvelle base. Le mobile pointe sur
-   l'origine API existante.
-4. **CI isolée** — l'outillage natif (Gradle, SDK Android) **ne rejoint pas**
-   le graphe Turborepo. Il vit dans un job GitHub Actions dédié, déclenché sur
-   tag/`workflow_dispatch`, qui ne ralentit jamais le pipeline JS/Docker.
+   `private`, non publié (`main: ./src/index.ts`). Un client mobile TypeScript
+   ne le réutilise « gratuitement » que **dans le monorepo**. Un dépôt séparé
+   imposerait de le publier sur un registre privé → release et risque de
+   désynchronisation de versions.
+2. **Source de vérité unique** — règles de validation et types TS partagés
+   entre web, API et mobile, sans dérive.
+3. **Backend déjà déployé** — facteur décisif de simplicité : pas de
+   réarchitecture, pas de nouveau déploiement, pas de nouvelle base. Le mobile
+   pointe sur l'origine API existante.
+4. **Isolation du build natif** — l'outillage natif (Gradle, SDK Android, EAS)
+   **ne rejoint pas** le graphe Turborepo. `apps/mobile` est **exclu du
+   `pnpm install` racine** (`!apps/mobile` dans `pnpm-workspace.yaml`) ; il a
+   ses propres dépendances installées par EAS au build. Les validateurs sont
+   partagés par la **source** (lien `file:` + résolution Metro), pas par le
+   lockfile racine. Résultat : la CI JS/Docker existante reste intacte.
 
 **Un dépôt séparé ne se justifierait que** si le mobile était confié à une
-autre équipe/prestataire, ou pour une isolation de build stricte assumée (avec
-publication de `@focusflow/validators` sur un registre privé). Pour une petite
-équipe interne, c'est du surcoût net.
-
-## Pourquoi une TWA plutôt qu'un développement natif
-
-Le web de Tokō est **déjà un vrai PWA** :
-
-- `apps/web/vite.config.ts` — service worker (Workbox), cache offline runtime,
-  Web Push via `push-sw.js`.
-- `apps/web/public/manifest.webmanifest` — `display: standalone`, icônes
-  maskables 192/512, couleur de thème, `start_url: /dashboard`.
-
-Une TWA affiche ce site en plein écran (Chrome Custom Tabs), validé par un
-**Digital Asset Link** (`.well-known/assetlinks.json`). Outils :
-**Bubblewrap** (CLI) ou **PWABuilder** (GUI) produisent un APK signé (test) +
-un AAB (Play Store).
-
-| Option | Réutilisation types/validateurs | Réutilisation UI | Vélocité | Maintenance petite équipe |
-|--------|-------------------------------|-----------------|----------|---------------------------|
-| **TWA / PWA** | 100 % | 100 % | ★★★★★ | ★★★★★ (un seul code) |
-| Expo / React Native | Haute (monorepo) | Nulle (réécriture) | ★★★ | ★★★ (2ᵉ frontend) |
-| React Native nu | Haute | Nulle | ★★ | ★★ |
-| Kotlin natif | Nulle | Nulle | ★ | ★ (compétence absente) |
-| Kotlin Multiplatform | Nulle (TS ≠ Kotlin) | Nulle | ★ | ★ |
-
-**Pourquoi la TWA gagne ici** : l'UI est faite de formulaires, listes et
-graphiques Recharts — aucun besoin natif (caméra, Bluetooth, capteurs) dans la
-surface API. Réutilisation totale, **zéro réécriture**, **zéro divergence**
-avec l'UX « TDAH-simple » déjà auditée (charge cognitive minimale, cohérence).
-shadcn/ui, TailwindCSS-web, TanStack Router et Recharts sont des librairies DOM
-qui **ne tournent pas** en React Native — passer à Expo signifierait réécrire
-tous les écrans.
-
-> **Garde-fou Play Store** : la revue « minimum functionality » rejette les
-> simples WebView. Un vrai PWA installable avec offline + push (ce que nous
-> avons déjà) passe ce seuil ; un wrapper naïf non.
+autre équipe/prestataire. Pour une petite équipe interne, c'est du surcoût net.
 
 ## Authentification mobile
 
@@ -91,74 +95,44 @@ Backend actuel (`apps/api/src/lib/auth.ts`) : Better Auth 1.5.6, **sessions par
 cookie** (30 j), `trustedOrigins`, plugins 2FA + passkey. CORS Hono
 (`apps/api/src/app.ts`) : `credentials: true`, `CORS_ORIGIN` unique.
 
-- **En TWA : aucun changement.** La TWA exécute le vrai site dans un contexte
-  navigateur, cookies first-party sur notre propre origine. Cookies, 2FA,
-  passkeys, Google OAuth : tout fonctionne comme sur le web. **Zéro travail
-  backend d'auth.**
-- **En Expo (repli) : changements additifs, non cassants.**
-  1. Ajouter le plugin serveur `expo()` (cookies stockés via
-     `expo-secure-store`, rejoués en en-têtes — même modèle de session).
-  2. Ajouter le scheme de l'app (`toko://`, + `exp://` en dev) à
-     `trustedOrigins`.
-  3. Client : `@better-auth/expo` + `expo-secure-store`.
-  4. CORS : rendre `cors.origin` tolérant au scheme de l'app (additif).
-  - Échappatoire pour clients non-navigateur : plugin **Bearer** de Better Auth
-    (jetons `Authorization: Bearer …`).
+Changements backend **additifs et non cassants** :
 
-## Paiement / facturation (point sensible)
+1. Ajouter le plugin serveur `expo()` (cookies stockés via `expo-secure-store`,
+   rejoués en en-têtes — même modèle de session).
+2. Ajouter le scheme de l'app (`toko://`, + `exp://` en dev) à `trustedOrigins`.
+3. Côté client : `@better-auth/expo` + `expo-secure-store` ;
+   `authClient.getCookie()` fournit le cookie à attacher aux appels API.
+4. CORS : rendre `cors.origin` tolérant au scheme de l'app (prédicat additif).
 
-Facturation actuelle : **Stripe Checkout** (abonnements « Famille »
-mensuel/annuel, `apps/api/src/lib/stripe.ts`). Le web reste 100 % Stripe.
+Aucun changement cassant pour l'auth web existante.
 
-**Règle générale Play** : la vente de biens numériques *dans* l'app doit passer
-par **Google Play Billing** (frais 15–30 %). Contexte 2025/2026 en évolution :
+## Paiement / facturation
 
-- **EEA / DMA** (pertinent — app française) : *external offers program*, on peut
-  informer/lier vers une offre externe, conditions et frais évolutifs.
-- **US** (post-injonction Epic, oct. 2025) : ouverture au billing tiers,
-  enrôlement requis avant **28 janv. 2026** ; régime transitoire jusqu'à
-  **nov. 2027**, susceptible d'évoluer (audience règlement **22 janv. 2026**).
+Facturation actuelle : **Stripe Checkout** (`apps/api/src/lib/stripe.ts`). Le
+web reste 100 % Stripe.
 
-**Stratégie retenue (par ordre de simplicité) :**
+**Décision : abonnement sur le web uniquement, app « reader ».** On ne vend
+rien dans l'app Android : l'utilisateur s'abonne sur le web (Stripe), l'app
+**lit le droit d'accès** via `GET /api/billing/status` et débloque le premium.
+Pas de Google Play Billing (15–30 %), pas de zone grise « checkout Stripe dans
+une webview ». L'achat se fait dans le **navigateur externe** (`expo-web-browser`),
+clairement hors de l'app.
 
-1. **Abonnement web uniquement, app « reader »** *(point de départ recommandé)*
-   — ne rien vendre dans l'app Android. L'utilisateur s'abonne sur le web
-   (Stripe), l'app **lit le droit d'accès** et débloque le premium. Sans frais,
-   sans complexité. Message neutre « gérez votre abonnement sur le site », sans
-   incitation in-app agressive tant que l'enrôlement au programme adéquat n'est
-   pas confirmé.
-2. **Enrôlement au programme *external offers* (EEA)** — garde Stripe, permet de
-   lier/informer légalement, frais réduits mais non nuls.
-3. **Intégrer Google Play Billing** — conformité maximale et meilleure UX
-   d'achat in-app, mais 15–30 %, second système à réconcilier avec Stripe,
-   vérification serveur des achats. Sur-ingénierie tant que la conversion
-   in-app n'est pas un levier prouvé.
+> ⚠️ Si la conversion in-app devient un levier prouvé, réévaluer le programme
+> *external offers* EEA ou Google Play Billing — politique Play en évolution
+> (audience US 22 janv. 2026 ; conditions EEA changeantes), à revérifier.
 
-> ⚠️ **Incertitude à lever à l'implémentation** : les règles exactes de
-> *steering* in-app et les frais sont en mouvement (audience US 22 janv. 2026 ;
-> conditions EEA changeantes). Revérifier les pages Play Console et idéalement
-> obtenir un avis juridique avant toute incitation in-app.
+## Release & distribution (EAS)
 
-## Release & distribution de l'APK / AAB (TWA)
-
-1. **Génération** : `bubblewrap init --manifest https://<domaine>/manifest.webmanifest`
-   puis `bubblewrap build` → `app-release-signed.apk` (test) +
-   `app-release-bundle.aab` (Play).
-2. **Digital Asset Links** : héberger `assetlinks.json` à
-   `https://<domaine>/.well-known/assetlinks.json` (empreinte SHA-256 du
-   certificat de signature). À placer dans `apps/web/public/.well-known/` pour
-   qu'il soit livré avec le frontend déployé (Hono/Traefik le sert déjà).
-3. **Signature** : keystore + mots de passe en **secrets GitHub Actions**,
-   jamais dans le repo. Activer **Play App Signing**.
-4. **CI** : workflow dédié (`setup-java`, SDK Android, Bubblewrap), déclenché
-   sur tag `mobile-v*` ou `workflow_dispatch` — **jamais** sur les push de
-   routine.
-5. **Distribution** : piste **Internal Testing** (≤ 100 testeurs) pour valider
-   la revue Play, puis Closed/Open → Production. Note : un **AAB ne se
-   distribue que via Play** ; l'APK direct (sideload) reste pour démo/interne.
-
-> En repli Expo : **EAS Build** (AAB/APK signés) + **EAS Submit** (clé de
-> compte de service Google en secret GH) pour publier sur la piste `internal`.
+- **EAS Build** produit un AAB (Play) signé et un APK (sideload/test) ; EAS gère
+  le keystore (jamais commité).
+- **EAS Submit** téléverse sur la piste **Internal Testing** via une clé de
+  **compte de service Google** (secret GitHub).
+- **CI** : workflow dédié `.github/workflows/android-release.yml`, déclenché sur
+  tag `mobile-v*` ou `workflow_dispatch` — **jamais** sur les push de routine.
+  Le mobile a son propre `versionCode`/`versionName`, découplé du tag Docker.
+- **Secrets requis** : `EXPO_TOKEN` (EAS), `GOOGLE_SERVICE_ACCOUNT_KEY_JSON`
+  (Play Submit).
 
 ## Architecture cible
 
@@ -166,55 +140,62 @@ par **Google Play Billing** (frais 15–30 %). Contexte 2025/2026 en évolution 
 toko/  (monorepo existant — backend inchangé)
 ├── apps/
 │   ├── api/        # Hono — déjà déployé ; le mobile est juste un client
-│   ├── web/        # PWA React — manifest + SW + Web Push déjà en place
-│   │   └── public/.well-known/assetlinks.json   # NOUVEAU : Digital Asset Link
-│   └── android/    # NOUVEAU : projet TWA Bubblewrap (généré, rarement édité)
-│                   #          exclu du `turbo build` par défaut
+│   ├── web/        # PWA React — inchangé (reste l'app web/desktop)
+│   └── mobile/     # NOUVEAU : Expo / React Native
+│                   #   exclu du pnpm install racine (!apps/mobile)
+│                   #   buildé par EAS ; valide via @focusflow/validators
 ├── packages/
-│   ├── validators/ # @focusflow/validators — inchangé, source de vérité unique
+│   ├── validators/ # @focusflow/validators — source de vérité partagée
 │   └── db/
 └── .github/workflows/
-    ├── ci.yml / release.yml   # pipeline backend inchangé
-    └── android-release.yml     # NOUVEAU : build mobile, gated sur tag mobile-v*
+    ├── ci.yml / release.yml      # pipeline backend inchangé
+    └── android-release.yml        # NOUVEAU : EAS build, gated sur tag mobile-v*
 ```
 
 ```mermaid
 graph TD
-    A[App Android TWA] -->|enrobe| B[PWA web déployé]
-    B -->|Fetch REST + cookie| C[API Hono déployée]
+    A[App Android Expo/RN] -->|Fetch REST + cookie SecureStore| C[API Hono déployée]
+    A -->|expo-notifications| N[Rappel du soir natif planifié OS]
+    A -->|@focusflow/validators| V[Schémas Zod partagés]
+    A -->|expo-web-browser| W[Abonnement web Stripe]
     C -->|Drizzle| D[PostgreSQL]
-    C -->|Webhooks| E[Stripe]
-    A -.assetlinks.json.-> B
-    F[apps/android Bubblewrap] -->|génère| G[APK / AAB]
-    G -->|Internal Testing| H[Play Store]
+    C -->|GET /api/billing/status| A
+    E[EAS Build] -->|AAB/APK signé| P[Play Internal Testing]
 ```
 
-## Plan de mise en œuvre (TWA)
+## Plan de mise en œuvre
 
-1. **Préparer le PWA pour la TWA** — vérifier que le manifest est complet
-   (déjà le cas) et choisir un `start_url` adapté à l'ouverture mobile.
-2. **Publier `assetlinks.json`** — ajouter `apps/web/public/.well-known/assetlinks.json`
-   avec l'empreinte SHA-256 du certificat de signature (Play App Signing).
-3. **Générer le projet** — `apps/android/` via Bubblewrap, exclu du
-   `turbo build` par défaut, avec son propre `versionCode`/`versionName`.
-4. **Workflow `android-release.yml`** — déclenché sur tag `mobile-v*`, secrets
-   keystore, sortie AAB téléversée sur la piste Internal Testing.
-5. **Abonnement** — laisser l'achat sur le web ; l'app lit `GET /api/billing/status`
-   pour débloquer le premium. Enrôler le compte au programme *external offers*
-   EEA avant toute incitation in-app.
-6. **Repli Expo** — décider à l'avance de migrer la cible Android vers Expo
-   (toujours en monorepo, validateurs réutilisés, `@better-auth/expo`)
-   **uniquement** si un besoin natif concret bloque la TWA.
+1. **Scaffold `apps/mobile`** (fait) — Expo, isolé du workspace racine,
+   réutilise `@focusflow/validators`, client API + auth + notifications.
+2. **Workflow `android-release.yml`** (fait) — EAS build/submit, gated tag.
+3. **Auth backend additive** — plugin `expo()` + scheme dans `trustedOrigins`
+   + prédicat CORS (à faire quand le flux mobile est branché).
+4. **Migration des écrans** — porter progressivement les écrans web (NativeWind
+   pour Tailwind, Victory Native pour les graphes Recharts), en commençant par
+   le **check-in du soir** (fonction critique) et l'auth.
+5. **Abonnement** — `GET /api/billing/status` pour le droit d'accès ; achat via
+   navigateur externe.
+6. **Secrets CI** — `EXPO_TOKEN`, `GOOGLE_SERVICE_ACCOUNT_KEY_JSON`.
+
+## Historique de décision
+
+1. **TWA-first** (initial) — le PWA existant enrobé en APK, réutilisation 100 %.
+2. **Grill contradictoire** — trois facteurs testés : iOS, fiabilité des
+   notifications, paiement in-app.
+3. **Pivot** — iOS écarté (Android-only) ; paiement web confirmé ; **le rappel
+   du soir jugé critique et sa planification fiable vérifiée comme infaisable en
+   PWA/TWA** → bascule vers **Expo / React Native**, seul à donner des
+   notifications dont l'OS possède l'horaire.
 
 ## Sources
 
 - Better Auth — [Expo](https://better-auth.com/docs/integrations/expo),
   [Bearer plugin](https://better-auth.com/docs/plugins/bearer)
-- Google Play — [Payments policy](https://support.google.com/googleplay/android-developer/answer/10281818),
-  [US billing update](https://support.google.com/googleplay/android-developer/answer/15582165),
-  [EEA external offers](https://support.google.com/googleplay/android-developer/answer/16505463)
+- [PWA notifications limits (DEV)](https://dev.to/nishchaldev/when-notifications-matter-pwas-start-to-show-their-limits-5ebl),
+  [PWA push reliability iOS/Android (Edana)](https://edana.ch/en/2026/03/19/push-notifications-on-web-applications-pwa-is-it-really-reliable-on-ios-and-android/),
+  [TWA web-push bug (PWABuilder #3788)](https://github.com/pwa-builder/PWABuilder/issues/3788)
 - Expo — [EAS Build](https://docs.expo.dev/build/introduction/),
+  [Notifications](https://docs.expo.dev/versions/latest/sdk/notifications/),
   [App signing](https://docs.expo.dev/app-signing/app-credentials/)
-- [Bubblewrap](https://github.com/GoogleChromeLabs/bubblewrap),
-  [Trusted Web Activities](https://developer.android.com/develop/ui/views/layout/webapps/guide-trusted-web-activities-version2),
-  [PWA in Play (codelab)](https://developers.google.com/codelabs/pwa-in-play)
+- Google Play — [Payments policy](https://support.google.com/googleplay/android-developer/answer/10281818),
+  [EEA external offers](https://support.google.com/googleplay/android-developer/answer/16505463)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,7 @@
 packages:
   - "apps/*"
+  # apps/mobile (Expo / React Native) is intentionally excluded from the root
+  # pnpm install graph so its native deps never touch the JS/Docker pipeline.
+  # It is built by EAS with its own install; see docs/android-app.md.
+  - "!apps/mobile"
   - "packages/*"


### PR DESCRIPTION
## Objet

Décision d'architecture **et** fondation de l'app Android de Tokō, puis chaîne de release. L'app mobile est **un client de plus** de l'API/DB déjà déployées — pas de réarchitecture backend.

## Décision (après grill contradictoire)

**Expo / React Native, dans le monorepo.** Le déclencheur : le **rappel du soir (16h30–21h00) doit être fiable**, or une notification *planifiée et sensible au temps* n'est pas garantie en PWA/TWA quand l'app est fermée — seul l'OS peut la posséder (`expo-notifications`). iOS écarté (Android-only), abonnement gardé **sur le web** (Stripe, pas de Play Billing).

Historique TWA-first → pivot Expo documenté dans `docs/android-app.md`.

## Contenu

- **`docs/android-app.md`** — ADR complet (techno, monorepo vs dépôt séparé, auth mobile, paiement, release EAS, diagrammes, historique de décision).
- **`apps/mobile/`** — scaffold Expo : client API cookie-aware, client Better Auth Expo (SecureStore), **planificateur de rappel du soir natif**, écrans Login/Home réutilisant les types `@focusflow/validators`, config `app.json`/`eas.json`/Metro.
- **`.github/workflows/android-release.yml`** — EAS build/submit, **gated sur tag `mobile-v*` / dispatch** (ne tourne jamais sur les push de routine).
- **`pnpm-workspace.yaml`** — `!apps/mobile` : le package mobile est **exclu du `pnpm install` racine**, donc ses dépendances natives ne touchent ni la CI JS ni le build Docker. Validateurs partagés par la source (lien `file:` + Metro/TS).

## Sûreté CI

- `pnpm install --frozen-lockfile` inchangé (lockfile non modifié, mobile hors workspace).
- `turbo typecheck` n'inclut pas le mobile ; linters maison (guilt-lexicon, trackers) scannent uniquement `apps/web`.
- Le build mobile réel est géré par EAS (cloud), hors de ce pipeline.

## Suite (hors PR)

Auth backend additive (plugin `expo()` + scheme dans `trustedOrigins` + prédicat CORS) et migration progressive des écrans (NativeWind, Victory Native), à commencer par le check-in du soir.

https://claude.ai/code/session_01Vw4dbYW3VqdGDFiFPQuNeY