### PR TITLE
feat(mobile): carte « Prochaine lecture » sur le dashboard

### DIFF
--- a/apps/mobile/src/lib/reading.ts
+++ b/apps/mobile/src/lib/reading.ts
@@ -1,0 +1,59 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useCallback, useEffect, useState } from "react";
+
+import { knowledgeArticles, type KnowledgeArticle } from "./knowledge";
+
+// Slugs of articles the parent has already opened. Persisted locally so the
+// "Prochaine lecture" card on the dashboard can suggest the next unread one.
+const STORAGE_KEY = "toko.knowledge.read";
+
+/**
+ * Tracks which knowledge-base articles have been opened, persisted in
+ * AsyncStorage. Lets the dashboard suggest a single "next" article and the
+ * Connaissances list mark articles as read when tapped.
+ */
+export function useReadArticles() {
+  const [read, setRead] = useState<Set<string>>(new Set());
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((raw) => {
+        if (cancelled || !raw) return;
+        setRead(new Set(JSON.parse(raw) as string[]));
+      })
+      .catch(() => {
+        // Corrupt/unavailable storage — start fresh, nothing is lost.
+      })
+      .finally(() => {
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const markRead = useCallback((slug: string) => {
+    setRead((prev) => {
+      if (prev.has(slug)) return prev;
+      const next = new Set(prev).add(slug);
+      void AsyncStorage.setItem(STORAGE_KEY, JSON.stringify([...next])).catch(
+        () => {
+          // Fail silent — the suggestion simply reappears next launch.
+        },
+      );
+      return next;
+    });
+  }, []);
+
+  return { read, markRead, loaded };
+}
+
+/**
+ * The next article the parent should read: the first one (in library order)
+ * they have not opened yet. Returns null once everything has been read.
+ */
+export function pickNextArticle(read: Set<string>): KnowledgeArticle | null {
+  return knowledgeArticles.find((a) => !read.has(a.slug)) ?? null;
+}

--- a/apps/mobile/src/screens/ConnaissancesScreen.tsx
+++ b/apps/mobile/src/screens/ConnaissancesScreen.tsx
@@ -4,6 +4,7 @@ import { Pressable, StyleSheet, Text, View } from "react-native";
 import { Card, Screen, ScreenHeader, colors } from "../components/ui";
 import { WEB_URL } from "../lib/config";
 import { knowledgeArticles } from "../lib/knowledge";
+import { useReadArticles } from "../lib/reading";
 import type { ConnaissancesProps } from "../navigation/types";
 
 // Display order of subjects (mirrors the web /connaissances grouping).
@@ -22,12 +23,14 @@ function subjectOf(cluster: string): string {
 }
 
 export function ConnaissancesScreen({ navigation }: ConnaissancesProps) {
+  const { markRead } = useReadArticles();
   const groups = SUBJECT_ORDER.map((subject) => ({
     subject,
     items: knowledgeArticles.filter((a) => subjectOf(a.cluster) === subject),
   })).filter((g) => g.items.length > 0);
 
   function openArticle(slug: string) {
+    markRead(slug);
     void WebBrowser.openBrowserAsync(`${WEB_URL}/connaissances/${slug}`);
   }
 

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import type { BottomTabNavigationProp } from "@react-navigation/bottom-tabs";
+import * as WebBrowser from "expo-web-browser";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 
 import {
@@ -12,7 +13,9 @@ import {
 } from "../components/ui";
 import { useActiveChild } from "../lib/active-child";
 import { authClient } from "../lib/auth";
+import { WEB_URL } from "../lib/config";
 import { scheduleEveningCheckin } from "../lib/notifications";
+import { pickNextArticle, useReadArticles } from "../lib/reading";
 import type { HomeProps, RootTabParamList } from "../navigation/types";
 
 const DIAGNOSIS_LABELS: Record<string, string> = {
@@ -77,7 +80,38 @@ export function HomeScreen({ navigation }: HomeProps) {
           );
         })
       )}
+
+      <NextReadingCard />
     </Screen>
+  );
+}
+
+/**
+ * "Prochaine lecture" — suggests the next unread knowledge-base article on the
+ * dashboard. One tap opens it and marks it read so the next launch moves on to
+ * the following article. Hidden once every article has been read.
+ */
+function NextReadingCard() {
+  const { read, markRead, loaded } = useReadArticles();
+  if (!loaded) return null;
+
+  const article = pickNextArticle(read);
+  if (!article) return null;
+
+  function open() {
+    markRead(article!.slug);
+    void WebBrowser.openBrowserAsync(`${WEB_URL}/connaissances/${article!.slug}`);
+  }
+
+  return (
+    <Pressable onPress={open}>
+      <Card style={styles.readingCard}>
+        <Text style={styles.readingEyebrow}>📖 Prochaine lecture</Text>
+        <Text style={styles.readingTitle}>{article.title}</Text>
+        <Text style={styles.readingMeta}>{article.readTime} de lecture</Text>
+        <Text style={styles.cta}>Lire l'article ›</Text>
+      </Card>
+    </Pressable>
   );
 }
 
@@ -101,4 +135,12 @@ const styles = StyleSheet.create({
   },
   muted: { color: colors.muted },
   cta: { color: colors.action, marginTop: 4 },
+  readingCard: {
+    marginTop: 8,
+    backgroundColor: "#eff6ff",
+    borderColor: "#bfdbfe",
+  },
+  readingEyebrow: { fontSize: 13, fontWeight: "600", color: "#1e40af" },
+  readingTitle: { fontSize: 16, fontWeight: "600", color: colors.text },
+  readingMeta: { fontSize: 12, color: colors.muted },
 });


### PR DESCRIPTION
## Problème

Sur l'app Android, le dashboard (onglet Accueil) ne proposait aucune lecture. La feature « Prochaine lecture » — le prochain article à lire — manquait, alors que le web met en avant des suggestions d'articles (`DailyTipCard`, `ResourceHintCard`).

## Solution

Ajout d'une carte **« Prochaine lecture »** en bas du `HomeScreen` qui propose le **prochain article non lu** de la base de connaissances :

- **Une seule action** : un tap ouvre l'article et le marque comme lu.
- **Progression** : les articles lus sont mémorisés localement (`AsyncStorage`), donc la suggestion avance à chaque lecture.
- **Cohérence** : ouvrir un article depuis l'écran Connaissances le marque aussi comme lu, pour que les deux restent synchronisés.
- **Pas de bruit** : la carte disparaît une fois tous les articles lus.

Respecte les principes de design TDAH : simplicité maximale, une action principale, libellé explicite, aucune surprise.

## Fichiers

- `apps/mobile/src/lib/reading.ts` *(nouveau)* — hook `useReadArticles` (suivi `AsyncStorage`) + `pickNextArticle`.
- `apps/mobile/src/screens/HomeScreen.tsx` — composant `NextReadingCard` + styles.
- `apps/mobile/src/screens/ConnaissancesScreen.tsx` — marque l'article lu à l'ouverture.

## Tests

- `pnpm typecheck` (apps/mobile) ✅

https://claude.ai/code/session_016QK6etLDnx6AUc4MWqDS7K

---
_Generated by [Claude Code](https://claude.ai/code/session_016QK6etLDnx6AUc4MWqDS7K)_