### PR TITLE
feat(mobile): écran routines (exécution du jour)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -16,6 +16,7 @@ import { EveningCheckinScreen } from "./src/screens/EveningCheckinScreen";
 import { HomeScreen } from "./src/screens/HomeScreen";
 import { JournalScreen } from "./src/screens/JournalScreen";
 import { LoginScreen } from "./src/screens/LoginScreen";
+import { RoutinesScreen } from "./src/screens/RoutinesScreen";
 
 const DAY_MS = 1000 * 60 * 60 * 24;
 
@@ -47,6 +48,7 @@ function RootNavigator() {
           <Stack.Screen name="Checkin" component={EveningCheckinScreen} />
           <Stack.Screen name="CalmMinutes" component={CalmMinutesScreen} />
           <Stack.Screen name="Journal" component={JournalScreen} />
+          <Stack.Screen name="Routines" component={RoutinesScreen} />
         </Stack.Group>
       ) : (
         <Stack.Screen name="Login" component={LoginScreen} />

--- a/apps/mobile/src/hooks/use-routines.ts
+++ b/apps/mobile/src/hooks/use-routines.ts
@@ -1,0 +1,103 @@
+import type { Routine, RoutineCompletion } from "@focusflow/validators";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { api } from "../lib/api";
+
+// Mirrors apps/web/src/hooks/use-routines.ts for the "execute the routine" use
+// case: list routines, list today's completions, toggle a step done/undone.
+// Authoring routines stays on the web.
+const routinesKey = (childId: string) => ["routines", childId] as const;
+const completionsKey = (childId: string, date: string) =>
+  ["routines", childId, "completions", date] as const;
+
+type ToggleVars = {
+  childId: string;
+  routineId: string;
+  stepId: string;
+  date: string;
+};
+
+export function useRoutines(childId: string) {
+  return useQuery({
+    queryKey: routinesKey(childId),
+    queryFn: () => api.get<Routine[]>(`/routines/${childId}`),
+    enabled: !!childId,
+  });
+}
+
+export function useRoutineCompletions(childId: string, date: string) {
+  return useQuery({
+    queryKey: completionsKey(childId, date),
+    queryFn: () =>
+      api.get<RoutineCompletion[]>(`/routines/${childId}/completions?date=${date}`),
+    enabled: !!childId,
+  });
+}
+
+export function useCompleteStep() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ routineId, stepId, date }: ToggleVars) =>
+      api.post<RoutineCompletion>(`/routines/${routineId}/complete`, {
+        stepId,
+        date,
+      }),
+    onMutate: async (variables) => {
+      const key = completionsKey(variables.childId, variables.date);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<RoutineCompletion[]>(key);
+      const optimistic: RoutineCompletion = {
+        id: `optimistic-${variables.stepId}`,
+        routineId: variables.routineId,
+        stepId: variables.stepId,
+        childId: variables.childId,
+        date: variables.date,
+        completedAt: new Date().toISOString(),
+      };
+      queryClient.setQueryData<RoutineCompletion[]>(key, (old) =>
+        old ? [...old, optimistic] : [optimistic],
+      );
+      return { previous, key };
+    },
+    onError: (_err, _variables, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(context.key, context.previous);
+      }
+    },
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: completionsKey(variables.childId, variables.date),
+      });
+    },
+  });
+}
+
+export function useUncompleteStep() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ routineId, stepId, date }: ToggleVars) =>
+      api.post<{ ok: true }>(`/routines/${routineId}/uncomplete`, {
+        stepId,
+        date,
+      }),
+    onMutate: async (variables) => {
+      const key = completionsKey(variables.childId, variables.date);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<RoutineCompletion[]>(key);
+      queryClient.setQueryData<RoutineCompletion[]>(key, (old) =>
+        old ? old.filter((c) => c.stepId !== variables.stepId) : old,
+      );
+      return { previous, key };
+    },
+    onError: (_err, _variables, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(context.key, context.previous);
+      }
+    },
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({
+        queryKey: completionsKey(variables.childId, variables.date),
+      });
+    },
+  });
+}

--- a/apps/mobile/src/lib/copy.ts
+++ b/apps/mobile/src/lib/copy.ts
@@ -43,6 +43,18 @@ export const journal = {
   delete: "Supprimer",
 } as const;
 
+// Mirrors fr.json → routines (mobile = execute the routine, authoring stays
+// on web).
+export const routines = {
+  title: "Routines",
+  today: "Aujourd'hui",
+  noneToday: "Aucune routine prévue aujourd'hui.",
+  done: "fait",
+  allDone: "Bravo, routine terminée !",
+  authorHint: "Créez et modifiez vos routines sur le site.",
+  minutes: "min",
+} as const;
+
 export const journalTagLabels: Record<string, string> = {
   school: "École",
   victory: "Victoire",

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -9,6 +9,7 @@ export type RootStackParamList = {
   Checkin: { childId?: string; childName?: string } | undefined;
   CalmMinutes: { childId: string; childName: string };
   Journal: { childId: string; childName: string };
+  Routines: { childId: string; childName: string };
 };
 
 export type HomeProps = NativeStackScreenProps<RootStackParamList, "Home">;
@@ -19,3 +20,4 @@ export type CalmMinutesProps = NativeStackScreenProps<
   "CalmMinutes"
 >;
 export type JournalProps = NativeStackScreenProps<RootStackParamList, "Journal">;
+export type RoutinesProps = NativeStackScreenProps<RootStackParamList, "Routines">;

--- a/apps/mobile/src/screens/ChildMenuScreen.tsx
+++ b/apps/mobile/src/screens/ChildMenuScreen.tsx
@@ -12,6 +12,7 @@ export function ChildMenuScreen({ navigation, route }: ChildMenuProps) {
   const items = [
     { label: "Point du soir", emoji: "🌙", go: () => navigation.navigate("Checkin", params) },
     { label: "Journal", emoji: "📓", go: () => navigation.navigate("Journal", params) },
+    { label: "Routines", emoji: "✅", go: () => navigation.navigate("Routines", params) },
     { label: "Minutes calmes", emoji: "🌿", go: () => navigation.navigate("CalmMinutes", params) },
   ];
 

--- a/apps/mobile/src/screens/RoutinesScreen.tsx
+++ b/apps/mobile/src/screens/RoutinesScreen.tsx
@@ -1,0 +1,171 @@
+import type { Routine, RoutineStep } from "@focusflow/validators";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { routines as copy } from "../lib/copy";
+import { todayISO } from "../lib/date";
+import {
+  useCompleteStep,
+  useRoutineCompletions,
+  useRoutines,
+  useUncompleteStep,
+} from "../hooks/use-routines";
+import type { RoutinesProps } from "../navigation/types";
+
+// Web stores days as 0=Mon..6=Sun; JS getDay() is 0=Sun..6=Sat.
+function mondayBasedDow(): number {
+  return (new Date().getDay() + 6) % 7;
+}
+
+export function RoutinesScreen({ navigation, route }: RoutinesProps) {
+  const { childId, childName } = route.params;
+  const today = todayISO();
+
+  const routinesQuery = useRoutines(childId);
+  const completionsQuery = useRoutineCompletions(childId, today);
+  const completeStep = useCompleteStep();
+  const uncompleteStep = useUncompleteStep();
+
+  const dow = mondayBasedDow();
+  const todays = (routinesQuery.data ?? []).filter(
+    (r) =>
+      r.active && (r.daysOfWeek.length === 0 || r.daysOfWeek.includes(dow)),
+  );
+  const doneStepIds = new Set(
+    (completionsQuery.data ?? []).map((c) => c.stepId),
+  );
+
+  function toggle(routine: Routine, step: RoutineStep) {
+    const vars = {
+      childId,
+      routineId: routine.id,
+      stepId: step.id,
+      date: today,
+    };
+    if (doneStepIds.has(step.id)) uncompleteStep.mutate(vars);
+    else completeStep.mutate(vars);
+  }
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
+      <Pressable onPress={() => navigation.goBack()} hitSlop={12}>
+        <Text style={styles.back}>‹ {childName}</Text>
+      </Pressable>
+
+      <Text style={styles.title}>{copy.title}</Text>
+      <Text style={styles.section}>{copy.today}</Text>
+
+      {routinesQuery.isLoading ? (
+        <ActivityIndicator />
+      ) : todays.length === 0 ? (
+        <View style={styles.emptyBox}>
+          <Text style={styles.muted}>{copy.noneToday}</Text>
+          <Text style={styles.hint}>{copy.authorHint}</Text>
+        </View>
+      ) : (
+        <ScrollView contentContainerStyle={styles.scroll}>
+          {todays.map((routine) => {
+            const steps = [...routine.steps].sort(
+              (a, b) => a.position - b.position,
+            );
+            const doneCount = steps.filter((s) => doneStepIds.has(s.id)).length;
+            const allDone = steps.length > 0 && doneCount === steps.length;
+            return (
+              <View key={routine.id} style={styles.routine}>
+                <View style={styles.routineHeader}>
+                  <Text style={styles.routineName}>
+                    {routine.emoji ? `${routine.emoji} ` : ""}
+                    {routine.name}
+                  </Text>
+                  <Text style={styles.progress}>
+                    {doneCount}/{steps.length}
+                  </Text>
+                </View>
+
+                {allDone ? (
+                  <Text style={styles.allDone}>{copy.allDone}</Text>
+                ) : null}
+
+                {steps.map((step) => {
+                  const done = doneStepIds.has(step.id);
+                  return (
+                    <Pressable
+                      key={step.id}
+                      style={styles.step}
+                      onPress={() => toggle(routine, step)}
+                    >
+                      <View
+                        style={[styles.checkbox, done && styles.checkboxOn]}
+                      >
+                        {done ? <Text style={styles.check}>✓</Text> : null}
+                      </View>
+                      <Text
+                        style={[styles.stepLabel, done && styles.stepLabelDone]}
+                      >
+                        {step.emoji ? `${step.emoji} ` : ""}
+                        {step.label}
+                      </Text>
+                      {step.durationMinutes ? (
+                        <Text style={styles.duration}>
+                          {step.durationMinutes} {copy.minutes}
+                        </Text>
+                      ) : null}
+                    </Pressable>
+                  );
+                })}
+              </View>
+            );
+          })}
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, gap: 12 },
+  back: { color: "#4f46e5", fontSize: 16 },
+  title: { fontSize: 24, fontWeight: "600" },
+  section: { fontSize: 14, color: "#71717a", textTransform: "uppercase" },
+  emptyBox: { gap: 6 },
+  muted: { color: "#71717a" },
+  hint: { color: "#a1a1aa", fontSize: 13 },
+  scroll: { gap: 16, paddingBottom: 24 },
+  routine: {
+    borderWidth: 1,
+    borderColor: "#e4e4e7",
+    borderRadius: 12,
+    padding: 16,
+    gap: 10,
+  },
+  routineHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  routineName: { fontSize: 17, fontWeight: "600", flexShrink: 1 },
+  progress: { fontSize: 14, color: "#71717a" },
+  allDone: { color: "#16a34a", fontWeight: "500" },
+  step: { flexDirection: "row", alignItems: "center", gap: 12, paddingVertical: 6 },
+  checkbox: {
+    width: 26,
+    height: 26,
+    borderRadius: 8,
+    borderWidth: 1.5,
+    borderColor: "#d4d4d8",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  checkboxOn: { backgroundColor: "#16a34a", borderColor: "#16a34a" },
+  check: { color: "#fff", fontSize: 16, fontWeight: "700" },
+  stepLabel: { flex: 1, fontSize: 15, color: "#27272a" },
+  stepLabelDone: { color: "#a1a1aa", textDecorationLine: "line-through" },
+  duration: { fontSize: 13, color: "#a1a1aa" },
+});


### PR DESCRIPTION
## Objet

Écran **Routines** : exécution des routines du jour (cocher les étapes). 2ᵉ des écrans restants.

## Contenu

- Liste les **routines actives du jour** (filtre jour de semaine base lundi, identique au web) avec leurs étapes.
- **Tap sur une étape** → complétée/décochée pour aujourd'hui (`POST /routines/:id/complete` · `/uncomplete`), avec **toggle optimiste**.
- Hooks `use-routines` alignés sur les clés web (`["routines", childId]` et `["routines", childId, "completions", date]`), types `@focusflow/validators`.
- Progression par routine (`fait`/total) + célébration « Bravo, routine terminée ! ».
- **L'édition** (éditeur d'étapes, modèles) reste volontairement **sur le web** ; le mobile sert à *exécuter* la routine. Accessible depuis le menu enfant.

## Vérifications
- **`tsc --noEmit` du mobile : ✅** (aucune nouvelle dépendance).
- Package mobile **toujours exclu du `pnpm install` racine** → CI JS/Docker inchangée.

## Suite
Liste de crise, puis checklist EAS/Play.

https://claude.ai/code/session_01Vw4dbYW3VqdGDFiFPQuNeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw4dbYW3VqdGDFiFPQuNeY)_