### PR TITLE
feat(mobile): écran liste de crise + mode crise

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -15,6 +15,7 @@ import { ChildMenuScreen } from "./src/screens/ChildMenuScreen";
 import { EveningCheckinScreen } from "./src/screens/EveningCheckinScreen";
 import { HomeScreen } from "./src/screens/HomeScreen";
 import { JournalScreen } from "./src/screens/JournalScreen";
+import { CrisisListScreen } from "./src/screens/CrisisListScreen";
 import { LoginScreen } from "./src/screens/LoginScreen";
 import { RoutinesScreen } from "./src/screens/RoutinesScreen";
 
@@ -49,6 +50,7 @@ function RootNavigator() {
           <Stack.Screen name="CalmMinutes" component={CalmMinutesScreen} />
           <Stack.Screen name="Journal" component={JournalScreen} />
           <Stack.Screen name="Routines" component={RoutinesScreen} />
+          <Stack.Screen name="CrisisList" component={CrisisListScreen} />
         </Stack.Group>
       ) : (
         <Stack.Screen name="Login" component={LoginScreen} />

--- a/apps/mobile/src/hooks/use-crisis-list.ts
+++ b/apps/mobile/src/hooks/use-crisis-list.ts
@@ -1,0 +1,74 @@
+import type { CreateCrisisItem, CrisisItem } from "@focusflow/validators";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { api } from "../lib/api";
+
+// Mirrors apps/web/src/hooks/use-crisis-list.ts (query key ["crisis-list",
+// childId], optimistic create/delete). Reorder/edit stay on the web.
+const crisisKey = (childId: string) => ["crisis-list", childId] as const;
+
+export function useCrisisItems(childId: string) {
+  return useQuery({
+    queryKey: crisisKey(childId),
+    queryFn: () => api.get<CrisisItem[]>(`/crisis-list/${childId}`),
+    enabled: !!childId,
+  });
+}
+
+export function useCreateCrisisItem() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateCrisisItem) =>
+      api.post<CrisisItem>("/crisis-list", data),
+    onMutate: async (variables) => {
+      const key = crisisKey(variables.childId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<CrisisItem[]>(key);
+      const now = new Date().toISOString();
+      const optimistic: CrisisItem = {
+        ...variables,
+        position: variables.position ?? (previous?.length ?? 0),
+        id: `optimistic-${now}`,
+        createdAt: now,
+        updatedAt: now,
+      };
+      queryClient.setQueryData<CrisisItem[]>(key, (old) =>
+        old ? [...old, optimistic] : [optimistic],
+      );
+      return { previous, key };
+    },
+    onError: (_err, _variables, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(context.key, context.previous);
+      }
+    },
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({ queryKey: crisisKey(variables.childId) });
+    },
+  });
+}
+
+export function useDeleteCrisisItem() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id }: { id: string; childId: string }) =>
+      api.delete<{ ok: true }>(`/crisis-list/${id}`),
+    onMutate: async (variables) => {
+      const key = crisisKey(variables.childId);
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<CrisisItem[]>(key);
+      queryClient.setQueryData<CrisisItem[]>(key, (old) =>
+        old ? old.filter((i) => i.id !== variables.id) : old,
+      );
+      return { previous, key };
+    },
+    onError: (_err, _variables, context) => {
+      if (context?.previous !== undefined) {
+        queryClient.setQueryData(context.key, context.previous);
+      }
+    },
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({ queryKey: crisisKey(variables.childId) });
+    },
+  });
+}

--- a/apps/mobile/src/lib/copy.ts
+++ b/apps/mobile/src/lib/copy.ts
@@ -55,6 +55,32 @@ export const routines = {
   minutes: "min",
 } as const;
 
+// Mirrors fr.json → crisis. The "mode crise" is a calm full-screen list of
+// what soothes the child during a meltdown.
+export const crisis = {
+  title: "Liste de la crise",
+  subtitle: (name: string) =>
+    `Les choses qui font du bien à ${name} quand ça ne va pas`,
+  crisisMode: "Mode crise",
+  close: "Fermer",
+  add: "Ajouter",
+  addToList: "Ajouter à ma liste",
+  labelPlaceholder: "Regarder mon dessin animé préféré",
+  emptyTitle: "La liste est vide",
+  emptyBody:
+    "Construisez cette liste avec votre enfant : qu'est-ce qui lui fait du bien quand ça ne va pas ?",
+  delete: "Supprimer",
+  cancel: "Annuler",
+  prev: "Précédent",
+  next: "Suivant",
+  supportTitle: "Vous traversez un moment difficile ?",
+  support3114: "3114 — Prévention du suicide",
+  supportAllo: "Allô Parents Bébé — 0 800 235 236",
+  supportHyper: "HyperSupers TDAH France",
+} as const;
+
+export const CRISIS_EMOJIS = ["💙", "🧸", "🎵", "📖", "🧘", "🤗", "🛁", "🐾"];
+
 export const journalTagLabels: Record<string, string> = {
   school: "École",
   victory: "Victoire",

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -10,6 +10,7 @@ export type RootStackParamList = {
   CalmMinutes: { childId: string; childName: string };
   Journal: { childId: string; childName: string };
   Routines: { childId: string; childName: string };
+  CrisisList: { childId: string; childName: string };
 };
 
 export type HomeProps = NativeStackScreenProps<RootStackParamList, "Home">;
@@ -21,3 +22,7 @@ export type CalmMinutesProps = NativeStackScreenProps<
 >;
 export type JournalProps = NativeStackScreenProps<RootStackParamList, "Journal">;
 export type RoutinesProps = NativeStackScreenProps<RootStackParamList, "Routines">;
+export type CrisisListProps = NativeStackScreenProps<
+  RootStackParamList,
+  "CrisisList"
+>;

--- a/apps/mobile/src/screens/ChildMenuScreen.tsx
+++ b/apps/mobile/src/screens/ChildMenuScreen.tsx
@@ -13,6 +13,7 @@ export function ChildMenuScreen({ navigation, route }: ChildMenuProps) {
     { label: "Point du soir", emoji: "🌙", go: () => navigation.navigate("Checkin", params) },
     { label: "Journal", emoji: "📓", go: () => navigation.navigate("Journal", params) },
     { label: "Routines", emoji: "✅", go: () => navigation.navigate("Routines", params) },
+    { label: "Liste de la crise", emoji: "🆘", go: () => navigation.navigate("CrisisList", params) },
     { label: "Minutes calmes", emoji: "🌿", go: () => navigation.navigate("CalmMinutes", params) },
   ];
 

--- a/apps/mobile/src/screens/CrisisListScreen.tsx
+++ b/apps/mobile/src/screens/CrisisListScreen.tsx
@@ -1,0 +1,300 @@
+import { useState } from "react";
+import {
+  ActivityIndicator,
+  Linking,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+
+import { CRISIS_EMOJIS, crisis as copy } from "../lib/copy";
+import {
+  useCreateCrisisItem,
+  useCrisisItems,
+  useDeleteCrisisItem,
+} from "../hooks/use-crisis-list";
+import type { CrisisListProps } from "../navigation/types";
+
+const SUPPORT_LINKS = [
+  { label: copy.support3114, url: "tel:3114" },
+  { label: copy.supportAllo, url: "tel:0800235236" },
+  { label: copy.supportHyper, url: "https://www.tdah-france.fr/" },
+];
+
+export function CrisisListScreen({ navigation, route }: CrisisListProps) {
+  const { childId, childName } = route.params;
+  const { data: items, isLoading } = useCrisisItems(childId);
+  const createItem = useCreateCrisisItem();
+  const deleteItem = useDeleteCrisisItem();
+
+  const [composing, setComposing] = useState(false);
+  const [label, setLabel] = useState("");
+  const [emoji, setEmoji] = useState(CRISIS_EMOJIS[0]);
+  const [crisisMode, setCrisisMode] = useState(false);
+  const [index, setIndex] = useState(0);
+
+  const list = items ?? [];
+
+  function submit() {
+    const trimmed = label.trim();
+    if (!trimmed) return;
+    createItem.mutate(
+      { childId, label: trimmed, emoji },
+      {
+        onSuccess: () => {
+          setLabel("");
+          setEmoji(CRISIS_EMOJIS[0]);
+          setComposing(false);
+        },
+      },
+    );
+  }
+
+  // Full-screen calm carousel for an active meltdown.
+  if (crisisMode && list.length > 0) {
+    const item = list[Math.min(index, list.length - 1)];
+    return (
+      <SafeAreaView style={styles.crisisContainer} edges={["top", "bottom"]}>
+        <Pressable
+          style={styles.crisisClose}
+          onPress={() => setCrisisMode(false)}
+          hitSlop={12}
+        >
+          <Text style={styles.crisisCloseText}>✕ {copy.close}</Text>
+        </Pressable>
+        <View style={styles.crisisCenter}>
+          <Text style={styles.crisisEmoji}>{item?.emoji ?? "💙"}</Text>
+          <Text style={styles.crisisLabel}>{item?.label}</Text>
+          <Text style={styles.crisisCounter}>
+            {Math.min(index, list.length - 1) + 1} / {list.length}
+          </Text>
+        </View>
+        <View style={styles.crisisNav}>
+          <Pressable
+            style={[styles.navButton, index <= 0 && styles.disabled]}
+            disabled={index <= 0}
+            onPress={() => setIndex((i) => Math.max(i - 1, 0))}
+          >
+            <Text style={styles.navButtonText}>‹ {copy.prev}</Text>
+          </Pressable>
+          <Pressable
+            style={[styles.navButton, index >= list.length - 1 && styles.disabled]}
+            disabled={index >= list.length - 1}
+            onPress={() => setIndex((i) => Math.min(i + 1, list.length - 1))}
+          >
+            <Text style={styles.navButtonText}>{copy.next} ›</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
+      <View style={styles.header}>
+        <Pressable onPress={() => navigation.goBack()} hitSlop={12} style={styles.headerSide}>
+          <Text style={styles.back}>‹ {childName}</Text>
+        </Pressable>
+        {!composing ? (
+          <Pressable onPress={() => setComposing(true)} hitSlop={12}>
+            <Text style={styles.link}>+ {copy.add}</Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      <Text style={styles.title}>{copy.title}</Text>
+      <Text style={styles.subtitle}>{copy.subtitle(childName)}</Text>
+
+      {list.length > 0 ? (
+        <Pressable
+          style={styles.crisisButton}
+          onPress={() => {
+            setIndex(0);
+            setCrisisMode(true);
+          }}
+        >
+          <Text style={styles.crisisButtonText}>🆘 {copy.crisisMode}</Text>
+        </Pressable>
+      ) : null}
+
+      {composing ? (
+        <View style={styles.composer}>
+          <View style={styles.emojiRow}>
+            {CRISIS_EMOJIS.map((e) => (
+              <Pressable
+                key={e}
+                style={[styles.emojiChip, emoji === e && styles.emojiChipOn]}
+                onPress={() => setEmoji(e)}
+              >
+                <Text style={styles.emojiChipText}>{e}</Text>
+              </Pressable>
+            ))}
+          </View>
+          <TextInput
+            style={styles.input}
+            placeholder={copy.labelPlaceholder}
+            value={label}
+            onChangeText={setLabel}
+            autoFocus
+          />
+          <View style={styles.composerActions}>
+            <Pressable onPress={() => setComposing(false)}>
+              <Text style={styles.cancel}>{copy.cancel}</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.button, createItem.isPending && styles.disabled]}
+              disabled={createItem.isPending}
+              onPress={submit}
+            >
+              <Text style={styles.buttonText}>{copy.addToList}</Text>
+            </Pressable>
+          </View>
+        </View>
+      ) : null}
+
+      {isLoading ? (
+        <ActivityIndicator />
+      ) : (
+        <ScrollView contentContainerStyle={styles.scroll}>
+          {list.length === 0 && !composing ? (
+            <View style={styles.emptyBox}>
+              <Text style={styles.emptyTitle}>{copy.emptyTitle}</Text>
+              <Text style={styles.muted}>{copy.emptyBody}</Text>
+            </View>
+          ) : (
+            list.map((item) => (
+              <View key={item.id} style={styles.card}>
+                <Text style={styles.cardEmoji}>{item.emoji ?? "💙"}</Text>
+                <Text style={styles.cardLabel}>{item.label}</Text>
+                <Pressable
+                  onPress={() => deleteItem.mutate({ id: item.id, childId })}
+                  hitSlop={8}
+                >
+                  <Text style={styles.deleteLink}>{copy.delete}</Text>
+                </Pressable>
+              </View>
+            ))
+          )}
+
+          <View style={styles.support}>
+            <Text style={styles.supportTitle}>{copy.supportTitle}</Text>
+            {SUPPORT_LINKS.map((s) => (
+              <Pressable key={s.url} onPress={() => Linking.openURL(s.url)}>
+                <Text style={styles.supportLink}>{s.label}</Text>
+              </Pressable>
+            ))}
+          </View>
+        </ScrollView>
+      )}
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, padding: 24, gap: 12 },
+  header: { flexDirection: "row", justifyContent: "space-between", alignItems: "center" },
+  headerSide: { flexShrink: 1 },
+  back: { color: "#4f46e5", fontSize: 16 },
+  link: { color: "#4f46e5", fontSize: 16, fontWeight: "500" },
+  title: { fontSize: 24, fontWeight: "600" },
+  subtitle: { fontSize: 14, color: "#71717a" },
+  crisisButton: {
+    backgroundColor: "#fee2e2",
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: "center",
+  },
+  crisisButtonText: { color: "#b91c1c", fontSize: 16, fontWeight: "700" },
+  composer: {
+    gap: 12,
+    borderWidth: 1,
+    borderColor: "#e4e4e7",
+    borderRadius: 12,
+    padding: 16,
+  },
+  emojiRow: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  emojiChip: {
+    width: 44,
+    height: 44,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#d4d4d8",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  emojiChipOn: { borderColor: "#4f46e5", backgroundColor: "#eef2ff" },
+  emojiChipText: { fontSize: 22 },
+  input: {
+    borderWidth: 1,
+    borderColor: "#d4d4d8",
+    borderRadius: 10,
+    padding: 12,
+    fontSize: 15,
+  },
+  composerActions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    alignItems: "center",
+    gap: 16,
+  },
+  cancel: { color: "#71717a" },
+  button: {
+    backgroundColor: "#4f46e5",
+    borderRadius: 10,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+  },
+  buttonText: { color: "#fff", fontWeight: "600" },
+  disabled: { opacity: 0.4 },
+  scroll: { gap: 12, paddingBottom: 24 },
+  emptyBox: { gap: 6, paddingVertical: 12 },
+  emptyTitle: { fontSize: 17, fontWeight: "600" },
+  muted: { color: "#71717a" },
+  card: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 14,
+    borderWidth: 1,
+    borderColor: "#e4e4e7",
+    borderRadius: 12,
+    padding: 16,
+  },
+  cardEmoji: { fontSize: 24 },
+  cardLabel: { flex: 1, fontSize: 16, color: "#27272a" },
+  deleteLink: { color: "#dc2626", fontSize: 13 },
+  support: {
+    marginTop: 12,
+    gap: 8,
+    borderTopWidth: 1,
+    borderTopColor: "#f4f4f5",
+    paddingTop: 16,
+  },
+  supportTitle: { fontSize: 15, fontWeight: "600", color: "#3f3f46" },
+  supportLink: { color: "#4f46e5", fontSize: 15, paddingVertical: 4 },
+  // Crisis mode
+  crisisContainer: { flex: 1, backgroundColor: "#eef2ff", padding: 24 },
+  crisisClose: { alignSelf: "flex-end" },
+  crisisCloseText: { color: "#4f46e5", fontSize: 16 },
+  crisisCenter: { flex: 1, alignItems: "center", justifyContent: "center", gap: 20 },
+  crisisEmoji: { fontSize: 96 },
+  crisisLabel: {
+    fontSize: 28,
+    fontWeight: "600",
+    color: "#1e1b4b",
+    textAlign: "center",
+  },
+  crisisCounter: { fontSize: 16, color: "#6366f1" },
+  crisisNav: { flexDirection: "row", justifyContent: "space-between", gap: 12 },
+  navButton: {
+    flex: 1,
+    backgroundColor: "#fff",
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: "center",
+  },
+  navButtonText: { color: "#4f46e5", fontSize: 16, fontWeight: "600" },
+});


### PR DESCRIPTION
## Objet

Écran **Liste de la crise** + **Mode crise**. Dernière des trois fonctionnalités d'écrans.

## Contenu

- **Liste** des activités qui apaisent l'enfant (emoji + libellé), **ajout** (sélecteur d'emoji + texte), **suppression**.
- **Mode crise** plein écran : carrousel calme (grand emoji + libellé, précédent/suivant) pour un moment de crise.
- **Ressources de soutien** (3114, Allô Parents Bébé, HyperSupers TDAH France) via liens `tel:`/`https`.
- Hooks `use-crisis-list` : create/delete optimistes + invalidation `["crisis-list", childId]`, types `@focusflow/validators`. La réorganisation (drag) et l'édition restent **sur le web**. Accessible depuis le menu enfant.

## Vérifications
- **`tsc --noEmit` du mobile : ✅** (aucune nouvelle dépendance).
- Package mobile **toujours exclu du `pnpm install` racine** → CI JS/Docker inchangée.

## Suite
Dernier item restant : la **checklist EAS/Play** (doc).

https://claude.ai/code/session_01Vw4dbYW3VqdGDFiFPQuNeY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vw4dbYW3VqdGDFiFPQuNeY)_