### PR TITLE
feat(mobile): ajouter une routine depuis un modèle (1 tap)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -53,6 +53,7 @@ import { SymptomsScreen } from "./src/screens/SymptomsScreen";
 import { EveningCheckinScreen } from "./src/screens/EveningCheckinScreen";
 // Routines
 import { RoutinesScreen } from "./src/screens/RoutinesScreen";
+import { AddRoutineScreen } from "./src/screens/AddRoutineScreen";
 // Plus (grouped menu + every secondary screen)
 import { PlusMenuScreen } from "./src/screens/PlusMenuScreen";
 import { MedicationsScreen } from "./src/screens/MedicationsScreen";
@@ -118,6 +119,7 @@ function RoutinesNavigator() {
   return (
     <RoutinesStack.Navigator screenOptions={stackOptions}>
       <RoutinesStack.Screen name="Routines" component={RoutinesScreen} />
+      <RoutinesStack.Screen name="AddRoutine" component={AddRoutineScreen} />
     </RoutinesStack.Navigator>
   );
 }

--- a/apps/mobile/src/hooks/use-routines.ts
+++ b/apps/mobile/src/hooks/use-routines.ts
@@ -1,4 +1,8 @@
-import type { Routine, RoutineCompletion } from "@focusflow/validators";
+import type {
+  AdoptRoutineTemplate,
+  Routine,
+  RoutineCompletion,
+} from "@focusflow/validators";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "../lib/api";
@@ -22,6 +26,20 @@ export function useRoutines(childId: string) {
     queryKey: routinesKey(childId),
     queryFn: () => api.get<Routine[]>(`/routines/${childId}`),
     enabled: !!childId,
+  });
+}
+
+// One-tap authoring: adopt a ready-made template (single transactional insert
+// server-side). Invalidates the child's routine list so the new one appears.
+export function useAdoptRoutineTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: AdoptRoutineTemplate) =>
+      api.post<Routine>("/routines/from-template", data),
+    onSuccess: (_data, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: routinesKey(variables.childId),
+      }),
   });
 }
 

--- a/apps/mobile/src/lib/copy.ts
+++ b/apps/mobile/src/lib/copy.ts
@@ -43,16 +43,27 @@ export const journal = {
   delete: "Supprimer",
 } as const;
 
-// Mirrors fr.json → routines (mobile = execute the routine, authoring stays
-// on web).
+// Mirrors fr.json → routines. Mobile executes routines and now adds them from
+// ready-made templates (one tap). Fine-grained custom authoring stays on web.
 export const routines = {
   title: "Routines",
   today: "Aujourd'hui",
   noneToday: "Aucune routine prévue aujourd'hui.",
   done: "fait",
   allDone: "Bravo, routine terminée !",
-  authorHint: "Créez et modifiez vos routines sur le site.",
+  authorHint: "Ajoutez une routine prête à l'emploi en un tap.",
   minutes: "min",
+  add: "Ajouter une routine",
+} as const;
+
+// Copy for the "add a routine from a template" screen.
+export const addRoutine = {
+  title: "Ajouter une routine",
+  subtitle: "Choisissez un modèle prêt à l'emploi. Vous pourrez l'adapter ensuite.",
+  steps: (n: number) => `${n} étape${n > 1 ? "s" : ""}`,
+  added: (name: string) => `Routine « ${name} » ajoutée`,
+  error: "Impossible d'ajouter la routine. Réessayez.",
+  customHint: "Besoin d'une routine sur mesure ? Créez-la sur le site.",
 } as const;
 
 // Mirrors fr.json → crisis. The "mode crise" is a calm full-screen list of

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -17,6 +17,7 @@ export type RootStackParamList = {
   Symptoms: ChildParams | undefined;
   Journal: ChildParams | undefined;
   Routines: ChildParams | undefined;
+  AddRoutine: ChildParams | undefined;
   // Suivi / tracking sub-screens
   Checkin: { childId?: string; childName?: string } | undefined;
   Medications: ChildParams;
@@ -66,6 +67,7 @@ export type InsightsProps = S<"Insights">;
 export type ActivityProps = S<"Activity">;
 export type ReportProps = S<"Report">;
 export type RoutinesProps = S<"Routines">;
+export type AddRoutineProps = S<"AddRoutine">;
 export type BarkleyProps = S<"Barkley">;
 export type RewardsProps = S<"Rewards">;
 export type DecodeurProps = S<"Decodeur">;

--- a/apps/mobile/src/screens/AddRoutineScreen.tsx
+++ b/apps/mobile/src/screens/AddRoutineScreen.tsx
@@ -1,0 +1,138 @@
+import { useMemo } from "react";
+import { Alert, Pressable, StyleSheet, Text, View } from "react-native";
+import { ROUTINE_TEMPLATES } from "@focusflow/validators";
+import { ChevronRight } from "lucide-react-native";
+
+import {
+  EmptyState,
+  Screen,
+  ScreenHeader,
+  fonts,
+} from "../components/ui";
+import { addRoutine as copy } from "../lib/copy";
+import { useTheme, type Palette } from "../lib/theme";
+import { useActiveChild } from "../lib/active-child";
+import { useAdoptRoutineTemplate } from "../hooks/use-routines";
+import type { AddRoutineProps } from "../navigation/types";
+
+// One-tap authoring on mobile: pick a ready-made template (curated with a
+// pediatric neurologist + child psy). The server inserts it transactionally;
+// fine-grained custom editing stays on the web. Aligns with the ADHD design
+// guardrails — no blank page, one decision per row.
+export function AddRoutineScreen({ navigation, route }: AddRoutineProps) {
+  const active = useActiveChild().active;
+  const childId = route.params?.childId ?? active?.id ?? "";
+  const childName = route.params?.childName ?? active?.name ?? "";
+
+  const c = useTheme();
+  const styles = useMemo(() => makeStyles(c), [c]);
+
+  const adopt = useAdoptRoutineTemplate();
+
+  function add(templateKey: string, title: string) {
+    if (!childId || adopt.isPending) return;
+    adopt.mutate(
+      { childId, templateKey },
+      {
+        onSuccess: () => {
+          Alert.alert(copy.added(title));
+          navigation.goBack();
+        },
+        onError: () => Alert.alert(copy.error),
+      },
+    );
+  }
+
+  if (!childId) {
+    return (
+      <Screen scroll>
+        <ScreenHeader
+          title={copy.title}
+          onBack={() => navigation.goBack()}
+        />
+        <EmptyState
+          title="Aucun enfant sélectionné"
+          body="Ajoutez un enfant depuis le site, il apparaîtra ici."
+        />
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen scroll>
+      <ScreenHeader
+        title={copy.title}
+        subtitle={childName}
+        onBack={() => navigation.goBack()}
+      />
+      <Text style={styles.intro}>{copy.subtitle}</Text>
+
+      {ROUTINE_TEMPLATES.map((t) => {
+        const gentle = t.tone === "gentle";
+        return (
+          <Pressable
+            key={t.key}
+            onPress={() => add(t.key, t.title)}
+            disabled={adopt.isPending}
+            accessibilityRole="button"
+            accessibilityLabel={`Ajouter la routine ${t.title}`}
+            style={[
+              styles.card,
+              gentle && styles.cardGentle,
+              adopt.isPending && styles.disabled,
+            ]}
+          >
+            <Text style={styles.emoji}>{t.emoji}</Text>
+            <View style={styles.body}>
+              <Text style={styles.name}>{t.title}</Text>
+              <Text style={styles.meta}>{copy.steps(t.steps.length)}</Text>
+            </View>
+            <ChevronRight size={22} color={c.chevron} />
+          </Pressable>
+        );
+      })}
+
+      <Text style={styles.customHint}>{copy.customHint}</Text>
+    </Screen>
+  );
+}
+
+const makeStyles = (c: Palette) =>
+  StyleSheet.create({
+    intro: {
+      fontSize: 14,
+      color: c.muted,
+      fontFamily: fonts.body,
+      lineHeight: 20,
+      marginBottom: 2,
+    },
+    card: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 14,
+      backgroundColor: c.card,
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 14,
+      paddingVertical: 16,
+      paddingHorizontal: 16,
+      minHeight: 64,
+    },
+    cardGentle: {
+      backgroundColor: c.tipSurface,
+      borderColor: c.tipBorder,
+    },
+    disabled: { opacity: 0.5 },
+    emoji: { fontSize: 28 },
+    body: { flex: 1 },
+    name: { fontSize: 16, color: c.text, fontFamily: fonts.semibold },
+    meta: { fontSize: 13, color: c.muted, fontFamily: fonts.body, marginTop: 2 },
+    customHint: {
+      fontSize: 13,
+      color: c.muted,
+      fontFamily: fonts.body,
+      textAlign: "center",
+      marginTop: 8,
+      lineHeight: 18,
+    },
+  });

--- a/apps/mobile/src/screens/RoutinesScreen.tsx
+++ b/apps/mobile/src/screens/RoutinesScreen.tsx
@@ -1,8 +1,10 @@
 import { useMemo } from "react";
 import type { Routine, RoutineStep } from "@focusflow/validators";
 import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Plus } from "lucide-react-native";
 
 import {
+  Button,
   Card,
   EmptyState,
   Loader,
@@ -28,13 +30,16 @@ function mondayBasedDow(): number {
   return (new Date().getDay() + 6) % 7;
 }
 
-export function RoutinesScreen({ route }: RoutinesProps) {
+export function RoutinesScreen({ navigation, route }: RoutinesProps) {
   const active = useActiveChild().active;
   const childId = route.params?.childId ?? active?.id ?? "";
   const childName = route.params?.childName ?? active?.name ?? "";
   const today = todayISO();
   const c = useTheme();
   const styles = useMemo(() => makeStyles(c), [c]);
+
+  const goAdd = () =>
+    navigation.navigate("AddRoutine", { childId, childName });
 
   const routinesQuery = useRoutines(childId);
   const completionsQuery = useRoutineCompletions(childId, today);
@@ -57,13 +62,37 @@ export function RoutinesScreen({ route }: RoutinesProps) {
 
   return (
     <Screen scroll>
-      <ScreenHeader title={copy.title} subtitle={childName} />
+      <ScreenHeader
+        title={copy.title}
+        subtitle={childName}
+        right={
+          childId ? (
+            <Pressable
+              onPress={goAdd}
+              hitSlop={10}
+              accessibilityRole="button"
+              accessibilityLabel={copy.add}
+            >
+              <Text style={styles.add}>+ Ajouter</Text>
+            </Pressable>
+          ) : undefined
+        }
+      />
       <SectionLabel>{copy.today}</SectionLabel>
 
       {routinesQuery.isLoading ? (
         <Loader />
       ) : todays.length === 0 ? (
-        <EmptyState title={copy.noneToday} body={copy.authorHint} />
+        <>
+          <EmptyState title={copy.noneToday} body={copy.authorHint} />
+          {childId ? (
+            <Button
+              label={copy.add}
+              icon={<Plus size={18} color="#fff" />}
+              onPress={goAdd}
+            />
+          ) : null}
+        </>
       ) : (
         todays.map((routine) => {
           const steps = [...routine.steps].sort((a, b) => a.position - b.position);
@@ -117,6 +146,7 @@ export function RoutinesScreen({ route }: RoutinesProps) {
 
 const makeStyles = (c: Palette) =>
   StyleSheet.create({
+    add: { color: c.action, fontSize: 15, fontFamily: fonts.semibold },
     head: {
       flexDirection: "row",
       justifyContent: "space-between",


### PR DESCRIPTION
## Besoin
Sur mobile, l'écran Routines ne faisait qu'**exécuter** les routines du jour ; impossible d'en **ajouter** (création réservée au web). Le backend savait déjà adopter un modèle (`POST /routines/from-template`) — on l'expose maintenant côté mobile.

## Approche (choix TDAH : modèles en 1 tap)
- **Nouvel écran `AddRoutine`** : les 6 modèles prêts à l'emploi (Matin d'école, Retour d'école, Devoirs, Coucher sans cris, Transition, Journée pourrie) en cartes (emoji, nb d'étapes, chevron). Un tap = routine créée → confirmation `Alert` → retour à la liste. Le modèle `gentle` (« Journée pourrie ») se distingue visuellement.
- **Hook `useAdoptRoutineTemplate`** : invalide la liste des routines de l'enfant après ajout.
- **Écran Routines** : bouton « + Ajouter » dans l'en-tête + bouton plein sur l'état vide (fini la page blanche).
- Design kit + tokens de thème (dark mode vérifié), copy 100% française.

La création sur mesure fine-grain (étape par étape, jours) reste sur le web pour préserver une charge cognitive minimale sur mobile.

## Vérification
Typecheck OK. Build release + install sur appareil : bouton « + Ajouter » → écran des 6 modèles → adoption d'un modèle → confirmation + retour, le tout en dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)