### PR TITLE
fix(mobile): refonte UX du point du soir

### DIFF
--- a/apps/mobile/src/screens/CrisisListScreen.tsx
+++ b/apps/mobile/src/screens/CrisisListScreen.tsx
@@ -10,6 +10,7 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { Trash2 } from "lucide-react-native";
 
 import { CRISIS_EMOJIS, crisis as copy } from "../lib/copy";
 import {
@@ -179,9 +180,12 @@ export function CrisisListScreen({ navigation, route }: CrisisListProps) {
                   onPress={() =>
                     confirmDelete(() => deleteItem.mutate({ id: item.id, childId }))
                   }
+                  style={styles.iconBtn}
+                  accessibilityRole="button"
+                  accessibilityLabel="Supprimer cet élément"
                   hitSlop={8}
                 >
-                  <Text style={styles.deleteLink}>{copy.delete}</Text>
+                  <Trash2 size={18} color={c.muted} />
                 </Pressable>
               </View>
             ))
@@ -277,7 +281,7 @@ const makeStyles = (c: Palette) =>
     },
     cardEmoji: { fontSize: 24 },
     cardLabel: { flex: 1, fontSize: 16, color: c.text, fontFamily: fonts.body },
-    deleteLink: { color: c.danger, fontSize: 13 },
+    iconBtn: { width: 44, height: 44, alignItems: "center", justifyContent: "center", marginRight: -10 },
     support: {
       marginTop: 12,
       gap: 8,

--- a/apps/mobile/src/screens/EveningCheckinScreen.tsx
+++ b/apps/mobile/src/screens/EveningCheckinScreen.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useMemo, useState } from "react";
-import {
-  ActivityIndicator,
-  Pressable,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { CheckCircle2, ChevronRight, Moon } from "lucide-react-native";
 
+import {
+  Button,
+  Card,
+  CalloutCard,
+  Loader,
+  Screen,
+  ScreenHeader,
+  fonts,
+} from "../components/ui";
 import { eveningCheck as copy } from "../lib/copy";
 import { todayISO } from "../lib/date";
 import { useTheme, type Palette } from "../lib/theme";
@@ -55,9 +58,6 @@ export function EveningCheckinScreen({ navigation, route }: CheckinProps) {
   const params = route.params ?? {};
   const children = useChildren();
 
-  const c = useTheme();
-  const styles = useMemo(() => makeStyles(c), [c]);
-
   const goBack = () =>
     navigation.canGoBack() ? navigation.goBack() : navigation.navigate("Home");
 
@@ -82,9 +82,9 @@ export function EveningCheckinScreen({ navigation, route }: CheckinProps) {
 
   if (!childId) {
     return (
-      <View style={styles.center}>
-        <ActivityIndicator color={c.action} />
-      </View>
+      <Screen>
+        <Loader />
+      </Screen>
     );
   }
 
@@ -169,30 +169,40 @@ function CheckinForm({
   }
 
   return (
-    <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
-      <Pressable onPress={onBack} hitSlop={12}>
-        <Text style={styles.back}>‹ {childName}</Text>
-      </Pressable>
-
-      <Text style={styles.title}>{copy.title}</Text>
+    <Screen scroll>
+      <ScreenHeader title={copy.title} subtitle={childName} onBack={onBack} />
 
       {saved ? (
-        <View style={styles.savedBox}>
-          <Text style={styles.savedText}>✓ {copy.saved}</Text>
-          <Pressable onPress={onViewCalm}>
-            <Text style={styles.link}>{copy.viewCalm} ›</Text>
-          </Pressable>
-          <Pressable
+        // Warm, intentional confirmation — not a bare line of text.
+        <>
+          <CalloutCard
+            variant="success"
+            label="C'est noté"
+            icon={<CheckCircle2 size={20} color={c.successFg} />}
+          >
+            <Text style={styles.savedTitle}>{copy.saved}</Text>
+            <Text style={styles.savedBody}>
+              Merci d'avoir pris ce petit moment. Une soirée à la fois, c'est
+              déjà beaucoup.
+            </Text>
+          </CalloutCard>
+
+          <Button
+            label={copy.viewCalm}
+            onPress={onViewCalm}
+            icon={<ChevronRight size={18} color="#fff" />}
+          />
+          <Button
+            label={copy.edit}
+            variant="secondary"
             onPress={() => {
               setSaved(false);
               setPendingHard(false);
             }}
-          >
-            <Text style={styles.link}>{copy.edit}</Text>
-          </Pressable>
-        </View>
+          />
+        </>
       ) : pendingHard ? (
-        <View style={styles.section}>
+        <Card>
           <Text style={styles.prompt}>{copy.painPrompt}</Text>
           <View style={styles.painGrid}>
             {PAIN_POINTS.map((p) => (
@@ -201,71 +211,88 @@ function CheckinForm({
                 style={[styles.painButton, isPending && styles.disabled]}
                 disabled={isPending}
                 onPress={() => handlePain(p.id)}
+                accessibilityRole="button"
+                accessibilityLabel={p.label}
               >
                 <Text style={styles.painLabel}>{p.label}</Text>
               </Pressable>
             ))}
           </View>
-          <Pressable onPress={() => setPendingHard(false)} disabled={isPending}>
-            <Text style={styles.cancel}>{copy.cancel}</Text>
-          </Pressable>
-        </View>
+          <Button
+            label={copy.cancel}
+            variant="secondary"
+            size="sm"
+            onPress={() => setPendingHard(false)}
+            disabled={isPending}
+          />
+        </Card>
       ) : (
-        <View style={styles.vibeRow}>
-          {VIBES.map((v) => (
-            <Pressable
-              key={v.id}
-              style={[styles.vibeButton, isPending && styles.disabled]}
-              disabled={isPending}
-              onPress={() => handleVibe(v)}
-              accessibilityLabel={v.label}
-            >
-              <Text style={styles.vibeEmoji}>{v.emoji}</Text>
-              <Text style={styles.vibeLabel}>{v.label}</Text>
-            </Pressable>
-          ))}
-        </View>
+        <Card>
+          <View style={styles.introRow}>
+            <Moon size={18} color={c.muted} />
+            <Text style={styles.intro}>
+              Un seul geste. Pas de détail à remplir.
+            </Text>
+          </View>
+          <View style={styles.vibeRow}>
+            {VIBES.map((v) => (
+              <Pressable
+                key={v.id}
+                style={[styles.vibeButton, isPending && styles.disabled]}
+                disabled={isPending}
+                onPress={() => handleVibe(v)}
+                accessibilityRole="button"
+                accessibilityLabel={v.label}
+              >
+                <Text style={styles.vibeEmoji}>{v.emoji}</Text>
+                <Text style={styles.vibeLabel}>{v.label}</Text>
+              </Pressable>
+            ))}
+          </View>
+        </Card>
       )}
 
-      {isPending ? <ActivityIndicator style={styles.spinner} color={c.action} /> : null}
-    </SafeAreaView>
+      {isPending ? <Loader /> : null}
+    </Screen>
   );
 }
 
 const makeStyles = (c: Palette) =>
   StyleSheet.create({
-    center: { flex: 1, justifyContent: "center", alignItems: "center", backgroundColor: c.bg },
-    container: { flex: 1, padding: 24, gap: 20, backgroundColor: c.bg },
-    back: { color: c.action, fontSize: 16 },
-    title: { fontSize: 22, fontWeight: "600", color: c.text },
-    vibeRow: { flexDirection: "row", gap: 12 },
+    introRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+    intro: { fontSize: 14, color: c.muted, fontFamily: fonts.body },
+    vibeRow: { flexDirection: "row", gap: 12, marginTop: 4 },
     vibeButton: {
       flex: 1,
       borderWidth: 1,
       borderColor: c.border,
-      borderRadius: 12,
-      paddingVertical: 16,
+      borderRadius: 14,
+      paddingVertical: 18,
       alignItems: "center",
-      gap: 4,
+      gap: 6,
+      backgroundColor: c.bg,
     },
-    vibeEmoji: { fontSize: 30 },
-    vibeLabel: { fontSize: 13, color: c.subtext },
-    section: { gap: 12 },
-    prompt: { fontSize: 15, color: c.muted },
-    painGrid: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+    vibeEmoji: { fontSize: 34 },
+    vibeLabel: { fontSize: 13, color: c.subtext, fontFamily: fonts.medium },
+    prompt: { fontSize: 16, color: c.text, fontFamily: fonts.semibold },
+    painGrid: { flexDirection: "row", flexWrap: "wrap", gap: 10, marginTop: 4 },
     painButton: {
-      width: "48%",
+      width: "47%",
+      flexGrow: 1,
       borderWidth: 1,
       borderColor: c.border,
-      borderRadius: 12,
-      paddingVertical: 16,
+      borderRadius: 14,
+      paddingVertical: 18,
       alignItems: "center",
+      backgroundColor: c.bg,
     },
-    painLabel: { fontSize: 15, color: c.subtext },
-    cancel: { textAlign: "center", color: c.muted, paddingTop: 4 },
-    savedBox: { gap: 8 },
-    savedText: { fontSize: 16, color: c.success, fontWeight: "500" },
-    link: { color: c.action },
+    painLabel: { fontSize: 15, color: c.text, fontFamily: fonts.medium },
     disabled: { opacity: 0.5 },
-    spinner: { marginTop: 4 },
+    savedTitle: { fontSize: 16, color: c.text, fontFamily: fonts.semibold },
+    savedBody: {
+      fontSize: 14,
+      color: c.subtext,
+      fontFamily: fonts.body,
+      lineHeight: 20,
+    },
   });

--- a/apps/mobile/src/screens/JournalScreen.tsx
+++ b/apps/mobile/src/screens/JournalScreen.tsx
@@ -2,10 +2,24 @@ import { useMemo, useState } from "react";
 import type { JournalTag } from "@focusflow/validators";
 import { journalTagSchema } from "@focusflow/validators";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
-import { Plus } from "lucide-react-native";
+import { Plus, Trash2 } from "lucide-react-native";
 
 import { journal as copy, journalTagLabels } from "../lib/copy";
 import { formatFrDate, todayISO } from "../lib/date";
+
+/** Friendly relative date: "Aujourd'hui" / "Hier" / full French date. */
+function relativeDate(iso: string): string {
+  const today = new Date();
+  const d = new Date(iso + "T00:00:00");
+  const days = Math.round(
+    (new Date(today.toISOString().slice(0, 10) + "T00:00:00").getTime() -
+      d.getTime()) /
+      86400000,
+  );
+  if (days === 0) return "Aujourd'hui";
+  if (days === 1) return "Hier";
+  return formatFrDate(iso);
+}
 import {
   useCreateJournalEntry,
   useDeleteJournalEntry,
@@ -148,7 +162,22 @@ export function JournalScreen({ route }: JournalProps) {
       ) : (
         visible.map((item) => (
           <Card key={item.id}>
-            <Text style={styles.cardDate}>{formatFrDate(item.date)}</Text>
+            <View style={styles.cardHead}>
+              <Text style={styles.cardDate}>{relativeDate(item.date)}</Text>
+              <Pressable
+                onPress={() =>
+                  confirmDelete(() =>
+                    deleteEntry.mutate({ id: item.id, childId }),
+                  )
+                }
+                style={styles.iconBtn}
+                accessibilityRole="button"
+                accessibilityLabel="Supprimer l'entrée"
+                hitSlop={8}
+              >
+                <Trash2 size={18} color={c.muted} />
+              </Pressable>
+            </View>
             {item.text ? <Text style={styles.cardText}>{item.text}</Text> : null}
             {item.tags.length > 0 ? (
               <View style={styles.tagRow}>
@@ -161,14 +190,6 @@ export function JournalScreen({ route }: JournalProps) {
                 ))}
               </View>
             ) : null}
-            <Pressable
-              onPress={() =>
-                confirmDelete(() => deleteEntry.mutate({ id: item.id, childId }))
-              }
-              hitSlop={8}
-            >
-              <Text style={styles.deleteLink}>{copy.delete}</Text>
-            </Pressable>
           </Card>
         ))
       )}
@@ -209,11 +230,24 @@ const makeStyles = (c: Palette) =>
     },
     cancelHit: { minHeight: 40, justifyContent: "center" },
     cancel: { color: c.muted, fontFamily: fonts.medium },
+    cardHead: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      alignItems: "center",
+    },
     cardDate: {
       fontSize: 14,
       color: c.muted,
       textTransform: "capitalize",
       fontFamily: fonts.semibold,
+    },
+    iconBtn: {
+      width: 44,
+      height: 44,
+      alignItems: "center",
+      justifyContent: "center",
+      marginRight: -10,
+      marginTop: -10,
     },
     cardText: { fontSize: 15, color: c.text, fontFamily: fonts.body, lineHeight: 22 },
     cardTag: {
@@ -223,5 +257,4 @@ const makeStyles = (c: Palette) =>
       paddingVertical: 4,
     },
     cardTagText: { fontSize: 12, color: c.subtext, fontFamily: fonts.medium },
-    deleteLink: { color: c.danger, fontSize: 13, fontFamily: fonts.medium },
   });

--- a/apps/mobile/src/screens/MedicationsScreen.tsx
+++ b/apps/mobile/src/screens/MedicationsScreen.tsx
@@ -1,6 +1,7 @@
 import type { MedicationSchedule } from "@focusflow/validators";
 import { useMemo, useState } from "react";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { Trash2 } from "lucide-react-native";
 
 import {
   Card,
@@ -134,19 +135,24 @@ export function MedicationsScreen({ navigation, route }: MedicationsProps) {
         list.data.map((m) => (
           <Card key={m.id}>
             <View style={styles.cardHead}>
-              <Text style={styles.name}>{m.name}</Text>
-              {!m.active ? <Text style={styles.inactive}>Arrêté</Text> : null}
+              <View style={styles.cardHeadLeft}>
+                <Text style={styles.name}>{m.name}</Text>
+                {!m.active ? <Text style={styles.inactive}>Arrêté</Text> : null}
+              </View>
+              <Pressable
+                onPress={() => confirmDelete(() => remove.mutate(m.id))}
+                style={styles.iconBtn}
+                accessibilityRole="button"
+                accessibilityLabel="Supprimer le traitement"
+                hitSlop={8}
+              >
+                <Trash2 size={18} color={c.muted} />
+              </Pressable>
             </View>
             <Text style={styles.meta}>
               {scheduleLabel(m.schedule)}
               {m.dose ? ` · ${m.dose}` : ""}
             </Text>
-            <Pressable
-              onPress={() => confirmDelete(() => remove.mutate(m.id))}
-              hitSlop={8}
-            >
-              <Text style={styles.delete}>Supprimer</Text>
-            </Pressable>
           </Card>
         ))
       ) : (
@@ -182,7 +188,9 @@ const makeStyles = (c: Palette) =>
     pillOn: { backgroundColor: c.brand, borderColor: c.brand },
     pillText: { color: c.subtext },
     pillTextOn: { color: "#fff", fontWeight: "600" },
-    cardHead: { flexDirection: "row", justifyContent: "space-between" },
+    cardHead: { flexDirection: "row", justifyContent: "space-between", alignItems: "flex-start" },
+    cardHeadLeft: { flex: 1, flexDirection: "row", alignItems: "center", gap: 8, flexWrap: "wrap" },
+    iconBtn: { width: 44, height: 44, alignItems: "center", justifyContent: "center", marginRight: -10, marginTop: -10 },
     name: { fontSize: 17, fontWeight: "600", color: c.text },
     inactive: { color: c.muted, fontSize: 13 },
     meta: { color: c.subtext },

--- a/apps/mobile/src/screens/StrengthsScreen.tsx
+++ b/apps/mobile/src/screens/StrengthsScreen.tsx
@@ -1,6 +1,7 @@
 import type { StrengthCategory } from "@focusflow/validators";
 import { useMemo, useState } from "react";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { Trash2 } from "lucide-react-native";
 
 import {
   Card,
@@ -156,16 +157,19 @@ export function StrengthsScreen({ navigation, route }: StrengthsProps) {
                   {categoryLabel(s.category)}
                 </Text>
               </View>
+              <Pressable
+                onPress={() => confirmDelete(() => remove.mutate(s.id))}
+                style={styles.iconBtn}
+                accessibilityRole="button"
+                accessibilityLabel="Supprimer cette force"
+                hitSlop={8}
+              >
+                <Trash2 size={18} color={c.muted} />
+              </Pressable>
             </View>
             {s.description ? (
               <Text style={styles.description}>{s.description}</Text>
             ) : null}
-            <Pressable
-              onPress={() => confirmDelete(() => remove.mutate(s.id))}
-              hitSlop={8}
-            >
-              <Text style={styles.delete}>Supprimer</Text>
-            </Pressable>
           </Card>
         ))
       ) : (
@@ -206,6 +210,7 @@ const makeStyles = (c: Palette) =>
     pillText: { color: c.subtext },
     pillTextOn: { color: "#fff", fontWeight: "600" },
     cardHead: { flexDirection: "row", alignItems: "center", gap: 12 },
+    iconBtn: { width: 44, height: 44, alignItems: "center", justifyContent: "center", marginRight: -10 },
     cardEmoji: { fontSize: 28 },
     cardBody: { flex: 1 },
     name: { fontSize: 17, fontWeight: "600", color: c.text },


### PR DESCRIPTION
## Problème
L'écran de check-in du soir (onglet Symptômes) utilisait des composants bruts (SafeAreaView, textes nus, liens flottants). Hors design system, il rendait vide et « standard » — surtout l'état « enregistré » (un simple texte vert + deux liens flottants).

## Correctif
Refonte au design kit, sans toucher à la logique métier (résolution enfant, persistance, règle B3 deux taps) :

- **Saisie** : `Card` avec une ligne d'aide (icône lune) « Un seul geste. Pas de détail à remplir. » + 3 grands boutons d'humeur lisibles.
- **Étape difficile** : `Card` avec grille de points de douleur + bouton secondaire Annuler.
- **Enregistré** : `CalloutCard` success (icône ✓, libellé « C'EST NOTÉ », message rassurant guilt-free) suivi de deux `Button` clairs — primaire « Voir les minutes calmes », secondaire « Modifier la réponse ».
- Respect des tokens de thème (dark mode inclus) et de la typo de marque.

## Vérification
Typecheck OK. Build release + install sur appareil, états « saisie » et « enregistré » vérifiés en dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)