### PR TITLE
feat(mobile): modifier et supprimer une routine

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -54,6 +54,7 @@ import { EveningCheckinScreen } from "./src/screens/EveningCheckinScreen";
 // Routines
 import { RoutinesScreen } from "./src/screens/RoutinesScreen";
 import { AddRoutineScreen } from "./src/screens/AddRoutineScreen";
+import { EditRoutineScreen } from "./src/screens/EditRoutineScreen";
 // Plus (grouped menu + every secondary screen)
 import { PlusMenuScreen } from "./src/screens/PlusMenuScreen";
 import { MedicationsScreen } from "./src/screens/MedicationsScreen";
@@ -120,6 +121,7 @@ function RoutinesNavigator() {
     <RoutinesStack.Navigator screenOptions={stackOptions}>
       <RoutinesStack.Screen name="Routines" component={RoutinesScreen} />
       <RoutinesStack.Screen name="AddRoutine" component={AddRoutineScreen} />
+      <RoutinesStack.Screen name="EditRoutine" component={EditRoutineScreen} />
     </RoutinesStack.Navigator>
   );
 }

--- a/apps/mobile/src/hooks/use-routines.ts
+++ b/apps/mobile/src/hooks/use-routines.ts
@@ -43,6 +43,67 @@ export function useAdoptRoutineTemplate() {
   });
 }
 
+type UpdateRoutineVars = {
+  childId: string;
+  id: string;
+  name?: string;
+  emoji?: string | null;
+  timeOfDay?: Routine["timeOfDay"];
+  daysOfWeek?: number[];
+  active?: boolean;
+};
+
+type StepInput = {
+  id?: string;
+  label: string;
+  emoji?: string | null;
+  durationMinutes?: number | null;
+};
+
+// Edit a routine's metadata (name/emoji/time/days/active).
+export function useUpdateRoutine() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, childId: _childId, ...patch }: UpdateRoutineVars) =>
+      api.patch<Routine>(`/routines/${id}`, patch),
+    onSuccess: (_data, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: routinesKey(variables.childId),
+      }),
+  });
+}
+
+// Replace the full step list (server diffs by id, keeps positions consistent).
+export function useUpsertRoutineSteps() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      steps,
+    }: {
+      childId: string;
+      id: string;
+      steps: StepInput[];
+    }) => api.patch<Routine>(`/routines/${id}/steps`, { steps }),
+    onSuccess: (_data, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: routinesKey(variables.childId),
+      }),
+  });
+}
+
+export function useDeleteRoutine() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id }: { childId: string; id: string }) =>
+      api.delete<{ ok: true }>(`/routines/${id}`),
+    onSuccess: (_data, variables) =>
+      queryClient.invalidateQueries({
+        queryKey: routinesKey(variables.childId),
+      }),
+  });
+}
+
 export function useRoutineCompletions(childId: string, date: string) {
   return useQuery({
     queryKey: completionsKey(childId, date),

--- a/apps/mobile/src/lib/copy.ts
+++ b/apps/mobile/src/lib/copy.ts
@@ -54,6 +54,8 @@ export const routines = {
   authorHint: "Ajoutez une routine prête à l'emploi en un tap.",
   minutes: "min",
   add: "Ajouter une routine",
+  others: "Autres routines",
+  inactive: "En pause",
 } as const;
 
 // Copy for the "add a routine from a template" screen.
@@ -65,6 +67,39 @@ export const addRoutine = {
   error: "Impossible d'ajouter la routine. Réessayez.",
   customHint: "Besoin d'une routine sur mesure ? Créez-la sur le site.",
 } as const;
+
+// Copy for the full routine editor (name, emoji, time, days, steps).
+export const editRoutine = {
+  title: "Modifier la routine",
+  name: "Nom",
+  namePlaceholder: "Nom de la routine",
+  emoji: "Emoji",
+  emojiPlaceholder: "ex. 🌙",
+  timeOfDay: "Moment",
+  days: "Jours",
+  daysHint: "Aucun jour sélectionné = tous les jours.",
+  steps: "Étapes",
+  stepPlaceholder: "Décrire l'étape",
+  stepEmojiPlaceholder: "🙂",
+  stepMinutesPlaceholder: "min",
+  addStep: "Ajouter une étape",
+  save: "Enregistrer",
+  saving: "Enregistrement…",
+  saved: "Routine modifiée",
+  error: "Impossible d'enregistrer. Réessayez.",
+  notFound: "Routine introuvable.",
+  deleteRoutine: "Supprimer la routine",
+} as const;
+
+// Shared labels for the day-of-week selector (0=Mon … 6=Sun) and time of day.
+export const DOW_LABELS = ["L", "M", "M", "J", "V", "S", "D"] as const;
+export const TIME_OF_DAY_LABELS: Record<string, string> = {
+  morning: "Matin",
+  noon: "Midi",
+  evening: "Soir",
+  bedtime: "Coucher",
+  anytime: "Toujours",
+};
 
 // Mirrors fr.json → crisis. The "mode crise" is a calm full-screen list of
 // what soothes the child during a meltdown.

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -18,6 +18,7 @@ export type RootStackParamList = {
   Journal: ChildParams | undefined;
   Routines: ChildParams | undefined;
   AddRoutine: ChildParams | undefined;
+  EditRoutine: ChildParams & { routineId: string };
   // Suivi / tracking sub-screens
   Checkin: { childId?: string; childName?: string } | undefined;
   Medications: ChildParams;
@@ -68,6 +69,7 @@ export type ActivityProps = S<"Activity">;
 export type ReportProps = S<"Report">;
 export type RoutinesProps = S<"Routines">;
 export type AddRoutineProps = S<"AddRoutine">;
+export type EditRoutineProps = S<"EditRoutine">;
 export type BarkleyProps = S<"Barkley">;
 export type RewardsProps = S<"Rewards">;
 export type DecodeurProps = S<"Decodeur">;

--- a/apps/mobile/src/screens/EditRoutineScreen.tsx
+++ b/apps/mobile/src/screens/EditRoutineScreen.tsx
@@ -1,0 +1,420 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { TIME_OF_DAY, type TimeOfDay } from "@focusflow/validators";
+import {
+  ChevronDown,
+  ChevronUp,
+  Plus,
+  Trash2,
+  X,
+} from "lucide-react-native";
+
+import {
+  Button,
+  Card,
+  ErrorNote,
+  Loader,
+  Screen,
+  ScreenHeader,
+  SectionLabel,
+  confirmDelete,
+  fonts,
+} from "../components/ui";
+import {
+  DOW_LABELS,
+  TIME_OF_DAY_LABELS,
+  editRoutine as copy,
+} from "../lib/copy";
+import { useTheme, type Palette } from "../lib/theme";
+import {
+  useDeleteRoutine,
+  useRoutines,
+  useUpdateRoutine,
+  useUpsertRoutineSteps,
+} from "../hooks/use-routines";
+import type { EditRoutineProps } from "../navigation/types";
+
+type StepDraft = {
+  id?: string;
+  label: string;
+  emoji: string;
+  minutes: string;
+};
+
+// Full routine editor on mobile (name, emoji, moment, days, steps). Metadata
+// and steps are saved via two endpoints; steps are reordered with explicit
+// up/down controls rather than drag — clearer and accessible for ADHD users.
+export function EditRoutineScreen({ navigation, route }: EditRoutineProps) {
+  const { childId, childName, routineId } = route.params;
+  const c = useTheme();
+  const styles = useMemo(() => makeStyles(c), [c]);
+
+  const routinesQuery = useRoutines(childId);
+  const routine = routinesQuery.data?.find((r) => r.id === routineId);
+
+  const updateRoutine = useUpdateRoutine();
+  const upsertSteps = useUpsertRoutineSteps();
+  const deleteRoutine = useDeleteRoutine();
+
+  const [ready, setReady] = useState(false);
+  const [name, setName] = useState("");
+  const [emoji, setEmoji] = useState("");
+  const [timeOfDay, setTimeOfDay] = useState<TimeOfDay>("morning");
+  const [days, setDays] = useState<number[]>([]);
+  const [steps, setSteps] = useState<StepDraft[]>([]);
+  const [error, setError] = useState(false);
+
+  // Populate the form once the routine is loaded (only the first time).
+  useEffect(() => {
+    if (ready || !routine) return;
+    setName(routine.name);
+    setEmoji(routine.emoji ?? "");
+    setTimeOfDay(routine.timeOfDay);
+    setDays([...routine.daysOfWeek]);
+    setSteps(
+      [...routine.steps]
+        .sort((a, b) => a.position - b.position)
+        .map((s) => ({
+          id: s.id,
+          label: s.label,
+          emoji: s.emoji ?? "",
+          minutes: s.durationMinutes != null ? String(s.durationMinutes) : "",
+        })),
+    );
+    setReady(true);
+  }, [routine, ready]);
+
+  const saving = updateRoutine.isPending || upsertSteps.isPending;
+
+  function toggleDay(d: number) {
+    setDays((prev) =>
+      prev.includes(d) ? prev.filter((x) => x !== d) : [...prev, d].sort(),
+    );
+  }
+
+  function updateStep(i: number, patch: Partial<StepDraft>) {
+    setSteps((prev) => prev.map((s, idx) => (idx === i ? { ...s, ...patch } : s)));
+  }
+  function removeStep(i: number) {
+    setSteps((prev) => prev.filter((_, idx) => idx !== i));
+  }
+  function moveStep(i: number, dir: -1 | 1) {
+    setSteps((prev) => {
+      const j = i + dir;
+      if (j < 0 || j >= prev.length) return prev;
+      const next = [...prev];
+      [next[i], next[j]] = [next[j]!, next[i]!];
+      return next;
+    });
+  }
+  function addStep() {
+    setSteps((prev) => [...prev, { label: "", emoji: "", minutes: "" }]);
+  }
+
+  async function save() {
+    setError(false);
+    const trimmedName = name.trim();
+    const cleanSteps = steps
+      .map((s) => ({ ...s, label: s.label.trim() }))
+      .filter((s) => s.label.length > 0)
+      .map((s) => {
+        const m = parseInt(s.minutes, 10);
+        return {
+          id: s.id,
+          label: s.label,
+          emoji: s.emoji.trim() || null,
+          durationMinutes:
+            Number.isFinite(m) && m >= 1 && m <= 180 ? m : null,
+        };
+      });
+    if (!trimmedName) {
+      setError(true);
+      return;
+    }
+    try {
+      await updateRoutine.mutateAsync({
+        childId,
+        id: routineId,
+        name: trimmedName,
+        emoji: emoji.trim() || null,
+        timeOfDay,
+        daysOfWeek: days,
+      });
+      await upsertSteps.mutateAsync({
+        childId,
+        id: routineId,
+        steps: cleanSteps,
+      });
+      Alert.alert(copy.saved);
+      navigation.goBack();
+    } catch {
+      setError(true);
+    }
+  }
+
+  function remove() {
+    confirmDelete(() =>
+      deleteRoutine.mutate(
+        { childId, id: routineId },
+        { onSuccess: () => navigation.goBack() },
+      ),
+    );
+  }
+
+  if (routinesQuery.isLoading || !ready) {
+    return (
+      <Screen scroll>
+        <ScreenHeader
+          title={copy.title}
+          subtitle={childName}
+          onBack={() => navigation.goBack()}
+        />
+        {routinesQuery.isLoading ? (
+          <Loader />
+        ) : (
+          <ErrorNote message={copy.notFound} />
+        )}
+      </Screen>
+    );
+  }
+
+  return (
+    <Screen scroll>
+      <ScreenHeader
+        title={copy.title}
+        subtitle={childName}
+        onBack={() => navigation.goBack()}
+      />
+
+      <Card>
+        <SectionLabel>{copy.name}</SectionLabel>
+        <TextInput
+          style={styles.input}
+          placeholder={copy.namePlaceholder}
+          placeholderTextColor={c.muted}
+          value={name}
+          onChangeText={setName}
+        />
+        <SectionLabel>{copy.emoji}</SectionLabel>
+        <TextInput
+          style={[styles.input, styles.emojiInput]}
+          placeholder={copy.emojiPlaceholder}
+          placeholderTextColor={c.muted}
+          value={emoji}
+          onChangeText={setEmoji}
+        />
+      </Card>
+
+      <Card>
+        <SectionLabel>{copy.timeOfDay}</SectionLabel>
+        <View style={styles.pills}>
+          {TIME_OF_DAY.map((t) => {
+            const on = t === timeOfDay;
+            return (
+              <Pressable
+                key={t}
+                onPress={() => setTimeOfDay(t)}
+                style={[styles.pill, on && styles.pillOn]}
+                accessibilityRole="button"
+                accessibilityState={{ selected: on }}
+              >
+                <Text style={[styles.pillText, on && styles.pillTextOn]}>
+                  {TIME_OF_DAY_LABELS[t] ?? t}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+
+        <SectionLabel>{copy.days}</SectionLabel>
+        <View style={styles.daysRow}>
+          {DOW_LABELS.map((label, d) => {
+            const on = days.includes(d);
+            return (
+              <Pressable
+                key={d}
+                onPress={() => toggleDay(d)}
+                style={[styles.dayChip, on && styles.dayChipOn]}
+                accessibilityRole="button"
+                accessibilityState={{ selected: on }}
+                accessibilityLabel={`Jour ${label}`}
+              >
+                <Text style={[styles.dayText, on && styles.dayTextOn]}>
+                  {label}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+        <Text style={styles.hint}>{copy.daysHint}</Text>
+      </Card>
+
+      <SectionLabel>{copy.steps}</SectionLabel>
+      {steps.map((step, i) => (
+        <Card key={step.id ?? `new-${i}`}>
+          <View style={styles.stepTop}>
+            <TextInput
+              style={[styles.input, styles.stepEmoji]}
+              placeholder={copy.stepEmojiPlaceholder}
+              placeholderTextColor={c.muted}
+              value={step.emoji}
+              onChangeText={(v) => updateStep(i, { emoji: v })}
+            />
+            <TextInput
+              style={[styles.input, styles.stepLabel]}
+              placeholder={copy.stepPlaceholder}
+              placeholderTextColor={c.muted}
+              value={step.label}
+              onChangeText={(v) => updateStep(i, { label: v })}
+            />
+            <Pressable
+              onPress={() => removeStep(i)}
+              style={styles.iconBtn}
+              accessibilityRole="button"
+              accessibilityLabel="Supprimer l'étape"
+              hitSlop={6}
+            >
+              <X size={18} color={c.muted} />
+            </Pressable>
+          </View>
+          <View style={styles.stepBottom}>
+            <TextInput
+              style={[styles.input, styles.stepMin]}
+              placeholder={copy.stepMinutesPlaceholder}
+              placeholderTextColor={c.muted}
+              value={step.minutes}
+              onChangeText={(v) =>
+                updateStep(i, { minutes: v.replace(/[^0-9]/g, "") })
+              }
+              keyboardType="number-pad"
+              maxLength={3}
+            />
+            <Text style={styles.minLabel}>min</Text>
+            <View style={styles.spacer} />
+            <Pressable
+              onPress={() => moveStep(i, -1)}
+              disabled={i === 0}
+              style={[styles.iconBtn, i === 0 && styles.iconDisabled]}
+              accessibilityRole="button"
+              accessibilityLabel="Monter l'étape"
+              hitSlop={6}
+            >
+              <ChevronUp size={20} color={c.subtext} />
+            </Pressable>
+            <Pressable
+              onPress={() => moveStep(i, 1)}
+              disabled={i === steps.length - 1}
+              style={[
+                styles.iconBtn,
+                i === steps.length - 1 && styles.iconDisabled,
+              ]}
+              accessibilityRole="button"
+              accessibilityLabel="Descendre l'étape"
+              hitSlop={6}
+            >
+              <ChevronDown size={20} color={c.subtext} />
+            </Pressable>
+          </View>
+        </Card>
+      ))}
+
+      <Button
+        label={copy.addStep}
+        variant="secondary"
+        icon={<Plus size={18} color={c.text} />}
+        onPress={addStep}
+      />
+
+      {error ? <ErrorNote message={copy.error} /> : null}
+
+      <Button
+        label={saving ? copy.saving : copy.save}
+        onPress={save}
+        loading={saving}
+        disabled={!name.trim()}
+      />
+
+      <Pressable
+        onPress={remove}
+        style={styles.deleteRow}
+        accessibilityRole="button"
+        accessibilityLabel={copy.deleteRoutine}
+        disabled={deleteRoutine.isPending}
+      >
+        <Trash2 size={18} color={c.danger} />
+        <Text style={styles.deleteText}>{copy.deleteRoutine}</Text>
+      </Pressable>
+    </Screen>
+  );
+}
+
+const makeStyles = (c: Palette) =>
+  StyleSheet.create({
+    input: {
+      borderWidth: 1,
+      borderColor: c.border,
+      borderRadius: 10,
+      paddingHorizontal: 12,
+      paddingVertical: 10,
+      fontSize: 15,
+      color: c.text,
+      backgroundColor: c.bg,
+      fontFamily: fonts.body,
+    },
+    emojiInput: { width: 80, textAlign: "center", fontSize: 20 },
+    pills: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+    pill: {
+      paddingHorizontal: 14,
+      paddingVertical: 8,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: c.border,
+    },
+    pillOn: { backgroundColor: c.brand, borderColor: c.brand },
+    pillText: { color: c.subtext, fontFamily: fonts.medium, fontSize: 14 },
+    pillTextOn: { color: "#fff", fontFamily: fonts.semibold },
+    daysRow: { flexDirection: "row", gap: 8 },
+    dayChip: {
+      flex: 1,
+      aspectRatio: 1,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: c.border,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    dayChipOn: { backgroundColor: c.brand, borderColor: c.brand },
+    dayText: { color: c.subtext, fontFamily: fonts.semibold, fontSize: 14 },
+    dayTextOn: { color: "#fff" },
+    hint: { fontSize: 12, color: c.muted, fontFamily: fonts.body },
+    stepTop: { flexDirection: "row", alignItems: "center", gap: 8 },
+    stepEmoji: { width: 52, textAlign: "center", fontSize: 18 },
+    stepLabel: { flex: 1 },
+    stepBottom: { flexDirection: "row", alignItems: "center", gap: 6 },
+    stepMin: { width: 64, textAlign: "center" },
+    minLabel: { color: c.muted, fontFamily: fonts.body, fontSize: 13 },
+    spacer: { flex: 1 },
+    iconBtn: {
+      width: 40,
+      height: 40,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    iconDisabled: { opacity: 0.3 },
+    deleteRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 8,
+      paddingVertical: 14,
+      marginTop: 4,
+    },
+    deleteText: { color: c.danger, fontFamily: fonts.semibold, fontSize: 15 },
+  });

--- a/apps/mobile/src/screens/RoutinesScreen.tsx
+++ b/apps/mobile/src/screens/RoutinesScreen.tsx
@@ -1,20 +1,21 @@
 import { useMemo } from "react";
 import type { Routine, RoutineStep } from "@focusflow/validators";
 import { Pressable, StyleSheet, Text, View } from "react-native";
-import { Plus } from "lucide-react-native";
+import { Pencil, Plus } from "lucide-react-native";
 
 import {
   Button,
   Card,
   EmptyState,
   Loader,
+  MenuRow,
   Screen,
   ScreenHeader,
   SectionLabel,
   fonts,
 } from "../components/ui";
 import { useTheme, type Palette } from "../lib/theme";
-import { routines as copy } from "../lib/copy";
+import { routines as copy, TIME_OF_DAY_LABELS } from "../lib/copy";
 import { todayISO } from "../lib/date";
 import {
   useCompleteStep,
@@ -40,6 +41,8 @@ export function RoutinesScreen({ navigation, route }: RoutinesProps) {
 
   const goAdd = () =>
     navigation.navigate("AddRoutine", { childId, childName });
+  const goEdit = (routineId: string) =>
+    navigation.navigate("EditRoutine", { childId, childName, routineId });
 
   const routinesQuery = useRoutines(childId);
   const completionsQuery = useRoutineCompletions(childId, today);
@@ -53,6 +56,20 @@ export function RoutinesScreen({ navigation, route }: RoutinesProps) {
   const doneStepIds = new Set(
     (completionsQuery.data ?? []).map((c) => c.stepId),
   );
+
+  // Every routine not shown in "today" stays reachable for editing/deletion
+  // (other days or paused) — otherwise a Saturday couldn't edit a school
+  // routine.
+  const todayIds = new Set(todays.map((r) => r.id));
+  const others = (routinesQuery.data ?? []).filter((r) => !todayIds.has(r.id));
+
+  function otherMeta(r: Routine): string {
+    const stepLabel = `${r.steps.length} ${r.steps.length > 1 ? "étapes" : "étape"}`;
+    const base = [TIME_OF_DAY_LABELS[r.timeOfDay] ?? "", stepLabel]
+      .filter(Boolean)
+      .join(" · ");
+    return r.active ? base : `${copy.inactive} · ${base}`;
+  }
 
   function toggle(routine: Routine, step: RoutineStep) {
     const vars = { childId, routineId: routine.id, stepId: step.id, date: today };
@@ -83,16 +100,7 @@ export function RoutinesScreen({ navigation, route }: RoutinesProps) {
       {routinesQuery.isLoading ? (
         <Loader />
       ) : todays.length === 0 ? (
-        <>
-          <EmptyState title={copy.noneToday} body={copy.authorHint} />
-          {childId ? (
-            <Button
-              label={copy.add}
-              icon={<Plus size={18} color="#fff" />}
-              onPress={goAdd}
-            />
-          ) : null}
-        </>
+        <EmptyState title={copy.noneToday} body={copy.authorHint} />
       ) : (
         todays.map((routine) => {
           const steps = [...routine.steps].sort((a, b) => a.position - b.position);
@@ -105,9 +113,20 @@ export function RoutinesScreen({ navigation, route }: RoutinesProps) {
                   {routine.emoji ? `${routine.emoji} ` : ""}
                   {routine.name}
                 </Text>
-                <Text style={styles.progress}>
-                  {doneCount}/{steps.length}
-                </Text>
+                <View style={styles.headRight}>
+                  <Text style={styles.progress}>
+                    {doneCount}/{steps.length}
+                  </Text>
+                  <Pressable
+                    onPress={() => goEdit(routine.id)}
+                    style={styles.editBtn}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Modifier la routine ${routine.name}`}
+                    hitSlop={8}
+                  >
+                    <Pencil size={18} color={c.muted} />
+                  </Pressable>
+                </View>
               </View>
               {allDone ? <Text style={styles.allDone}>{copy.allDone}</Text> : null}
 
@@ -140,6 +159,29 @@ export function RoutinesScreen({ navigation, route }: RoutinesProps) {
           );
         })
       )}
+
+      {!routinesQuery.isLoading && others.length > 0 ? (
+        <>
+          <SectionLabel>{copy.others}</SectionLabel>
+          {others.map((r) => (
+            <MenuRow
+              key={r.id}
+              emoji={r.emoji ?? undefined}
+              label={r.name}
+              hint={otherMeta(r)}
+              onPress={() => goEdit(r.id)}
+            />
+          ))}
+        </>
+      ) : null}
+
+      {!routinesQuery.isLoading && childId ? (
+        <Button
+          label={copy.add}
+          icon={<Plus size={18} color="#fff" />}
+          onPress={goAdd}
+        />
+      ) : null}
     </Screen>
   );
 }
@@ -147,6 +189,14 @@ export function RoutinesScreen({ navigation, route }: RoutinesProps) {
 const makeStyles = (c: Palette) =>
   StyleSheet.create({
     add: { color: c.action, fontSize: 15, fontFamily: fonts.semibold },
+    headRight: { flexDirection: "row", alignItems: "center", gap: 6 },
+    editBtn: {
+      width: 36,
+      height: 36,
+      alignItems: "center",
+      justifyContent: "center",
+      marginRight: -8,
+    },
     head: {
       flexDirection: "row",
       justifyContent: "space-between",


### PR DESCRIPTION
## Besoin
Après l'ajout de routines par modèle (#309), il manquait la possibilité de **modifier** et **supprimer** une routine depuis le mobile. Le backend gérait déjà tout (`PATCH /routines/:id`, `PATCH /routines/:id/steps`, `DELETE /routines/:id`).

## Approche (édition complète, choisie par le produit)
- **Nouvel écran `EditRoutine`** : nom, emoji, moment, jours de la semaine, et un **éditeur d'étapes** (emoji + libellé + durée, ajouter/supprimer, réordonner via flèches ↑/↓ — plus clair et accessible que le drag pour un usage TDAH).
- **Enregistrement en deux temps** : métadonnées (`PATCH /:id`) puis étapes (`PATCH /:id/steps`), confirmation `Alert`.
- **Suppression** depuis l'éditeur (bouton dédié rouge + confirmation `confirmDelete`).
- Hooks `useUpdateRoutine` / `useUpsertRoutineSteps` / `useDeleteRoutine`.
- **Écran Routines** : icône crayon sur chaque carte du jour + nouvelle section **« Autres routines »** (autres jours / en pause) accessible à l'édition — sinon impossible d'éditer une routine non planifiée le jour même.
- Bouton « Ajouter une routine » désormais persistant en bas de liste.
- Design kit + tokens de thème (dark mode vérifié), copy 100% française.

## Vérification (sur appareil, dark mode)
Crayon → éditeur (nom/emoji/moment/jours/étapes) ✓ · réordonner/supprimer/ajouter une étape ✓ · **Enregistrer** → « Routine modifiée » + retour, round-trip API OK ✓ · bouton **Supprimer la routine** présent ✓ · section « Autres routines » liste Matin d'école / Devoirs ✓. Typecheck OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)