### PR TITLE
fix(mobile): refonte de l'écran « minutes de calme » (KPI H1)

### DIFF
--- a/apps/mobile/src/lib/copy.ts
+++ b/apps/mobile/src/lib/copy.ts
@@ -24,8 +24,13 @@ export const calmMinutes = {
   title: "Minutes de calme cette semaine",
   total: (minutes: number) => `${minutes} min`,
   average: (minutes: number, days: number) =>
-    `Moyenne de ${minutes} min/jour sur ${days} j notés`,
+    `Moyenne de ${minutes} min/jour sur ${days} j noté${days > 1 ? "s" : ""}`,
   empty: "Commencez à noter vos soirées pour voir le calme s'accumuler.",
+  weekLabel: "7 derniers jours",
+  explainTitle: "Le calme, pas la performance",
+  explainBody:
+    "Ces minutes sont une trace de ce qui a bien marché, pas un score à battre. Un seul soir noté suffit pour commencer.",
+  goCheckin: "Noter la soirée de ce soir",
 } as const;
 
 // Mirrors fr.json → journal (+ tags). Guilt-free placeholder kept verbatim.

--- a/apps/mobile/src/screens/CalmMinutesScreen.tsx
+++ b/apps/mobile/src/screens/CalmMinutesScreen.tsx
@@ -1,24 +1,60 @@
 import { useMemo } from "react";
-import {
-  ActivityIndicator,
-  Pressable,
-  StyleSheet,
-  Text,
-  View,
-} from "react-native";
-import { SafeAreaView } from "react-native-safe-area-context";
+import { StyleSheet, Text, View } from "react-native";
+import { Leaf } from "lucide-react-native";
 
+import {
+  Card,
+  CalloutCard,
+  Loader,
+  Screen,
+  ScreenHeader,
+  fonts,
+} from "../components/ui";
 import { calmMinutes as copy } from "../lib/copy";
 import { useCalmMinutes } from "../hooks/use-stats";
 import { useTheme, type Palette } from "../lib/theme";
 import type { CalmMinutesProps } from "../navigation/types";
 
 // Business rule H1: the north-star KPI — minutes of calm earned, shown over the
-// last 7 days. Read-only reward that closes the evening check-in loop. A simple
-// View-based bar row keeps the bundle light (no charting library).
+// last 7 days. Read-only reward that closes the evening check-in loop. The API
+// only returns days that have an entry, so we scaffold a fixed 7-day window
+// (zeros included) to render a real weekly chart. View-based bars keep the
+// bundle light (no charting library).
 const WEEKDAY = ["D", "L", "M", "M", "J", "V", "S"];
+const BAR_MAX_HEIGHT = 104;
 
-const BAR_MAX_HEIGHT = 96;
+function pad(n: number) {
+  return String(n).padStart(2, "0");
+}
+
+type Day = {
+  date: string;
+  minutes: number;
+  weekday: string;
+  isToday: boolean;
+};
+
+// Fixed window of the last 7 calendar days ending today, filled from the
+// sparse API data.
+function last7Days(byDate: Map<string, number>): Day[] {
+  const today = new Date();
+  const out: Day[] = [];
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(
+      today.getFullYear(),
+      today.getMonth(),
+      today.getDate() - i,
+    );
+    const iso = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+    out.push({
+      date: iso,
+      minutes: byDate.get(iso) ?? 0,
+      weekday: WEEKDAY[d.getDay()] ?? "",
+      isToday: i === 0,
+    });
+  }
+  return out;
+}
 
 export function CalmMinutesScreen({ navigation, route }: CalmMinutesProps) {
   const { childId, childName } = route.params;
@@ -29,80 +65,122 @@ export function CalmMinutesScreen({ navigation, route }: CalmMinutesProps) {
   const goBack = () =>
     navigation.canGoBack() ? navigation.goBack() : navigation.navigate("Home");
 
-  return (
-    <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
-      <Pressable onPress={goBack} hitSlop={12}>
-        <Text style={styles.back}>‹ {childName}</Text>
-      </Pressable>
+  const days = useMemo(() => {
+    if (!data) return [];
+    const byDate = new Map(data.daily.map((d) => [d.date, d.minutes]));
+    return last7Days(byDate);
+  }, [data]);
 
-      <Text style={styles.title}>{copy.title}</Text>
+  const hasData = !!data && data.daysWithEntry > 0;
+  const cap = data?.dailyCapMinutes || 0;
+
+  return (
+    <Screen scroll>
+      <ScreenHeader
+        title={copy.title}
+        subtitle={childName}
+        onBack={goBack}
+      />
 
       {isLoading || !data ? (
-        <ActivityIndicator color={c.action} />
+        <Loader />
       ) : (
         <>
-          <Text style={styles.total}>{copy.total(data.totalMinutes)}</Text>
-          <Text style={styles.subtitle}>
-            {data.daysWithEntry > 0
-              ? copy.average(data.averagePerDay, data.daysWithEntry)
-              : copy.empty}
-          </Text>
+          <Card style={styles.hero}>
+            <View style={styles.headRow}>
+              <Leaf size={16} color={c.success} />
+              <Text style={styles.weekLabel}>{copy.weekLabel}</Text>
+            </View>
 
-          {data.daysWithEntry > 0 ? (
+            <Text style={styles.total}>{copy.total(data.totalMinutes)}</Text>
+            <Text style={styles.subtitle}>
+              {hasData
+                ? copy.average(data.averagePerDay, data.daysWithEntry)
+                : copy.empty}
+            </Text>
+
             <View style={styles.chart}>
-              {data.daily.map((d) => {
-                const ratio = data.dailyCapMinutes
-                  ? Math.min(d.minutes / data.dailyCapMinutes, 1)
-                  : 0;
-                const weekday = WEEKDAY[new Date(d.date).getDay()] ?? "";
+              {days.map((d) => {
+                const ratio = cap ? Math.min(d.minutes / cap, 1) : 0;
+                const height = d.minutes > 0 ? Math.max(ratio * BAR_MAX_HEIGHT, 6) : 0;
                 return (
                   <View key={d.date} style={styles.barColumn}>
+                    <Text style={styles.barValue}>
+                      {d.minutes > 0 ? d.minutes : ""}
+                    </Text>
                     <View style={styles.barTrack}>
-                      <View
-                        style={[
-                          styles.barFill,
-                          { height: Math.max(ratio * BAR_MAX_HEIGHT, 2) },
-                        ]}
-                      />
+                      {height > 0 ? (
+                        <View
+                          style={[
+                            styles.barFill,
+                            { height },
+                            d.isToday && styles.barFillToday,
+                          ]}
+                        />
+                      ) : null}
                     </View>
-                    <Text style={styles.barLabel}>{weekday}</Text>
+                    <Text
+                      style={[styles.barLabel, d.isToday && styles.barLabelToday]}
+                    >
+                      {d.weekday}
+                    </Text>
                   </View>
                 );
               })}
             </View>
-          ) : null}
+          </Card>
+
+          <CalloutCard
+            variant="success"
+            label={copy.explainTitle}
+            icon={<Leaf size={18} color={c.successFg} />}
+          >
+            <Text style={styles.explainBody}>{copy.explainBody}</Text>
+          </CalloutCard>
         </>
       )}
-    </SafeAreaView>
+    </Screen>
   );
 }
 
 const makeStyles = (c: Palette) =>
   StyleSheet.create({
-    container: { flex: 1, backgroundColor: c.bg, padding: 24, gap: 12 },
-    back: { color: c.brand, fontSize: 16 },
-    title: { fontSize: 22, fontWeight: "600", color: c.text },
+    hero: { gap: 4 },
+    headRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+    weekLabel: {
+      fontSize: 11,
+      letterSpacing: 0.8,
+      textTransform: "uppercase",
+      color: c.muted,
+      fontFamily: fonts.semibold,
+    },
     total: {
-      fontSize: 40,
-      fontWeight: "700",
+      fontSize: 44,
       color: c.success,
+      fontFamily: fonts.bold,
       fontVariant: ["tabular-nums"],
     },
-    subtitle: { fontSize: 14, color: c.muted },
+    subtitle: { fontSize: 14, color: c.muted, fontFamily: fonts.body },
     chart: {
       flexDirection: "row",
       justifyContent: "space-between",
       alignItems: "flex-end",
-      gap: 8,
+      gap: 6,
       marginTop: 16,
-      height: BAR_MAX_HEIGHT + 24,
     },
     barColumn: { flex: 1, alignItems: "center", gap: 6 },
+    barValue: {
+      fontSize: 11,
+      color: c.muted,
+      fontFamily: fonts.medium,
+      fontVariant: ["tabular-nums"],
+      minHeight: 14,
+    },
     barTrack: {
       width: "100%",
       height: BAR_MAX_HEIGHT,
       justifyContent: "flex-end",
-      backgroundColor: c.border,
+      backgroundColor: c.secondary,
       borderRadius: 8,
       overflow: "hidden",
     },
@@ -111,5 +189,13 @@ const makeStyles = (c: Palette) =>
       backgroundColor: c.successBorder,
       borderRadius: 8,
     },
-    barLabel: { fontSize: 12, color: c.chevron },
+    barFillToday: { backgroundColor: c.success },
+    barLabel: { fontSize: 12, color: c.muted, fontFamily: fonts.medium },
+    barLabelToday: { color: c.success, fontFamily: fonts.bold },
+    explainBody: {
+      fontSize: 14,
+      color: c.subtext,
+      fontFamily: fonts.body,
+      lineHeight: 20,
+    },
   });


### PR DESCRIPTION
## Problème
L'écran « Minutes de calme » (KPI nord H1) utilisait des composants bruts (vide, hors design system) et son mini-graphe ne traçait **qu'une seule barre** : l'API ne renvoie que les jours **ayant** un relevé, donc un seul check-in = une seule barre flottante avec un label « S » isolé.

## Correctif
- Passage au design kit : `Screen` + `ScreenHeader` + `Card` + `CalloutCard`.
- **Carte héro** : icône feuille + « 7 derniers jours », grand total, moyenne.
- **Graphe reconstruit sur une fenêtre fixe de 7 jours** (D→S), zéros inclus : les jours sans relevé affichent une piste vide, **aujourd'hui** est mis en évidence (vert vif + label en gras) et la valeur est affichée au-dessus de chaque barre non nulle.
- **Callout « Le calme, pas la performance »** : cadrage sans culpabilité (règle B7), qui remplit l'espace de façon utile.
- Tokens de thème (dark mode vérifié), typo de marque, copy française.

## Vérification
Typecheck OK. Build release + install : écran vérifié en dark mode — héro 15 min, graphe 7 jours avec aujourd'hui (S) en vert et « 15 » au-dessus, callout affiché.

🤖 Generated with [Claude Code](https://claude.com/claude-code)