### PR TITLE
feat(api): support auth Better Auth Expo pour le client mobile (additif)

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -14,6 +14,7 @@
     "db:seed": "tsx --env-file-if-exists=../../.env src/seed.ts"
   },
   "dependencies": {
+    "@better-auth/expo": "1.5.6",
     "@better-auth/passkey": "1.5.6",
     "@focusflow/db": "workspace:*",
     "@simplewebauthn/server": "13.3.0",

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -119,10 +119,24 @@ app.route("/api/admin-vault", adminVaultRoutes);
 // Body size limit — 1MB global (after webhook route which needs raw body)
 app.use("*", bodyLimit({ maxSize: 1024 * 1024 }));
 
+// The web SPA is the primary CORS origin; the Expo Android client (apps/mobile)
+// sends `Origin: toko://` (or `exp://` in dev). Native apps aren't subject to
+// browser CORS, but Better Auth's Expo plugin still emits an Origin header, so
+// we reflect the app scheme back to keep credentialed requests clean. Unknown
+// origins fall back to the web origin (no reflection), preserving prior behavior.
+const webOrigin = env.CORS_ORIGIN ?? "http://localhost:5173";
+const mobileOriginSchemes = ["toko://", "exp://"];
 app.use(
   "*",
   cors({
-    origin: env.CORS_ORIGIN ?? "http://localhost:5173",
+    origin: (origin) => {
+      if (!origin) return webOrigin;
+      if (origin === webOrigin) return webOrigin;
+      if (mobileOriginSchemes.some((scheme) => origin.startsWith(scheme))) {
+        return origin;
+      }
+      return webOrigin;
+    },
     credentials: true,
   })
 );

--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -3,6 +3,7 @@ import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { APIError } from "better-auth/api";
 import { twoFactor } from "better-auth/plugins";
 import { passkey } from "@better-auth/passkey";
+import { expo } from "@better-auth/expo";
 import { eq } from "drizzle-orm";
 import { db, user } from "@focusflow/db";
 import { env } from "./env";
@@ -21,6 +22,13 @@ export const REMINDER_STEP_HEADER = "x-toko-verify-reminder-step";
 
 const devWebOrigins = ["http://localhost:5173", "http://localhost:5176"] as const
 
+// Deep-link schemes for the Expo Android client (apps/mobile). The native app
+// has no browser Origin, so Better Auth validates these schemes against
+// trustedOrigins on state-changing auth requests. `toko://` is the production
+// scheme (app.json → expo.scheme); `exp://` covers Expo Go during dev. Adding
+// them is purely additive and does not affect web auth.
+const mobileAppOrigins = ["toko://", "exp://"] as const
+
 export const auth = betterAuth({
   // Surfaced as the TOTP issuer label in authenticator apps ("Tokō:
   // parent@example.com" in Google Authenticator / Authy / 1Password).
@@ -32,6 +40,7 @@ export const auth = betterAuth({
   // elle diffère légèrement de CORS_ORIGIN.
   trustedOrigins: [
     ...devWebOrigins,
+    ...mobileAppOrigins,
     ...(env.CORS_ORIGIN ? [env.CORS_ORIGIN] : []),
     ...(env.APP_URL ? [env.APP_URL] : []),
   ],
@@ -158,6 +167,11 @@ export const auth = betterAuth({
     },
   },
   plugins: [
+    // Native Android client support (apps/mobile). Enables the Expo client to
+    // store the session cookie in expo-secure-store and replay it via headers,
+    // and handles the app's deep-link scheme for OAuth redirects. Additive —
+    // web auth (cookies, 2FA, passkeys) is unchanged.
+    expo(),
     // TOTP-based second factor. Backup codes are auto-generated on enroll
     // and surfaced once — the SPA must show them, the parent must save
     // them. `issuer` falls back to `appName` above; setting it explicitly

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -2,7 +2,13 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    // The API runs via tsx and is never emitted as a library (build = tsx,
+    // no project references point here), so it produces no .d.ts. Disabling
+    // declaration emit avoids spurious TS2742 "inferred type cannot be named"
+    // errors from pnpm-virtualised Better Auth plugin types (e.g. better-call).
+    "declaration": false,
+    "declarationMap": false
   },
   "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
 
   apps/api:
     dependencies:
+      '@better-auth/expo':
+        specifier: 1.5.6
+        version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(better-auth@1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(gel@2.2.0)(kysely@0.28.14)(postgres@3.4.8))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))))
       '@better-auth/passkey':
         specifier: 1.5.6
         version: 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(better-auth@1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(gel@2.2.0)(kysely@0.28.14)(postgres@3.4.8))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))))(better-call@1.3.2(zod@3.25.76))(nanostores@1.2.0)
@@ -887,6 +890,25 @@ packages:
       drizzle-orm: '>=0.41.0'
     peerDependenciesMeta:
       drizzle-orm:
+        optional: true
+
+  '@better-auth/expo@1.5.6':
+    resolution: {integrity: sha512-LZsX8c1hbo+W3EEx3bpuO+MCl8BKhuiboGs8+Kaq6TaB3Ca684oGgvWAhHVPaH4yd6TA+jdX5QC+RXb9xX2Gmw==}
+    peerDependencies:
+      '@better-auth/core': 1.5.6
+      better-auth: 1.5.6
+      expo-constants: '>=17.0.0'
+      expo-linking: '>=7.0.0'
+      expo-network: '>=8.0.7'
+      expo-web-browser: '>=14.0.0'
+    peerDependenciesMeta:
+      expo-constants:
+        optional: true
+      expo-linking:
+        optional: true
+      expo-network:
+        optional: true
+      expo-web-browser:
         optional: true
 
   '@better-auth/kysely-adapter@1.5.6':
@@ -5864,6 +5886,14 @@ snapshots:
     optionalDependencies:
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.0)(gel@2.2.0)(kysely@0.28.14)(postgres@3.4.8)
 
+  '@better-auth/expo@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(better-auth@1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(gel@2.2.0)(kysely@0.28.14)(postgres@3.4.8))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0))))':
+    dependencies:
+      '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
+      '@better-fetch/fetch': 1.1.21
+      better-auth: 1.5.6(@opentelemetry/api@1.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.0)(gel@2.2.0)(kysely@0.28.14)(postgres@3.4.8))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.0)(jsdom@29.0.1(@noble/hashes@2.0.1))(msw@2.12.14(@types/node@25.5.0)(typescript@5.9.3))(vite@6.4.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)(tsx@4.21.0)))
+      better-call: 1.3.2(zod@4.3.6)
+      zod: 4.3.6
+
   '@better-auth/kysely-adapter@1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0))(@better-auth/utils@0.3.1)(kysely@0.28.14)':
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.0)(better-call@1.3.2(zod@3.25.76))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.2.0)
@@ -7203,6 +7233,15 @@ snapshots:
       set-cookie-parser: 3.1.0
     optionalDependencies:
       zod: 3.25.76
+
+  better-call@1.3.2(zod@4.3.6):
+    dependencies:
+      '@better-auth/utils': 0.3.1
+      '@better-fetch/fetch': 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.0
+    optionalDependencies:
+      zod: 4.3.6
 
   bidi-js@1.0.3:
     dependencies:


### PR DESCRIPTION
## Objet

Étape 1 du plan post-ADR (`docs/android-app.md`) : permettre au client Expo Android (`apps/mobile`) de s'authentifier contre le backend existant, **sans aucun changement cassant** pour l'auth web.

## Changements (tous additifs)

- **Plugin serveur `expo()`** ajouté à Better Auth (`apps/api/src/lib/auth.ts`) — permet au client Expo de stocker le cookie de session dans `expo-secure-store` et de le rejouer en en-têtes, et gère le scheme deep-link pour les redirections OAuth.
- **Schemes `toko://` et `exp://`** ajoutés à `trustedOrigins` — l'app native n'a pas d'`Origin` navigateur ; Better Auth valide ces schemes sur les requêtes d'auth sensibles.
- **Prédicat CORS** (`apps/api/src/app.ts`) — reflète le scheme de l'app pour des requêtes credentialées propres ; l'origine web et le comportement existant sont inchangés (fallback sur `webOrigin` pour toute origine inconnue).
- **`@better-auth/expo@1.5.6`** ajouté aux dépendances de l'API (aligné sur `@better-auth/passkey`).

## Note technique : `declaration: false` pour l'API

Le plugin Expo tire une variante pnpm-virtualisée de `better-call` (liée à zod 4) qui rend le type inféré de `auth` non-nommable → **TS2742** lors de la validation d'émission `.d.ts`. L'API tourne via **tsx** et n'émet jamais de `.d.ts` (build = `tsx`, aucune référence de projet ne pointe vers elle), donc `declaration`/`declarationMap` y sont désactivés. Correctif propre et ciblé, pas un contournement global.

## Vérifications locales

- `pnpm --filter @focusflow/api typecheck` ✅
- `pnpm --filter @focusflow/api test` ✅ (105 passés)
- `pnpm typecheck` (monorepo) ✅
- linters maison (guilt-lexicon, trackers) ✅

## Suite

Migration progressive des écrans mobile (NativeWind, Victory Native), en commençant par le check-in du soir.

https://claude.ai/code/session_01Vw4dbYW3VqdGDFiFPQuNeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw4dbYW3VqdGDFiFPQuNeY)_