### PR TITLE
feat(mobile): écran de check-in du soir (React Native)

### DIFF
--- a/apps/mobile/src/hooks/use-symptoms.ts
+++ b/apps/mobile/src/hooks/use-symptoms.ts
@@ -1,0 +1,90 @@
+import type {
+  CreateSymptom,
+  Symptom,
+  UpdateSymptom,
+} from "@focusflow/validators";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { api } from "../lib/api";
+
+// Mirrors apps/web/src/hooks/use-symptoms.ts: same query keys, optimistic
+// updates and invalidation (symptoms list + stats for the calm-minutes KPI),
+// so the mobile evening check-in behaves exactly like the web one.
+const symptomsKey = (childId: string) => ["symptoms", childId] as const;
+
+export function useSymptoms(childId: string) {
+  return useQuery({
+    queryKey: symptomsKey(childId),
+    queryFn: () => api.get<Symptom[]>(`/symptoms/${childId}`),
+    enabled: !!childId,
+  });
+}
+
+export function useCreateSymptom() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateSymptom) => api.post<Symptom>("/symptoms", data),
+    onMutate: async (variables) => {
+      const key = symptomsKey(variables.childId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<Symptom[]>(key);
+      const now = new Date().toISOString();
+      const optimistic: Symptom = {
+        ...variables,
+        routinesOk: variables.routinesOk ?? true,
+        id: `optimistic-${now}`,
+        createdAt: now,
+        updatedAt: now,
+      };
+      queryClient.setQueryData<Symptom[]>(key, (old) =>
+        old ? [optimistic, ...old] : [optimistic],
+      );
+      return { previous, key };
+    },
+    onError: (_err, _variables, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(context.key, context.previous);
+      }
+    },
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({ queryKey: symptomsKey(variables.childId) });
+      queryClient.invalidateQueries({ queryKey: ["stats", variables.childId] });
+    },
+  });
+}
+
+export function useUpdateSymptom() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      childId: _childId,
+      ...data
+    }: UpdateSymptom & { id: string; childId: string }) =>
+      api.patch<Symptom>(`/symptoms/${id}`, data),
+    onMutate: async (variables) => {
+      const key = symptomsKey(variables.childId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<Symptom[]>(key);
+      queryClient.setQueryData<Symptom[]>(key, (old) =>
+        old
+          ? old.map((s) =>
+              s.id === variables.id
+                ? { ...s, ...variables, updatedAt: new Date().toISOString() }
+                : s,
+            )
+          : old,
+      );
+      return { previous, key };
+    },
+    onError: (_err, _variables, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(context.key, context.previous);
+      }
+    },
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({ queryKey: symptomsKey(variables.childId) });
+      queryClient.invalidateQueries({ queryKey: ["stats", variables.childId] });
+    },
+  });
+}

--- a/apps/mobile/src/lib/copy.ts
+++ b/apps/mobile/src/lib/copy.ts
@@ -1,0 +1,18 @@
+// French copy mirrored verbatim from the web app's i18n
+// (apps/web/src/lib/i18n/locales/fr.json → eveningCheck) so the mobile screen
+// keeps the exact guilt-free lexicon (business rule B7). Inlined rather than
+// pulling i18next into the mobile app for a single screen.
+export const eveningCheck = {
+  title: "La soirée de ce soir ?",
+  vibe_hard: "Difficile",
+  vibe_ok: "Moyenne",
+  vibe_top: "Top",
+  painPrompt: "Quelle étape a été la plus dure ?",
+  pain_shower: "Douche",
+  pain_homework: "Devoirs",
+  pain_bedtime: "Coucher",
+  pain_meal: "Repas",
+  cancel: "Annuler",
+  saved: "Bilan de la soirée enregistré",
+  edit: "Modifier la réponse",
+} as const;

--- a/apps/mobile/src/lib/date.ts
+++ b/apps/mobile/src/lib/date.ts
@@ -1,0 +1,8 @@
+/** Local calendar date as YYYY-MM-DD (mirrors apps/web/src/lib/date.ts). */
+export function todayISO(): string {
+  const d = new Date();
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}

--- a/apps/mobile/src/screens/EveningCheckinScreen.tsx
+++ b/apps/mobile/src/screens/EveningCheckinScreen.tsx
@@ -1,0 +1,202 @@
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+
+import { eveningCheck as copy } from "../lib/copy";
+import { todayISO } from "../lib/date";
+import {
+  useCreateSymptom,
+  useSymptoms,
+  useUpdateSymptom,
+} from "../hooks/use-symptoms";
+
+// Faithful React Native port of apps/web/src/components/dashboard/evening-check.tsx
+// (business rule B3): three smileys for the whole evening, one sub-choice for the
+// pain point when it was hard. Two taps, under two seconds. The native screen is
+// the reason this app isn't a TWA — it's reachable from the reliable scheduled
+// reminder (see src/lib/notifications.ts).
+
+const VIBES = [
+  { id: "hard", emoji: "😵", mood: 2, agitation: 8, label: copy.vibe_hard },
+  { id: "ok", emoji: "😐", mood: 6, agitation: 5, label: copy.vibe_ok },
+  { id: "top", emoji: "😊", mood: 9, agitation: 2, label: copy.vibe_top },
+] as const;
+
+type Vibe = (typeof VIBES)[number];
+
+const PAIN_POINTS = [
+  { id: "shower", label: copy.pain_shower },
+  { id: "homework", label: copy.pain_homework },
+  { id: "bedtime", label: copy.pain_bedtime },
+  { id: "meal", label: copy.pain_meal },
+] as const;
+
+type PainPoint = (typeof PAIN_POINTS)[number]["id"];
+
+const NEUTRAL = {
+  agitation: 5,
+  focus: 5,
+  impulse: 5,
+  mood: 5,
+  sleep: 5,
+  routinesOk: true,
+};
+
+type Props = {
+  childId: string;
+  childName: string;
+  onBack: () => void;
+};
+
+export function EveningCheckinScreen({ childId, childName, onBack }: Props) {
+  const { data: symptoms } = useSymptoms(childId);
+  const createSymptom = useCreateSymptom();
+  const updateSymptom = useUpdateSymptom();
+
+  const [pendingHard, setPendingHard] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  const today = todayISO();
+  const todayEntry = symptoms?.find((s) => s.date === today) ?? null;
+  const isPending = createSymptom.isPending || updateSymptom.isPending;
+
+  function persist(vibe: Vibe, painPoint: PainPoint | null) {
+    const patch = {
+      mood: vibe.mood,
+      agitation: vibe.agitation,
+      context: painPoint ?? undefined,
+      routinesOk: vibe.id !== "hard",
+    };
+
+    const onSuccess = () => {
+      setPendingHard(false);
+      setSaved(true);
+    };
+
+    if (todayEntry) {
+      updateSymptom.mutate(
+        { id: todayEntry.id, childId, ...patch },
+        { onSuccess },
+      );
+    } else {
+      createSymptom.mutate(
+        { childId, date: today, ...NEUTRAL, ...patch },
+        { onSuccess },
+      );
+    }
+  }
+
+  function handleVibe(vibe: Vibe) {
+    if (vibe.id === "hard") {
+      setPendingHard(true);
+      return;
+    }
+    persist(vibe, null);
+  }
+
+  function handlePain(point: PainPoint) {
+    const hard = VIBES[0];
+    persist(hard, point);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Pressable onPress={onBack} hitSlop={12}>
+        <Text style={styles.back}>‹ {childName}</Text>
+      </Pressable>
+
+      <Text style={styles.title}>{copy.title}</Text>
+
+      {saved ? (
+        <View style={styles.savedBox}>
+          <Text style={styles.savedText}>✓ {copy.saved}</Text>
+          <Pressable
+            onPress={() => {
+              setSaved(false);
+              setPendingHard(false);
+            }}
+          >
+            <Text style={styles.link}>{copy.edit}</Text>
+          </Pressable>
+        </View>
+      ) : pendingHard ? (
+        <View style={styles.section}>
+          <Text style={styles.prompt}>{copy.painPrompt}</Text>
+          <View style={styles.painGrid}>
+            {PAIN_POINTS.map((p) => (
+              <Pressable
+                key={p.id}
+                style={[styles.painButton, isPending && styles.disabled]}
+                disabled={isPending}
+                onPress={() => handlePain(p.id)}
+              >
+                <Text style={styles.painLabel}>{p.label}</Text>
+              </Pressable>
+            ))}
+          </View>
+          <Pressable onPress={() => setPendingHard(false)} disabled={isPending}>
+            <Text style={styles.cancel}>{copy.cancel}</Text>
+          </Pressable>
+        </View>
+      ) : (
+        <View style={styles.vibeRow}>
+          {VIBES.map((v) => (
+            <Pressable
+              key={v.id}
+              style={[styles.vibeButton, isPending && styles.disabled]}
+              disabled={isPending}
+              onPress={() => handleVibe(v)}
+              accessibilityLabel={v.label}
+            >
+              <Text style={styles.vibeEmoji}>{v.emoji}</Text>
+              <Text style={styles.vibeLabel}>{v.label}</Text>
+            </Pressable>
+          ))}
+        </View>
+      )}
+
+      {isPending ? <ActivityIndicator style={styles.spinner} /> : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { padding: 24, gap: 20 },
+  back: { color: "#4f46e5", fontSize: 16 },
+  title: { fontSize: 22, fontWeight: "600" },
+  vibeRow: { flexDirection: "row", gap: 12 },
+  vibeButton: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: "#d4d4d8",
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: "center",
+    gap: 4,
+  },
+  vibeEmoji: { fontSize: 30 },
+  vibeLabel: { fontSize: 13, color: "#3f3f46" },
+  section: { gap: 12 },
+  prompt: { fontSize: 15, color: "#71717a" },
+  painGrid: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  painButton: {
+    width: "48%",
+    borderWidth: 1,
+    borderColor: "#d4d4d8",
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: "center",
+  },
+  painLabel: { fontSize: 15, color: "#3f3f46" },
+  cancel: { textAlign: "center", color: "#71717a", paddingTop: 4 },
+  savedBox: { gap: 8 },
+  savedText: { fontSize: 16, color: "#16a34a", fontWeight: "500" },
+  link: { color: "#4f46e5" },
+  disabled: { opacity: 0.5 },
+  spinner: { marginTop: 4 },
+});

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import type { Child } from "@focusflow/validators";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import {
   ActivityIndicator,
   FlatList,
@@ -15,13 +15,16 @@ import { api, fetchBillingStatus } from "../lib/api";
 import { authClient } from "../lib/auth";
 import { WEB_URL } from "../lib/config";
 import { scheduleEveningCheckin } from "../lib/notifications";
+import { EveningCheckinScreen } from "./EveningCheckinScreen";
 
 /**
  * Home screen: lists the parent's children (typed by the shared
- * `@focusflow/validators` schema), schedules the native evening reminder, and
- * routes subscription to the web (no in-app purchase).
+ * `@focusflow/validators` schema). Tapping a child opens the native evening
+ * check-in. Subscription is routed to the web (no in-app purchase).
  */
 export function HomeScreen() {
+  const [activeChild, setActiveChild] = useState<Child | null>(null);
+
   const children = useQuery({
     queryKey: ["children"],
     queryFn: () => api.get<Child[]>("/children"),
@@ -36,6 +39,16 @@ export function HomeScreen() {
   useEffect(() => {
     void scheduleEveningCheckin();
   }, []);
+
+  if (activeChild) {
+    return (
+      <EveningCheckinScreen
+        childId={activeChild.id}
+        childName={activeChild.name}
+        onBack={() => setActiveChild(null)}
+      />
+    );
+  }
 
   const isPremium = billing.data?.active || billing.data?.granted;
 
@@ -54,12 +67,14 @@ export function HomeScreen() {
         <FlatList
           data={children.data ?? []}
           keyExtractor={(child) => child.id}
-          ListEmptyComponent={<Text style={styles.muted}>Aucun enfant pour l'instant.</Text>}
+          ListEmptyComponent={
+            <Text style={styles.muted}>Aucun enfant pour l'instant.</Text>
+          }
           renderItem={({ item }) => (
-            <View style={styles.card}>
+            <Pressable style={styles.card} onPress={() => setActiveChild(item)}>
               <Text style={styles.cardTitle}>{item.name}</Text>
-              <Text style={styles.muted}>{item.ageRange} ans</Text>
-            </View>
+              <Text style={styles.muted}>Faire le point du soir ›</Text>
+            </Pressable>
           )}
         />
       )}
@@ -78,7 +93,11 @@ export function HomeScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, padding: 24, gap: 16 },
-  header: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
   title: { fontSize: 24, fontWeight: "600" },
   link: { color: "#4f46e5" },
   muted: { color: "#71717a" },
@@ -88,6 +107,7 @@ const styles = StyleSheet.create({
     borderRadius: 12,
     padding: 16,
     marginBottom: 12,
+    gap: 4,
   },
   cardTitle: { fontSize: 18, fontWeight: "500" },
   button: {


### PR DESCRIPTION
## Objet

Premier écran fonctionnel de l'app Android : le **check-in du soir** (règle métier B3), porté fidèlement depuis le web. C'est l'écran vers lequel mène le rappel natif programmé — la fonction qui a justifié le choix Expo plutôt qu'une TWA (`docs/android-app.md`).

## Fidélité au web

Port 1:1 de `apps/web/src/components/dashboard/evening-check.tsx` :

- **Flux 2-taps** : 3 smileys (😵 Difficile / 😐 Moyenne / 😊 Top), puis si « Difficile », sous-choix du point de douleur (Douche / Devoirs / Coucher / Repas).
- **Même contrat de données** : `POST /api/symptoms` (ou `PATCH` si une entrée existe déjà aujourd'hui), defaults neutres + mappings identiques (`mood`/`agitation`/`routinesOk`/`context`).
- **Hooks** `use-symptoms` qui reproduisent les mises à jour optimistes et l'invalidation `symptoms` + `stats` (KPI minutes calmes), en réutilisant `CreateSymptom`/`UpdateSymptom`/`Symptom` de **`@focusflow/validators`** (source de vérité unique).
- **Copy FR reprise mot pour mot** du i18n web (lexique sans culpabilité, règle B7).

Accessible en un tap depuis la liste des enfants sur l'écran d'accueil.

## Vérifications

- **`tsc --noEmit` du package mobile : ✅** (typecheck en install isolée).
- Package mobile **toujours exclu du `pnpm install` racine** → CI JS/Docker inchangée (`pnpm install --frozen-lockfile` vérifié, lockfile non modifié).

## Limites connues / suite

- Le tap sur la notification ouvre l'accueil (un tap du check-in) ; le deep-link direct vers le check-in viendra avec react-navigation.
- File d'attente offline (replay des POST hors-ligne) : à câbler ensuite (parité avec la stratégie offline web, encore non finalisée côté web non plus).
- Branchement réel de l'auth mobile (plugin `expo()` mergé en #287) à tester sur device.

https://claude.ai/code/session_01Vw4dbYW3VqdGDFiFPQuNeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw4dbYW3VqdGDFiFPQuNeY)_