### PR TITLE
feat(mobile): écran « minutes calmes » (KPI H1)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -10,6 +10,7 @@ import { setupOnlineManager } from "./src/lib/online";
 import { persister, queryClient } from "./src/lib/query";
 import { linking } from "./src/navigation/linking";
 import type { RootStackParamList } from "./src/navigation/types";
+import { CalmMinutesScreen } from "./src/screens/CalmMinutesScreen";
 import { EveningCheckinScreen } from "./src/screens/EveningCheckinScreen";
 import { HomeScreen } from "./src/screens/HomeScreen";
 import { LoginScreen } from "./src/screens/LoginScreen";
@@ -41,6 +42,7 @@ function RootNavigator() {
         <Stack.Group>
           <Stack.Screen name="Home" component={HomeScreen} />
           <Stack.Screen name="Checkin" component={EveningCheckinScreen} />
+          <Stack.Screen name="CalmMinutes" component={CalmMinutesScreen} />
         </Stack.Group>
       ) : (
         <Stack.Screen name="Login" component={LoginScreen} />

--- a/apps/mobile/src/hooks/use-stats.ts
+++ b/apps/mobile/src/hooks/use-stats.ts
@@ -1,0 +1,30 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { api } from "../lib/api";
+import { calmMinutesQueryKey } from "../lib/mutation-keys";
+
+// Mirrors apps/web/src/hooks/use-stats.ts. Calm minutes (business rule H1) are
+// computed server-side, so there is no shared Zod schema — the response shape
+// is declared locally.
+export type CalmMinutes = {
+  period: "week" | "month" | "quarter";
+  periodDays: number;
+  dailyCapMinutes: number;
+  totalMinutes: number;
+  averagePerDay: number;
+  daysWithEntry: number;
+  daily: Array<{ date: string; minutes: number }>;
+};
+
+export function useCalmMinutes(
+  childId: string,
+  period: "week" | "month" | "quarter" = "week",
+) {
+  return useQuery({
+    queryKey: [...calmMinutesQueryKey(childId), period],
+    queryFn: () =>
+      api.get<CalmMinutes>(`/stats/${childId}/calm-minutes?period=${period}`),
+    enabled: !!childId,
+    staleTime: 60_000,
+  });
+}

--- a/apps/mobile/src/lib/copy.ts
+++ b/apps/mobile/src/lib/copy.ts
@@ -15,4 +15,15 @@ export const eveningCheck = {
   cancel: "Annuler",
   saved: "Bilan de la soirée enregistré",
   edit: "Modifier la réponse",
+  viewCalm: "Voir les minutes calmes",
+} as const;
+
+// Mirrors fr.json → calmMinutes (the dashboard card variant). Same guilt-free
+// framing: a factual memory of calm, not a score to beat.
+export const calmMinutes = {
+  title: "Minutes de calme cette semaine",
+  total: (minutes: number) => `${minutes} min`,
+  average: (minutes: number, days: number) =>
+    `Moyenne de ${minutes} min/jour sur ${days} j notés`,
+  empty: "Commencez à noter vos soirées pour voir le calme s'accumuler.",
 } as const;

--- a/apps/mobile/src/lib/mutation-keys.ts
+++ b/apps/mobile/src/lib/mutation-keys.ts
@@ -4,7 +4,10 @@
 export const symptomsQueryKey = (childId: string) =>
   ["symptoms", childId] as const;
 
-export const statsQueryKey = (childId: string) => ["stats", childId] as const;
+// Prefix of the calm-minutes queries (one per period). Invalidating the
+// prefix refreshes every period after a check-in. Matches the web key.
+export const calmMinutesQueryKey = (childId: string) =>
+  ["calm-minutes", childId] as const;
 
 export const symptomMutationKeys = {
   create: ["symptoms", "create"] as const,

--- a/apps/mobile/src/lib/mutations.ts
+++ b/apps/mobile/src/lib/mutations.ts
@@ -7,7 +7,7 @@ import type { QueryClient } from "@tanstack/react-query";
 
 import { api } from "./api";
 import {
-  statsQueryKey,
+  calmMinutesQueryKey,
   symptomMutationKeys,
   symptomsQueryKey,
 } from "./mutation-keys";
@@ -47,7 +47,7 @@ export function registerMutationDefaults(queryClient: QueryClient) {
     },
     onSettled: (_data, _err, variables: CreateSymptom) => {
       queryClient.invalidateQueries({ queryKey: symptomsQueryKey(variables.childId) });
-      queryClient.invalidateQueries({ queryKey: statsQueryKey(variables.childId) });
+      queryClient.invalidateQueries({ queryKey: calmMinutesQueryKey(variables.childId) });
     },
   });
 
@@ -77,7 +77,7 @@ export function registerMutationDefaults(queryClient: QueryClient) {
     },
     onSettled: (_data, _err, variables: UpdateVars) => {
       queryClient.invalidateQueries({ queryKey: symptomsQueryKey(variables.childId) });
-      queryClient.invalidateQueries({ queryKey: statsQueryKey(variables.childId) });
+      queryClient.invalidateQueries({ queryKey: calmMinutesQueryKey(variables.childId) });
     },
   });
 }

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -6,7 +6,12 @@ export type RootStackParamList = {
   // Reached either from the Home child list (params set) or from the evening
   // reminder deep-link (no params — the screen then resolves the child).
   Checkin: { childId?: string; childName?: string } | undefined;
+  CalmMinutes: { childId: string; childName: string };
 };
 
 export type HomeProps = NativeStackScreenProps<RootStackParamList, "Home">;
 export type CheckinProps = NativeStackScreenProps<RootStackParamList, "Checkin">;
+export type CalmMinutesProps = NativeStackScreenProps<
+  RootStackParamList,
+  "CalmMinutes"
+>;

--- a/apps/mobile/src/screens/CalmMinutesScreen.tsx
+++ b/apps/mobile/src/screens/CalmMinutesScreen.tsx
@@ -1,0 +1,110 @@
+import {
+  ActivityIndicator,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { calmMinutes as copy } from "../lib/copy";
+import { useCalmMinutes } from "../hooks/use-stats";
+import type { CalmMinutesProps } from "../navigation/types";
+
+// Business rule H1: the north-star KPI — minutes of calm earned, shown over the
+// last 7 days. Read-only reward that closes the evening check-in loop. A simple
+// View-based bar row keeps the bundle light (no charting library).
+const WEEKDAY = ["D", "L", "M", "M", "J", "V", "S"];
+
+const BAR_MAX_HEIGHT = 96;
+
+export function CalmMinutesScreen({ navigation, route }: CalmMinutesProps) {
+  const { childId, childName } = route.params;
+  const { data, isLoading } = useCalmMinutes(childId, "week");
+
+  const goBack = () =>
+    navigation.canGoBack() ? navigation.goBack() : navigation.navigate("Home");
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
+      <Pressable onPress={goBack} hitSlop={12}>
+        <Text style={styles.back}>‹ {childName}</Text>
+      </Pressable>
+
+      <Text style={styles.title}>{copy.title}</Text>
+
+      {isLoading || !data ? (
+        <ActivityIndicator />
+      ) : (
+        <>
+          <Text style={styles.total}>{copy.total(data.totalMinutes)}</Text>
+          <Text style={styles.subtitle}>
+            {data.daysWithEntry > 0
+              ? copy.average(data.averagePerDay, data.daysWithEntry)
+              : copy.empty}
+          </Text>
+
+          {data.daysWithEntry > 0 ? (
+            <View style={styles.chart}>
+              {data.daily.map((d) => {
+                const ratio = data.dailyCapMinutes
+                  ? Math.min(d.minutes / data.dailyCapMinutes, 1)
+                  : 0;
+                const weekday = WEEKDAY[new Date(d.date).getDay()] ?? "";
+                return (
+                  <View key={d.date} style={styles.barColumn}>
+                    <View style={styles.barTrack}>
+                      <View
+                        style={[
+                          styles.barFill,
+                          { height: Math.max(ratio * BAR_MAX_HEIGHT, 2) },
+                        ]}
+                      />
+                    </View>
+                    <Text style={styles.barLabel}>{weekday}</Text>
+                  </View>
+                );
+              })}
+            </View>
+          ) : null}
+        </>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, gap: 12 },
+  back: { color: "#4f46e5", fontSize: 16 },
+  title: { fontSize: 22, fontWeight: "600" },
+  total: {
+    fontSize: 40,
+    fontWeight: "700",
+    color: "#16a34a",
+    fontVariant: ["tabular-nums"],
+  },
+  subtitle: { fontSize: 14, color: "#71717a" },
+  chart: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+    gap: 8,
+    marginTop: 16,
+    height: BAR_MAX_HEIGHT + 24,
+  },
+  barColumn: { flex: 1, alignItems: "center", gap: 6 },
+  barTrack: {
+    width: "100%",
+    height: BAR_MAX_HEIGHT,
+    justifyContent: "flex-end",
+    backgroundColor: "#f4f4f5",
+    borderRadius: 8,
+    overflow: "hidden",
+  },
+  barFill: {
+    width: "100%",
+    backgroundColor: "#86efac",
+    borderRadius: 8,
+  },
+  barLabel: { fontSize: 12, color: "#a1a1aa" },
+});

--- a/apps/mobile/src/screens/EveningCheckinScreen.tsx
+++ b/apps/mobile/src/screens/EveningCheckinScreen.tsx
@@ -84,11 +84,19 @@ export function EveningCheckinScreen({ navigation, route }: CheckinProps) {
     );
   }
 
+  const resolvedName = childName ?? "Retour";
+
   return (
     <CheckinForm
       childId={childId}
-      childName={childName ?? "Retour"}
+      childName={resolvedName}
       onBack={goBack}
+      onViewCalm={() =>
+        navigation.navigate("CalmMinutes", {
+          childId: childId!,
+          childName: resolvedName,
+        })
+      }
     />
   );
 }
@@ -97,10 +105,12 @@ function CheckinForm({
   childId,
   childName,
   onBack,
+  onViewCalm,
 }: {
   childId: string;
   childName: string;
   onBack: () => void;
+  onViewCalm: () => void;
 }) {
   const { data: symptoms } = useSymptoms(childId);
   const createSymptom = useCreateSymptom();
@@ -162,6 +172,9 @@ function CheckinForm({
       {saved ? (
         <View style={styles.savedBox}>
           <Text style={styles.savedText}>✓ {copy.saved}</Text>
+          <Pressable onPress={onViewCalm}>
+            <Text style={styles.link}>{copy.viewCalm} ›</Text>
+          </Pressable>
           <Pressable
             onPress={() => {
               setSaved(false);


### PR DESCRIPTION
## Objet

3ᵉ et dernière demande : l'écran **« minutes calmes »** (KPI H1, north-star), qui ferme la boucle du check-in (noter → voir le calme s'accumuler).

## Contenu

- **`useCalmMinutes`** → `GET /api/stats/:childId/calm-minutes`, **clé alignée sur le web** (`["calm-minutes", childId, period]`).
- **`CalmMinutesScreen`** : total + moyenne quotidienne (copy reprise du i18n web, lexique sans culpabilité), et une **barre 7 jours légère en Views** (pas de dépendance de graphes).
- **Accessible depuis l'état « enregistré » du check-in** (« Voir les minutes calmes › »).
- Les mutations symptôme **invalident désormais la clé calm-minutes** → l'écran se rafraîchit juste après un point du soir.

## Vérifications

- **`tsc --noEmit` du mobile : ✅** (aucune nouvelle dépendance).
- Package mobile **toujours exclu du `pnpm install` racine** → CI JS/Docker inchangée (`--frozen-lockfile` vérifié).

## Bilan des 3 demandes

| Demande | PR |
|---|---|
| 1. Deep-link notification → check-in | #289 ✅ |
| 2. File d'attente offline | #289 ✅ |
| 3. Écran minutes calmes | cette PR |

https://claude.ai/code/session_01Vw4dbYW3VqdGDFiFPQuNeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw4dbYW3VqdGDFiFPQuNeY)_