### PR TITLE
feat(mobile): carte « Prochaine lecture » sur le dashboard

### DIFF
--- a/apps/mobile/src/lib/reading.ts
+++ b/apps/mobile/src/lib/reading.ts
@@ -1,0 +1,59 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useCallback, useEffect, useState } from "react";
+
+import { knowledgeArticles, type KnowledgeArticle } from "./knowledge";
+
+// Slugs of articles the parent has already opened. Persisted locally so the
+// "Prochaine lecture" card on the dashboard can suggest the next unread one.
+const STORAGE_KEY = "toko.knowledge.read";
+
+/**
+ * Tracks which knowledge-base articles have been opened, persisted in
+ * AsyncStorage. Lets the dashboard suggest a single "next" article and the
+ * Connaissances list mark articles as read when tapped.
+ */
+export function useReadArticles() {
+  const [read, setRead] = useState<Set<string>>(new Set());
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((raw) => {
+        if (cancelled || !raw) return;
+        setRead(new Set(JSON.parse(raw) as string[]));
+      })
+      .catch(() => {
+        // Corrupt/unavailable storage — start fresh, nothing is lost.
+      })
+      .finally(() => {
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const markRead = useCallback((slug: string) => {
+    setRead((prev) => {
+      if (prev.has(slug)) return prev;
+      const next = new Set(prev).add(slug);
+      void AsyncStorage.setItem(STORAGE_KEY, JSON.stringify([...next])).catch(
+        () => {
+          // Fail silent — the suggestion simply reappears next launch.
+        },
+      );
+      return next;
+    });
+  }, []);
+
+  return { read, markRead, loaded };
+}
+
+/**
+ * The next article the parent should read: the first one (in library order)
+ * they have not opened yet. Returns null once everything has been read.
+ */
+export function pickNextArticle(read: Set<string>): KnowledgeArticle | null {
+  return knowledgeArticles.find((a) => !read.has(a.slug)) ?? null;
+}

--- a/apps/mobile/src/screens/ConnaissancesScreen.tsx
+++ b/apps/mobile/src/screens/ConnaissancesScreen.tsx
@@ -4,6 +4,7 @@ import { Pressable, StyleSheet, Text, View } from "react-native";
 import { Card, Screen, ScreenHeader } from "../components/ui";
 import { useTheme, type Palette } from "../lib/theme";
 import { knowledgeArticles } from "../lib/knowledge";
+import { useReadArticles } from "../lib/reading";
 import type { ConnaissancesProps } from "../navigation/types";
 
 // Display order of subjects (mirrors the web /connaissances grouping).
@@ -24,12 +25,14 @@ function subjectOf(cluster: string): string {
 export function ConnaissancesScreen({ navigation }: ConnaissancesProps) {
   const c = useTheme();
   const styles = useMemo(() => makeStyles(c), [c]);
+  const { markRead } = useReadArticles();
   const groups = SUBJECT_ORDER.map((subject) => ({
     subject,
     items: knowledgeArticles.filter((a) => subjectOf(a.cluster) === subject),
   })).filter((g) => g.items.length > 0);
 
   function openArticle(slug: string, title: string) {
+    markRead(slug);
     navigation.navigate("ConnaissancesArticle", { slug, title });
   }
 

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -18,6 +18,7 @@ import { scheduleEveningCheckin } from "../lib/notifications";
 import { useInsights } from "../hooks/use-insights";
 import { useCalmMinutes } from "../hooks/use-stats";
 import { useParentMood, useUpsertParentMood } from "../hooks/use-parent-mood";
+import { pickNextArticle, useReadArticles } from "../lib/reading";
 import type { HomeProps, RootTabParamList } from "../navigation/types";
 
 const MOODS = [
@@ -71,6 +72,8 @@ export function HomeScreen({ navigation }: HomeProps) {
   const calm = useCalmMinutes(childId, "week");
   const mood = useParentMood(1);
   const upsertMood = useUpsertParentMood();
+  const reading = useReadArticles();
+  const nextArticle = reading.loaded ? pickNextArticle(reading.read) : null;
 
   const firstName = session?.user?.name?.split(" ")[0];
   const todaysMood = mood.data?.find((m) => m.date.slice(0, 10) === todayISO());
@@ -90,6 +93,13 @@ export function HomeScreen({ navigation }: HomeProps) {
   }
   function goSymptoms() {
     (tab() as any)?.navigate("SymptomesTab");
+  }
+  function goArticle(slug: string, title: string) {
+    reading.markRead(slug);
+    (tab() as any)?.navigate("PlusTab", {
+      screen: "ConnaissancesArticle",
+      params: { slug, title },
+    });
   }
 
   const s = insights.data;
@@ -201,6 +211,22 @@ export function HomeScreen({ navigation }: HomeProps) {
           <CalloutCard variant="tip" label="Conseil du jour">
             <Text style={styles.calloutBody}>{TIPS[dayOfYear() % TIPS.length]}</Text>
           </CalloutCard>
+
+          {/* Next reading — next unread knowledge article */}
+          {nextArticle ? (
+            <Pressable
+              onPress={() => goArticle(nextArticle.slug, nextArticle.title)}
+              accessibilityRole="button"
+            >
+              <Card>
+                <Text style={styles.readingLabel}>📖 Prochaine lecture</Text>
+                <Text style={styles.readingTitle}>{nextArticle.title}</Text>
+                <Text style={styles.readingMeta}>
+                  {nextArticle.readTime} de lecture · Lire ›
+                </Text>
+              </Card>
+            </Pressable>
+          ) : null}
         </>
       )}
     </Screen>
@@ -255,4 +281,7 @@ const makeStyles = (c: Palette) =>
     actionTitle: { color: "#fff", fontSize: 17, fontFamily: fonts.semibold },
     actionHint: { color: "#ffffffcc", fontSize: 13, fontFamily: fonts.body, marginTop: 2 },
     actionChevron: { color: "#fff", fontSize: 24 },
+    readingLabel: { color: c.muted, fontFamily: fonts.semibold, fontSize: 11, letterSpacing: 0.8, textTransform: "uppercase" },
+    readingTitle: { color: c.text, fontFamily: fonts.semibold, fontSize: 16 },
+    readingMeta: { color: c.muted, fontFamily: fonts.body, fontSize: 13 },
   });


### PR DESCRIPTION
Réimplémentation propre de l'idée de #299 (devenue obsolète après la refonte du dashboard + le mode sombre).

- `src/lib/reading.ts` : `useReadArticles()` (suivi des articles ouverts via AsyncStorage) + `pickNextArticle()` (repris de #299).
- **Dashboard** : carte « Prochaine lecture » = prochain article non lu de `knowledge.ts` ; tap → ouvre l'article **in-app** (ConnaissancesArticle) et le marque lu. Masquée quand tout est lu.
- **Connaissances** : marque l'article lu à l'ouverture.

Thémée (clair/sombre), typecheck strict OK, build OK, vérifié sur device en mode sombre. Remplace #299.

🤖 Generated with [Claude Code](https://claude.com/claude-code)