### PR TITLE
feat(mobile): FAB + filtres Symptômes (polish liste)

### DIFF
--- a/apps/mobile/src/components/ui.tsx
+++ b/apps/mobile/src/components/ui.tsx
@@ -59,31 +59,32 @@ export const fonts = {
   bold: "PlusJakartaSans_700Bold",
 } as const;
 
-/** Full-screen container. Use `scroll` for content that can overflow. */
+/** Full-screen container. Use `scroll` for content that can overflow.
+ * `fab` is rendered as an absolute overlay (bottom-right). */
 export function Screen({
   children,
   scroll = false,
   edges = ["top", "bottom"],
+  fab,
 }: {
   children: ReactNode;
   scroll?: boolean;
   edges?: ("top" | "bottom" | "left" | "right")[];
+  fab?: ReactNode;
 }) {
-  if (scroll) {
-    return (
-      <SafeAreaView style={styles.flex} edges={edges}>
+  return (
+    <SafeAreaView style={styles.flex} edges={edges}>
+      {scroll ? (
         <ScrollView
           contentContainerStyle={styles.scrollContent}
           keyboardShouldPersistTaps="handled"
         >
           {children}
         </ScrollView>
-      </SafeAreaView>
-    );
-  }
-  return (
-    <SafeAreaView style={[styles.flex, styles.padded]} edges={edges}>
-      {children}
+      ) : (
+        <View style={[styles.flex, styles.padded]}>{children}</View>
+      )}
+      {fab}
     </SafeAreaView>
   );
 }

--- a/apps/mobile/src/screens/JournalScreen.tsx
+++ b/apps/mobile/src/screens/JournalScreen.tsx
@@ -19,8 +19,10 @@ import {
   useDeleteJournalEntry,
   useJournal,
 } from "../hooks/use-journal";
+import { Plus } from "lucide-react-native";
+
 import { useActiveChild } from "../lib/active-child";
-import { FilterChips, confirmDelete } from "../components/ui";
+import { FAB, FilterChips, confirmDelete } from "../components/ui";
 import type { JournalProps } from "../navigation/types";
 
 const ALL_TAGS = journalTagSchema.options;
@@ -68,11 +70,6 @@ export function JournalScreen({ navigation, route }: JournalProps) {
     <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
       <View style={styles.header}>
         <Text style={styles.back}>{childName}</Text>
-        {!composing ? (
-          <Pressable onPress={() => setComposing(true)} hitSlop={12}>
-            <Text style={styles.link}>+ {copy.writeButton}</Text>
-          </Pressable>
-        ) : null}
       </View>
 
       <Text style={styles.title}>{copy.title}</Text>
@@ -161,6 +158,14 @@ export function JournalScreen({ navigation, route }: JournalProps) {
           )}
         />
       )}
+
+      {!composing ? (
+        <FAB
+          icon={<Plus size={26} color="#fff" />}
+          label="Écrire une entrée"
+          onPress={() => setComposing(true)}
+        />
+      ) : null}
     </SafeAreaView>
   );
 }

--- a/apps/mobile/src/screens/SymptomsScreen.tsx
+++ b/apps/mobile/src/screens/SymptomsScreen.tsx
@@ -1,10 +1,14 @@
 import type { Symptom } from "@focusflow/validators";
+import { useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
+import { Plus } from "lucide-react-native";
 
 import {
   Card,
   EmptyState,
   ErrorNote,
+  FAB,
+  FilterChips,
   Loader,
   Screen,
   ScreenHeader,
@@ -13,6 +17,29 @@ import {
 import { useSymptoms } from "../hooks/use-symptoms";
 import { useActiveChild } from "../lib/active-child";
 import type { SymptomsProps } from "../navigation/types";
+
+const FILTERS = [
+  { key: "all", label: "Toutes" },
+  { key: "agitation", label: "Agitation élevée" },
+  { key: "impulse", label: "Impulsivité élevée" },
+  { key: "mood", label: "Humeur difficile" },
+  { key: "sleep", label: "Sommeil perturbé" },
+];
+
+function matchesFilter(s: Symptom, key: string): boolean {
+  switch (key) {
+    case "agitation":
+      return s.agitation >= 7;
+    case "impulse":
+      return s.impulse >= 7;
+    case "mood":
+      return s.mood <= 3;
+    case "sleep":
+      return s.sleep <= 3;
+    default:
+      return true;
+  }
+}
 
 // The 5 numeric dimensions from the Symptom schema (routinesOk is boolean, handled separately)
 const DIMENSIONS: { key: keyof Symptom; label: string; highIsBad: boolean }[] =
@@ -91,24 +118,37 @@ function SymptomCard({ symptom }: { symptom: Symptom }) {
   );
 }
 
-export function SymptomsScreen({ route }: SymptomsProps) {
+export function SymptomsScreen({ navigation, route }: SymptomsProps) {
   const active = useActiveChild().active;
   const childId = route.params?.childId ?? active?.id ?? "";
   const childName = route.params?.childName ?? active?.name ?? "";
   const { isLoading, isError, data } = useSymptoms(childId);
 
-  // Most recent first
+  const [filter, setFilter] = useState("all");
+  // Most recent first, then category filter
   const sorted = data
     ? [...data].sort((a, b) => b.date.localeCompare(a.date))
     : [];
+  const shown = sorted.filter((s) => matchesFilter(s, filter));
 
   return (
-    <Screen scroll>
-      <ScreenHeader
-        title="Symptômes"
-        subtitle={childName}
-        onBack={undefined}
-      />
+    <Screen
+      scroll
+      fab={
+        <FAB
+          icon={<Plus size={26} color="#fff" />}
+          label="Ajouter une observation"
+          onPress={() =>
+            navigation.navigate("Checkin", { childId, childName })
+          }
+        />
+      }
+    >
+      <ScreenHeader title="Symptômes" subtitle={childName} onBack={undefined} />
+
+      {sorted.length > 0 ? (
+        <FilterChips options={FILTERS} value={filter} onChange={setFilter} />
+      ) : null}
 
       {isLoading ? (
         <Loader />
@@ -119,8 +159,10 @@ export function SymptomsScreen({ route }: SymptomsProps) {
           title="Aucune observation"
           body="Les observations enregistrées via le formulaire de suivi apparaîtront ici."
         />
+      ) : shown.length === 0 ? (
+        <EmptyState title="Aucune observation pour ce filtre" />
       ) : (
-        sorted.map((s) => <SymptomCard key={s.id} symptom={s} />)
+        shown.map((s) => <SymptomCard key={s.id} symptom={s} />)
       )}
     </Screen>
   );


### PR DESCRIPTION
Dernier polish du redesign (parité PWA, garde-fous TDAH) :
- `Screen` accepte un slot `fab` (overlay absolu).
- **FAB « + »** sur Journal (ouvre le composer ; suppression du « + Écrire » doublon) et sur Symptômes (→ Point du soir).
- **Symptômes** : `FilterChips` de catégories (Toutes / Agitation élevée / Impulsivité élevée / Humeur difficile / Sommeil perturbé).

Typecheck strict OK, build release OK. Vérif visuelle device en attente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)