### PR TITLE
feat(mobile): menu enfant + écran journal

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -11,8 +11,10 @@ import { persister, queryClient } from "./src/lib/query";
 import { linking } from "./src/navigation/linking";
 import type { RootStackParamList } from "./src/navigation/types";
 import { CalmMinutesScreen } from "./src/screens/CalmMinutesScreen";
+import { ChildMenuScreen } from "./src/screens/ChildMenuScreen";
 import { EveningCheckinScreen } from "./src/screens/EveningCheckinScreen";
 import { HomeScreen } from "./src/screens/HomeScreen";
+import { JournalScreen } from "./src/screens/JournalScreen";
 import { LoginScreen } from "./src/screens/LoginScreen";
 
 const DAY_MS = 1000 * 60 * 60 * 24;
@@ -41,8 +43,10 @@ function RootNavigator() {
       {session ? (
         <Stack.Group>
           <Stack.Screen name="Home" component={HomeScreen} />
+          <Stack.Screen name="ChildMenu" component={ChildMenuScreen} />
           <Stack.Screen name="Checkin" component={EveningCheckinScreen} />
           <Stack.Screen name="CalmMinutes" component={CalmMinutesScreen} />
+          <Stack.Screen name="Journal" component={JournalScreen} />
         </Stack.Group>
       ) : (
         <Stack.Screen name="Login" component={LoginScreen} />
@@ -58,9 +62,15 @@ export default function App() {
       persistOptions={{
         persister,
         maxAge: DAY_MS,
-        // Persist paused (offline) mutations so the evening check-in survives
-        // an app restart and replays once back online.
-        dehydrateOptions: { shouldDehydrateMutation: () => true },
+        // Persist only the evening check-in's paused (offline) mutations so it
+        // survives an app restart and replays online. Other features
+        // (journal…) still pause/resume within a session via onlineManager,
+        // but aren't kept across a cold start.
+        dehydrateOptions: {
+          shouldDehydrateMutation: (mutation) =>
+            Array.isArray(mutation.options.mutationKey) &&
+            mutation.options.mutationKey[0] === "symptoms",
+        },
       }}
       onSuccess={() => {
         void queryClient.resumePausedMutations();

--- a/apps/mobile/src/hooks/use-journal.ts
+++ b/apps/mobile/src/hooks/use-journal.ts
@@ -1,0 +1,80 @@
+import type {
+  CreateJournalEntry,
+  JournalEntry,
+} from "@focusflow/validators";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { api } from "../lib/api";
+
+// Mirrors apps/web/src/hooks/use-journal.ts (query key ["journal", childId],
+// optimistic create/delete, invalidate on settle). Offline pause/resume comes
+// from the global onlineManager wiring; journal entries are not persisted
+// across a cold restart (only the evening check-in is — see App.tsx).
+const journalKey = (childId: string) => ["journal", childId] as const;
+
+export function useJournal(childId: string) {
+  return useQuery({
+    queryKey: journalKey(childId),
+    queryFn: () => api.get<JournalEntry[]>(`/journal/${childId}`),
+    enabled: !!childId,
+  });
+}
+
+export function useCreateJournalEntry() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateJournalEntry) =>
+      api.post<JournalEntry>("/journal", data),
+    onMutate: async (variables) => {
+      const key = journalKey(variables.childId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<JournalEntry[]>(key);
+      const now = new Date().toISOString();
+      const optimistic: JournalEntry = {
+        ...variables,
+        text: variables.text ?? "",
+        tags: variables.tags ?? [],
+        id: `optimistic-${now}`,
+        createdAt: now,
+        updatedAt: now,
+      };
+      queryClient.setQueryData<JournalEntry[]>(key, (old) =>
+        old ? [optimistic, ...old] : [optimistic],
+      );
+      return { previous, key };
+    },
+    onError: (_err, _variables, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(context.key, context.previous);
+      }
+    },
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({ queryKey: journalKey(variables.childId) });
+    },
+  });
+}
+
+export function useDeleteJournalEntry() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id }: { id: string; childId: string }) =>
+      api.delete<{ ok: true }>(`/journal/${id}`),
+    onMutate: async (variables) => {
+      const key = journalKey(variables.childId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<JournalEntry[]>(key);
+      queryClient.setQueryData<JournalEntry[]>(key, (old) =>
+        old ? old.filter((e) => e.id !== variables.id) : old,
+      );
+      return { previous, key };
+    },
+    onError: (_err, _variables, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(context.key, context.previous);
+      }
+    },
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({ queryKey: journalKey(variables.childId) });
+    },
+  });
+}

--- a/apps/mobile/src/lib/copy.ts
+++ b/apps/mobile/src/lib/copy.ts
@@ -27,3 +27,28 @@ export const calmMinutes = {
     `Moyenne de ${minutes} min/jour sur ${days} j notés`,
   empty: "Commencez à noter vos soirées pour voir le calme s'accumuler.",
 } as const;
+
+// Mirrors fr.json → journal (+ tags). Guilt-free placeholder kept verbatim.
+export const journal = {
+  title: "Journal",
+  writeButton: "Écrire",
+  newEntry: "Nouvelle entrée",
+  notes: "Notes",
+  notesPlaceholder: "Une victoire, une difficulté, une stratégie qui a aidé…",
+  tags: "Tags",
+  addEntry: "Ajouter l'entrée",
+  saving: "Enregistrement...",
+  cancel: "Annuler",
+  empty: "Votre journal est vide. Commencez à écrire vos premières observations.",
+  delete: "Supprimer",
+} as const;
+
+export const journalTagLabels: Record<string, string> = {
+  school: "École",
+  victory: "Victoire",
+  crisis: "Crise",
+  medication: "Traitement",
+  sleep: "Sommeil",
+  sport: "Sport",
+  therapy: "Thérapie",
+};

--- a/apps/mobile/src/lib/date.ts
+++ b/apps/mobile/src/lib/date.ts
@@ -6,3 +6,25 @@ export function todayISO(): string {
   const day = String(d.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
+
+const FR_MONTHS = [
+  "janvier",
+  "février",
+  "mars",
+  "avril",
+  "mai",
+  "juin",
+  "juillet",
+  "août",
+  "septembre",
+  "octobre",
+  "novembre",
+  "décembre",
+];
+
+/** "2026-01-15" -> "15 janvier". Manual to avoid relying on Intl in Hermes. */
+export function formatFrDate(iso: string): string {
+  const [, month, day] = iso.split("-").map(Number);
+  if (!month || !day) return iso;
+  return `${day} ${FR_MONTHS[month - 1] ?? ""}`.trim();
+}

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -3,15 +3,19 @@ import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 export type RootStackParamList = {
   Login: undefined;
   Home: undefined;
-  // Reached either from the Home child list (params set) or from the evening
+  ChildMenu: { childId: string; childName: string };
+  // Reached either from the child menu (params set) or from the evening
   // reminder deep-link (no params — the screen then resolves the child).
   Checkin: { childId?: string; childName?: string } | undefined;
   CalmMinutes: { childId: string; childName: string };
+  Journal: { childId: string; childName: string };
 };
 
 export type HomeProps = NativeStackScreenProps<RootStackParamList, "Home">;
+export type ChildMenuProps = NativeStackScreenProps<RootStackParamList, "ChildMenu">;
 export type CheckinProps = NativeStackScreenProps<RootStackParamList, "Checkin">;
 export type CalmMinutesProps = NativeStackScreenProps<
   RootStackParamList,
   "CalmMinutes"
 >;
+export type JournalProps = NativeStackScreenProps<RootStackParamList, "Journal">;

--- a/apps/mobile/src/screens/ChildMenuScreen.tsx
+++ b/apps/mobile/src/screens/ChildMenuScreen.tsx
@@ -1,0 +1,56 @@
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import type { ChildMenuProps } from "../navigation/types";
+
+// One clear list of actions per child — low cognitive load, one tap each.
+// Feature screens are added here as they land (routines, crisis list…).
+export function ChildMenuScreen({ navigation, route }: ChildMenuProps) {
+  const { childId, childName } = route.params;
+  const params = { childId, childName };
+
+  const items = [
+    { label: "Point du soir", emoji: "🌙", go: () => navigation.navigate("Checkin", params) },
+    { label: "Journal", emoji: "📓", go: () => navigation.navigate("Journal", params) },
+    { label: "Minutes calmes", emoji: "🌿", go: () => navigation.navigate("CalmMinutes", params) },
+  ];
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
+      <Pressable onPress={() => navigation.navigate("Home")} hitSlop={12}>
+        <Text style={styles.back}>‹ Mes enfants</Text>
+      </Pressable>
+
+      <Text style={styles.title}>{childName}</Text>
+
+      <View style={styles.list}>
+        {items.map((item) => (
+          <Pressable key={item.label} style={styles.row} onPress={item.go}>
+            <Text style={styles.emoji}>{item.emoji}</Text>
+            <Text style={styles.label}>{item.label}</Text>
+            <Text style={styles.chevron}>›</Text>
+          </Pressable>
+        ))}
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, gap: 16 },
+  back: { color: "#4f46e5", fontSize: 16 },
+  title: { fontSize: 24, fontWeight: "600" },
+  list: { gap: 12 },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+    borderWidth: 1,
+    borderColor: "#e4e4e7",
+    borderRadius: 12,
+    padding: 18,
+  },
+  emoji: { fontSize: 22 },
+  label: { flex: 1, fontSize: 17, fontWeight: "500", color: "#27272a" },
+  chevron: { fontSize: 22, color: "#a1a1aa" },
+});

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -60,14 +60,14 @@ export function HomeScreen({ navigation }: HomeProps) {
             <Pressable
               style={styles.card}
               onPress={() =>
-                navigation.navigate("Checkin", {
+                navigation.navigate("ChildMenu", {
                   childId: item.id,
                   childName: item.name,
                 })
               }
             >
               <Text style={styles.cardTitle}>{item.name}</Text>
-              <Text style={styles.muted}>Faire le point du soir ›</Text>
+              <Text style={styles.muted}>Voir le suivi ›</Text>
             </Pressable>
           )}
         />

--- a/apps/mobile/src/screens/JournalScreen.tsx
+++ b/apps/mobile/src/screens/JournalScreen.tsx
@@ -1,0 +1,224 @@
+import type { JournalTag } from "@focusflow/validators";
+import { journalTagSchema } from "@focusflow/validators";
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { journal as copy, journalTagLabels } from "../lib/copy";
+import { formatFrDate, todayISO } from "../lib/date";
+import {
+  useCreateJournalEntry,
+  useDeleteJournalEntry,
+  useJournal,
+} from "../hooks/use-journal";
+import type { JournalProps } from "../navigation/types";
+
+const ALL_TAGS = journalTagSchema.options;
+
+export function JournalScreen({ navigation, route }: JournalProps) {
+  const { childId, childName } = route.params;
+  const { data: entries, isLoading } = useJournal(childId);
+  const createEntry = useCreateJournalEntry();
+  const deleteEntry = useDeleteJournalEntry();
+
+  const [composing, setComposing] = useState(false);
+  const [text, setText] = useState("");
+  const [tags, setTags] = useState<JournalTag[]>([]);
+
+  function toggleTag(tag: JournalTag) {
+    setTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    );
+  }
+
+  function submit() {
+    createEntry.mutate(
+      { childId, date: todayISO(), text: text.trim(), tags },
+      {
+        onSuccess: () => {
+          setText("");
+          setTags([]);
+          setComposing(false);
+        },
+      },
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
+      <View style={styles.header}>
+        <Pressable
+          onPress={() => navigation.goBack()}
+          hitSlop={12}
+          style={styles.headerSide}
+        >
+          <Text style={styles.back}>‹ {childName}</Text>
+        </Pressable>
+        {!composing ? (
+          <Pressable onPress={() => setComposing(true)} hitSlop={12}>
+            <Text style={styles.link}>+ {copy.writeButton}</Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      <Text style={styles.title}>{copy.title}</Text>
+
+      {composing ? (
+        <View style={styles.composer}>
+          <TextInput
+            style={styles.input}
+            placeholder={copy.notesPlaceholder}
+            value={text}
+            onChangeText={setText}
+            multiline
+            autoFocus
+          />
+          <View style={styles.tagRow}>
+            {ALL_TAGS.map((tag) => {
+              const on = tags.includes(tag);
+              return (
+                <Pressable
+                  key={tag}
+                  style={[styles.tag, on && styles.tagOn]}
+                  onPress={() => toggleTag(tag)}
+                >
+                  <Text style={[styles.tagText, on && styles.tagTextOn]}>
+                    {journalTagLabels[tag] ?? tag}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          <View style={styles.composerActions}>
+            <Pressable onPress={() => setComposing(false)}>
+              <Text style={styles.cancel}>{copy.cancel}</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.button, createEntry.isPending && styles.disabled]}
+              disabled={createEntry.isPending}
+              onPress={submit}
+            >
+              <Text style={styles.buttonText}>
+                {createEntry.isPending ? copy.saving : copy.addEntry}
+              </Text>
+            </Pressable>
+          </View>
+        </View>
+      ) : null}
+
+      {isLoading ? (
+        <ActivityIndicator />
+      ) : (
+        <FlatList
+          data={entries ?? []}
+          keyExtractor={(e) => e.id}
+          contentContainerStyle={styles.listContent}
+          ListEmptyComponent={
+            composing ? null : <Text style={styles.muted}>{copy.empty}</Text>
+          }
+          renderItem={({ item }) => (
+            <View style={styles.card}>
+              <Text style={styles.cardDate}>{formatFrDate(item.date)}</Text>
+              {item.text ? <Text style={styles.cardText}>{item.text}</Text> : null}
+              {item.tags.length > 0 ? (
+                <View style={styles.tagRow}>
+                  {item.tags.map((tag) => (
+                    <View key={tag} style={styles.cardTag}>
+                      <Text style={styles.cardTagText}>
+                        {journalTagLabels[tag] ?? tag}
+                      </Text>
+                    </View>
+                  ))}
+                </View>
+              ) : null}
+              <Pressable
+                onPress={() => deleteEntry.mutate({ id: item.id, childId })}
+                hitSlop={8}
+              >
+                <Text style={styles.deleteLink}>{copy.delete}</Text>
+              </Pressable>
+            </View>
+          )}
+        />
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, gap: 14 },
+  header: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
+  headerSide: { flexShrink: 1 },
+  back: { color: "#4f46e5", fontSize: 16 },
+  link: { color: "#4f46e5", fontSize: 16, fontWeight: "500" },
+  title: { fontSize: 24, fontWeight: "600" },
+  composer: {
+    gap: 12,
+    borderWidth: 1,
+    borderColor: "#e4e4e7",
+    borderRadius: 12,
+    padding: 16,
+  },
+  input: {
+    minHeight: 90,
+    borderWidth: 1,
+    borderColor: "#d4d4d8",
+    borderRadius: 10,
+    padding: 12,
+    fontSize: 15,
+    textAlignVertical: "top",
+  },
+  tagRow: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  tag: {
+    borderWidth: 1,
+    borderColor: "#d4d4d8",
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+  },
+  tagOn: { backgroundColor: "#4f46e5", borderColor: "#4f46e5" },
+  tagText: { fontSize: 13, color: "#3f3f46" },
+  tagTextOn: { color: "#fff" },
+  composerActions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    alignItems: "center",
+    gap: 16,
+  },
+  cancel: { color: "#71717a" },
+  button: {
+    backgroundColor: "#4f46e5",
+    borderRadius: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  buttonText: { color: "#fff", fontWeight: "600" },
+  disabled: { opacity: 0.5 },
+  listContent: { gap: 12, paddingBottom: 24 },
+  muted: { color: "#71717a" },
+  card: {
+    borderWidth: 1,
+    borderColor: "#e4e4e7",
+    borderRadius: 12,
+    padding: 16,
+    gap: 8,
+  },
+  cardDate: { fontSize: 13, color: "#71717a", textTransform: "capitalize" },
+  cardText: { fontSize: 15, color: "#27272a" },
+  cardTag: {
+    backgroundColor: "#f4f4f5",
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+  },
+  cardTagText: { fontSize: 12, color: "#52525b" },
+  deleteLink: { color: "#dc2626", fontSize: 13 },
+});


### PR DESCRIPTION
## Objet

Navigation par **menu enfant** + **écran Journal**. Première des PRs livrant les écrans restants (journal, routines, liste de crise).

## Contenu

**Menu enfant (refactor navigation)**
- Accueil → enfant → **`ChildMenu`** : liste claire d'actions (Point du soir, Journal, Minutes calmes), une par tap. Les écrans suivants viendront s'y greffer.
- Le deep-link du rappel continue d'ouvrir directement le check-in.

**Écran Journal** (port fidèle de `apps/web` journal)
- Liste des entrées (date FR, texte, tags), **composition** d'une nouvelle entrée (notes + chips de tags réutilisant `journalTagSchema`), **suppression**.
- Hooks `use-journal` : create/delete optimistes + invalidation `["journal", childId]`, types `@focusflow/validators`.
- Copy FR reprise du i18n web (placeholder sans culpabilité verbatim).

**Affinage offline**
- La persistance des mutations en pause est restreinte au **check-in** (clé `symptoms`) ; les autres features se mettent en pause/reprennent dans la session via `onlineManager`, sans laisser de mutation persistée orpheline après un cold start.

## Vérifications
- **`tsc --noEmit` du mobile : ✅** (aucune nouvelle dépendance).
- Package mobile **toujours exclu du `pnpm install` racine** → CI JS/Docker inchangée (`--frozen-lockfile` OK).

## Suite (PRs séparées)
Routines, puis liste de crise, puis checklist EAS/Play.

https://claude.ai/code/session_01Vw4dbYW3VqdGDFiFPQuNeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw4dbYW3VqdGDFiFPQuNeY)_