### PR TITLE
feat(mobile): confirmations de suppression + filtre Journal + en-têtes d'onglet

### DIFF
--- a/apps/mobile/src/components/ui.tsx
+++ b/apps/mobile/src/components/ui.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import {
   ActivityIndicator,
+  Alert,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -398,6 +399,17 @@ export function Loader() {
 
 export function ErrorNote({ message }: { message: string }) {
   return <Text style={styles.error}>{message}</Text>;
+}
+
+/** Confirm a destructive action before running it (ADHD error-tolerance). */
+export function confirmDelete(
+  onConfirm: () => void,
+  message = "Cette action est définitive.",
+) {
+  Alert.alert("Supprimer ?", message, [
+    { text: "Annuler", style: "cancel" },
+    { text: "Supprimer", style: "destructive", onPress: onConfirm },
+  ]);
 }
 
 /** Floating action button (fixed bottom-right). */

--- a/apps/mobile/src/screens/CrisisListScreen.tsx
+++ b/apps/mobile/src/screens/CrisisListScreen.tsx
@@ -17,6 +17,7 @@ import {
   useCrisisItems,
   useDeleteCrisisItem,
 } from "../hooks/use-crisis-list";
+import { confirmDelete } from "../components/ui";
 import type { CrisisListProps } from "../navigation/types";
 
 const SUPPORT_LINKS = [
@@ -171,7 +172,9 @@ export function CrisisListScreen({ navigation, route }: CrisisListProps) {
                 <Text style={styles.cardEmoji}>{item.emoji ?? "💙"}</Text>
                 <Text style={styles.cardLabel}>{item.label}</Text>
                 <Pressable
-                  onPress={() => deleteItem.mutate({ id: item.id, childId })}
+                  onPress={() =>
+                    confirmDelete(() => deleteItem.mutate({ id: item.id, childId }))
+                  }
                   hitSlop={8}
                 >
                   <Text style={styles.deleteLink}>{copy.delete}</Text>

--- a/apps/mobile/src/screens/JournalScreen.tsx
+++ b/apps/mobile/src/screens/JournalScreen.tsx
@@ -20,15 +20,24 @@ import {
   useJournal,
 } from "../hooks/use-journal";
 import { useActiveChild } from "../lib/active-child";
+import { FilterChips, confirmDelete } from "../components/ui";
 import type { JournalProps } from "../navigation/types";
 
 const ALL_TAGS = journalTagSchema.options;
+const TAG_FILTERS = [
+  { key: "all", label: "Toutes" },
+  ...ALL_TAGS.map((t) => ({ key: t, label: journalTagLabels[t] ?? t })),
+];
 
 export function JournalScreen({ navigation, route }: JournalProps) {
   const active = useActiveChild().active;
   const childId = route.params?.childId ?? active?.id ?? "";
   const childName = route.params?.childName ?? active?.name ?? "";
   const { data: entries, isLoading } = useJournal(childId);
+  const [filterTag, setFilterTag] = useState<string>("all");
+  const visible = (entries ?? []).filter(
+    (e) => filterTag === "all" || e.tags.includes(filterTag as JournalTag),
+  );
   const createEntry = useCreateJournalEntry();
   const deleteEntry = useDeleteJournalEntry();
 
@@ -58,17 +67,7 @@ export function JournalScreen({ navigation, route }: JournalProps) {
   return (
     <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
       <View style={styles.header}>
-        {navigation.canGoBack() ? (
-          <Pressable
-            onPress={() => navigation.goBack()}
-            hitSlop={12}
-            style={styles.headerSide}
-          >
-            <Text style={styles.back}>‹ {childName}</Text>
-          </Pressable>
-        ) : (
-          <Text style={styles.back}>{childName}</Text>
-        )}
+        <Text style={styles.back}>{childName}</Text>
         {!composing ? (
           <Pressable onPress={() => setComposing(true)} hitSlop={12}>
             <Text style={styles.link}>+ {copy.writeButton}</Text>
@@ -121,11 +120,15 @@ export function JournalScreen({ navigation, route }: JournalProps) {
         </View>
       ) : null}
 
+      {!composing && (entries?.length ?? 0) > 0 ? (
+        <FilterChips options={TAG_FILTERS} value={filterTag} onChange={setFilterTag} />
+      ) : null}
+
       {isLoading ? (
         <ActivityIndicator />
       ) : (
         <FlatList
-          data={entries ?? []}
+          data={visible}
           keyExtractor={(e) => e.id}
           contentContainerStyle={styles.listContent}
           ListEmptyComponent={
@@ -147,7 +150,9 @@ export function JournalScreen({ navigation, route }: JournalProps) {
                 </View>
               ) : null}
               <Pressable
-                onPress={() => deleteEntry.mutate({ id: item.id, childId })}
+                onPress={() =>
+                  confirmDelete(() => deleteEntry.mutate({ id: item.id, childId }))
+                }
                 hitSlop={8}
               >
                 <Text style={styles.deleteLink}>{copy.delete}</Text>

--- a/apps/mobile/src/screens/MedicationsScreen.tsx
+++ b/apps/mobile/src/screens/MedicationsScreen.tsx
@@ -11,6 +11,7 @@ import {
   Screen,
   ScreenHeader,
   colors,
+  confirmDelete,
 } from "../components/ui";
 import {
   useCreateMedication,
@@ -137,7 +138,10 @@ export function MedicationsScreen({ navigation, route }: MedicationsProps) {
               {scheduleLabel(m.schedule)}
               {m.dose ? ` · ${m.dose}` : ""}
             </Text>
-            <Pressable onPress={() => remove.mutate(m.id)} hitSlop={8}>
+            <Pressable
+              onPress={() => confirmDelete(() => remove.mutate(m.id))}
+              hitSlop={8}
+            >
               <Text style={styles.delete}>Supprimer</Text>
             </Pressable>
           </Card>

--- a/apps/mobile/src/screens/RoutinesScreen.tsx
+++ b/apps/mobile/src/screens/RoutinesScreen.tsx
@@ -58,13 +58,7 @@ export function RoutinesScreen({ navigation, route }: RoutinesProps) {
 
   return (
     <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
-      {navigation.canGoBack() ? (
-        <Pressable onPress={() => navigation.goBack()} hitSlop={12}>
-          <Text style={styles.back}>‹ {childName}</Text>
-        </Pressable>
-      ) : (
-        <Text style={styles.back}>{childName}</Text>
-      )}
+      <Text style={styles.back}>{childName}</Text>
 
       <Text style={styles.title}>{copy.title}</Text>
       <Text style={styles.section}>{copy.today}</Text>

--- a/apps/mobile/src/screens/StrengthsScreen.tsx
+++ b/apps/mobile/src/screens/StrengthsScreen.tsx
@@ -11,6 +11,7 @@ import {
   Screen,
   ScreenHeader,
   colors,
+  confirmDelete,
 } from "../components/ui";
 import {
   useCreateStrength,
@@ -156,7 +157,10 @@ export function StrengthsScreen({ navigation, route }: StrengthsProps) {
             {s.description ? (
               <Text style={styles.description}>{s.description}</Text>
             ) : null}
-            <Pressable onPress={() => remove.mutate(s.id)} hitSlop={8}>
+            <Pressable
+              onPress={() => confirmDelete(() => remove.mutate(s.id))}
+              hitSlop={8}
+            >
               <Text style={styles.delete}>Supprimer</Text>
             </Pressable>
           </Card>

--- a/apps/mobile/src/screens/SymptomsScreen.tsx
+++ b/apps/mobile/src/screens/SymptomsScreen.tsx
@@ -91,7 +91,7 @@ function SymptomCard({ symptom }: { symptom: Symptom }) {
   );
 }
 
-export function SymptomsScreen({ navigation, route }: SymptomsProps) {
+export function SymptomsScreen({ route }: SymptomsProps) {
   const active = useActiveChild().active;
   const childId = route.params?.childId ?? active?.id ?? "";
   const childName = route.params?.childName ?? active?.name ?? "";
@@ -107,7 +107,7 @@ export function SymptomsScreen({ navigation, route }: SymptomsProps) {
       <ScreenHeader
         title="Symptômes"
         subtitle={childName}
-        onBack={navigation.canGoBack() ? () => navigation.goBack() : undefined}
+        onBack={undefined}
       />
 
       {isLoading ? (


### PR DESCRIPTION
## Vague 3 du redesign — garde-fous TDAH + parité PWA

- **Confirmations de suppression** : helper `confirmDelete` (Alert « Supprimer ? » / Annuler, style destructif) ajouté au kit et appliqué partout où la suppression était en **tap unique** : Journal, Liste de crise, Médicaments, Forces. → respecte la *tolérance aux erreurs* (plus de perte de données accidentelle).
- **Journal** : filtre par tag (`FilterChips` : Toutes + tags) — parité PWA.
- **En-têtes des onglets racines** (Journal/Symptômes/Routines) : suppression du chevron « retour » trompeur (un changement d'onglet n'est pas un retour) ; affichage simple du nom de l'enfant.

Typecheck strict OK, build release OK. Vérif visuelle device en attente (débogage sans fil coupé en fin de session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)