### PR TITLE
feat(mobile): minuteur visuel (cadran, présets, démarrer/pause)

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -57,6 +57,7 @@ import { AddRoutineScreen } from "./src/screens/AddRoutineScreen";
 import { EditRoutineScreen } from "./src/screens/EditRoutineScreen";
 // Plus (grouped menu + every secondary screen)
 import { PlusMenuScreen } from "./src/screens/PlusMenuScreen";
+import { TimerScreen } from "./src/screens/TimerScreen";
 import { MedicationsScreen } from "./src/screens/MedicationsScreen";
 import { CalmMinutesScreen } from "./src/screens/CalmMinutesScreen";
 import { InsightsScreen } from "./src/screens/InsightsScreen";
@@ -130,6 +131,7 @@ function PlusNavigator() {
   return (
     <PlusStack.Navigator screenOptions={stackOptions}>
       <PlusStack.Screen name="PlusMenu" component={PlusMenuScreen} />
+      <PlusStack.Screen name="Timer" component={TimerScreen} />
       <PlusStack.Screen name="Medications" component={MedicationsScreen} />
       <PlusStack.Screen name="CalmMinutes" component={CalmMinutesScreen} />
       <PlusStack.Screen name="Insights" component={InsightsScreen} />

--- a/apps/mobile/src/lib/copy.ts
+++ b/apps/mobile/src/lib/copy.ts
@@ -2,6 +2,27 @@
 // (apps/web/src/lib/i18n/locales/fr.json → eveningCheck) so the mobile screen
 // keeps the exact guilt-free lexicon (business rule B7). Inlined rather than
 // pulling i18next into the mobile app for a single screen.
+// Mirrors fr.json → timer. The visual dial helps the child (and parent)
+// perceive time left for a task.
+export const timer = {
+  title: "Minuteur visuel",
+  subtitle:
+    "Un cadran qui se vide aide à percevoir le temps qui reste : devoirs, brossage de dents, jeu, transition.",
+  start: "Démarrer",
+  pause: "Pause",
+  resume: "Reprendre",
+  reset: "Réinitialiser",
+  finished: "Terminé !",
+  almostDone: "Bientôt fini, prépare-toi",
+  ready: "Prêt quand tu veux",
+  running: "C'est parti",
+  speedUpOff: "Mode rapide",
+  speedUpOn: "Mode rapide activé",
+  speedUpHint: "Pour les petits défis : ranger, s'habiller, brossage de dents.",
+  minutesLabel: (m: number) => `${m} min`,
+  secondsLabel: (s: number) => (s < 60 ? `${s} s` : `${s / 60} min`),
+} as const;
+
 export const eveningCheck = {
   title: "La soirée de ce soir ?",
   vibe_hard: "Difficile",

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -28,6 +28,7 @@ export type RootStackParamList = {
   Report: ChildParams;
   // Plus (grouped menu)
   PlusMenu: undefined;
+  Timer: undefined;
   Barkley: ChildParams;
   Rewards: ChildParams;
   Decodeur: ChildParams;
@@ -59,6 +60,7 @@ type S<T extends keyof RootStackParamList> = NativeStackScreenProps<
 
 export type HomeProps = S<"Home">;
 export type PlusMenuProps = S<"PlusMenu">;
+export type TimerProps = S<"Timer">;
 export type CheckinProps = S<"Checkin">;
 export type SymptomsProps = S<"Symptoms">;
 export type MedicationsProps = S<"Medications">;

--- a/apps/mobile/src/screens/PlusMenuScreen.tsx
+++ b/apps/mobile/src/screens/PlusMenuScreen.tsx
@@ -8,6 +8,7 @@ import {
   Brain,
   HandHeart,
   HeartPulse,
+  Leaf,
   Library,
   LogOut,
   MessageSquareText,
@@ -65,11 +66,12 @@ export function PlusMenuScreen({ navigation }: PlusMenuProps) {
       <MenuRow icon={ic(Book, c.brand)} label="Programme Barkley" onPress={go("Barkley")} />
       <MenuRow icon={ic(Brain, c.brand)} label="Décodeur" onPress={go("Decodeur")} />
       <MenuRow icon={ic(MessageSquareText, c.brand)} label="Scripts" onPress={go("Scripts")} />
+      <MenuRow icon={ic(Timer, c.brand)} label="Minuteur visuel" onPress={goPlain("Timer")} />
 
       <SectionLabel>Suivi</SectionLabel>
       <MenuRow icon={ic(Pill, c.brand)} label="Médicaments" onPress={go("Medications")} />
       <MenuRow icon={ic(Sparkles, c.brand)} label="Forces" onPress={go("Strengths")} />
-      <MenuRow icon={ic(Timer, c.brand)} label="Minutes calmes" onPress={go("CalmMinutes")} />
+      <MenuRow icon={ic(Leaf, c.brand)} label="Minutes calmes" onPress={go("CalmMinutes")} />
       <MenuRow icon={ic(TrendingUp, c.brand)} label="Insights" onPress={go("Insights")} />
       <MenuRow icon={ic(Activity, c.brand)} label="Activité" onPress={go("Activity")} />
       <MenuRow icon={ic(Book, c.brand)} label="Rapport" onPress={go("Report")} />

--- a/apps/mobile/src/screens/TimerScreen.tsx
+++ b/apps/mobile/src/screens/TimerScreen.tsx
@@ -1,0 +1,287 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Pressable, StyleSheet, Text, Vibration, View } from "react-native";
+import Svg, { Circle } from "react-native-svg";
+import { Pause, Play, RotateCcw, Zap } from "lucide-react-native";
+
+import { Button, Screen, ScreenHeader, fonts } from "../components/ui";
+import { timer as copy } from "../lib/copy";
+import { useTheme, type Palette } from "../lib/theme";
+
+// React Native port of the PWA visual timer (apps/web/src/components/timer).
+// Core parity: presets, a depleting dial, start/pause/reset, a "speed-up" mode
+// for short challenges, an "almost done" warning and a vibration on finish.
+// (Companion/critter gamification and routine sequence-chaining from the web
+// are tracked as follow-ups.)
+const PRESET_MINUTES = [2, 5, 10, 20, 45] as const;
+const PRESET_SPEEDUP_SECONDS = [30, 60, 120, 180] as const;
+const DEFAULT_SEC = 10 * 60;
+const ALMOST_DONE_SEC = 10;
+const VIBRATION_PATTERN = [0, 400, 200, 400, 200, 600];
+
+const DIAL_SIZE = 260;
+const STROKE = 18;
+const R = (DIAL_SIZE - STROKE) / 2;
+const C = 2 * Math.PI * R;
+
+function fmt(total: number): string {
+  const m = Math.floor(total / 60);
+  const s = total % 60;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+export function TimerScreen() {
+  const c = useTheme();
+  const styles = useMemo(() => makeStyles(c), [c]);
+
+  const [durationSec, setDurationSec] = useState(DEFAULT_SEC);
+  const [remainingSec, setRemainingSec] = useState(DEFAULT_SEC);
+  const [running, setRunning] = useState(false);
+  const [speedUp, setSpeedUp] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const clear = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clear, [clear]);
+
+  // The ticking loop. Re-created whenever `running` flips.
+  useEffect(() => {
+    if (!running) return;
+    intervalRef.current = setInterval(() => {
+      setRemainingSec((prev) => {
+        if (prev <= 1) {
+          clear();
+          setRunning(false);
+          Vibration.vibrate(VIBRATION_PATTERN);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return clear;
+  }, [running, clear]);
+
+  function selectDuration(sec: number) {
+    clear();
+    setRunning(false);
+    setDurationSec(sec);
+    setRemainingSec(sec);
+  }
+
+  function toggleSpeedUp() {
+    const next = !speedUp;
+    setSpeedUp(next);
+    const sec = next ? PRESET_SPEEDUP_SECONDS[1] : DEFAULT_SEC;
+    selectDuration(sec);
+  }
+
+  function toggleRun() {
+    if (remainingSec === 0) {
+      // Restart from the chosen duration.
+      setRemainingSec(durationSec);
+      setRunning(true);
+      return;
+    }
+    setRunning((r) => !r);
+  }
+
+  function reset() {
+    clear();
+    setRunning(false);
+    setRemainingSec(durationSec);
+  }
+
+  const finished = remainingSec === 0;
+  const almostDone = running && remainingSec > 0 && remainingSec <= ALMOST_DONE_SEC;
+  const progress = durationSec > 0 ? remainingSec / durationSec : 0;
+  const dashoffset = C * (1 - progress);
+
+  const dialColor = finished
+    ? c.success
+    : almostDone
+      ? c.danger
+      : c.brand;
+
+  const statusText = finished
+    ? copy.finished
+    : almostDone
+      ? copy.almostDone
+      : running
+        ? copy.running
+        : copy.ready;
+
+  const presets = speedUp ? PRESET_SPEEDUP_SECONDS : PRESET_MINUTES.map((m) => m * 60);
+
+  return (
+    <Screen scroll>
+      <ScreenHeader title={copy.title} />
+      <Text style={styles.subtitle}>{copy.subtitle}</Text>
+
+      {/* Presets */}
+      <View style={styles.presets}>
+        {presets.map((sec) => {
+          const on = durationSec === sec;
+          return (
+            <Pressable
+              key={sec}
+              onPress={() => selectDuration(sec)}
+              style={[styles.chip, on && styles.chipOn]}
+              accessibilityRole="button"
+              accessibilityState={{ selected: on }}
+            >
+              <Text style={[styles.chipText, on && styles.chipTextOn]}>
+                {speedUp ? copy.secondsLabel(sec) : copy.minutesLabel(sec / 60)}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {/* Dial */}
+      <View style={styles.dialWrap}>
+        <Svg width={DIAL_SIZE} height={DIAL_SIZE}>
+          <Circle
+            cx={DIAL_SIZE / 2}
+            cy={DIAL_SIZE / 2}
+            r={R}
+            stroke={c.secondary}
+            strokeWidth={STROKE}
+            fill="none"
+          />
+          <Circle
+            cx={DIAL_SIZE / 2}
+            cy={DIAL_SIZE / 2}
+            r={R}
+            stroke={dialColor}
+            strokeWidth={STROKE}
+            fill="none"
+            strokeLinecap="round"
+            strokeDasharray={`${C} ${C}`}
+            strokeDashoffset={dashoffset}
+            transform={`rotate(-90 ${DIAL_SIZE / 2} ${DIAL_SIZE / 2})`}
+          />
+        </Svg>
+        <View style={styles.dialCenter} pointerEvents="none">
+          <Text style={[styles.time, { color: dialColor }]}>
+            {fmt(remainingSec)}
+          </Text>
+          <Text style={styles.status}>{statusText}</Text>
+        </View>
+      </View>
+
+      {/* Controls */}
+      <Button
+        label={finished ? copy.start : running ? copy.pause : remainingSec < durationSec ? copy.resume : copy.start}
+        icon={
+          running ? (
+            <Pause size={20} color="#fff" fill="#fff" />
+          ) : (
+            <Play size={20} color="#fff" fill="#fff" />
+          )
+        }
+        onPress={toggleRun}
+      />
+      <Button
+        label={copy.reset}
+        variant="secondary"
+        icon={<RotateCcw size={18} color={c.text} />}
+        onPress={reset}
+      />
+
+      {/* Speed-up mode */}
+      <Pressable
+        onPress={toggleSpeedUp}
+        style={[styles.speedRow, speedUp && styles.speedRowOn]}
+        accessibilityRole="button"
+        accessibilityState={{ selected: speedUp }}
+      >
+        <Zap
+          size={16}
+          color={speedUp ? c.alertFg : c.muted}
+          fill={speedUp ? c.alertFg : "none"}
+        />
+        <Text style={[styles.speedText, speedUp && styles.speedTextOn]}>
+          {speedUp ? copy.speedUpOn : copy.speedUpOff}
+        </Text>
+      </Pressable>
+      {speedUp ? <Text style={styles.speedHint}>{copy.speedUpHint}</Text> : null}
+    </Screen>
+  );
+}
+
+const makeStyles = (c: Palette) =>
+  StyleSheet.create({
+    subtitle: {
+      fontSize: 14,
+      color: c.muted,
+      fontFamily: fonts.body,
+      lineHeight: 20,
+    },
+    presets: {
+      flexDirection: "row",
+      flexWrap: "wrap",
+      justifyContent: "center",
+      gap: 8,
+      marginTop: 4,
+    },
+    chip: {
+      paddingHorizontal: 16,
+      paddingVertical: 9,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.card,
+      minHeight: 40,
+      justifyContent: "center",
+    },
+    chipOn: { backgroundColor: c.brand, borderColor: c.brand },
+    chipText: { color: c.subtext, fontFamily: fonts.medium, fontSize: 14 },
+    chipTextOn: { color: "#fff", fontFamily: fonts.semibold },
+    dialWrap: {
+      alignItems: "center",
+      justifyContent: "center",
+      marginVertical: 12,
+      width: DIAL_SIZE,
+      height: DIAL_SIZE,
+      alignSelf: "center",
+    },
+    dialCenter: {
+      ...StyleSheet.absoluteFillObject,
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 4,
+    },
+    time: {
+      fontSize: 56,
+      fontFamily: fonts.bold,
+      fontVariant: ["tabular-nums"],
+    },
+    status: { fontSize: 14, color: c.muted, fontFamily: fonts.medium },
+    speedRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 8,
+      alignSelf: "center",
+      paddingHorizontal: 14,
+      paddingVertical: 8,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: c.border,
+      marginTop: 4,
+    },
+    speedRowOn: { backgroundColor: c.alertSurface, borderColor: c.alertBorder },
+    speedText: { fontSize: 13, color: c.muted, fontFamily: fonts.medium },
+    speedTextOn: { color: c.alertFg, fontFamily: fonts.semibold },
+    speedHint: {
+      fontSize: 12,
+      color: c.muted,
+      fontFamily: fonts.body,
+      textAlign: "center",
+      lineHeight: 17,
+    },
+  });


### PR DESCRIPTION
## Besoin
La PWA a un minuteur visuel complet (`/timer`) ; l'app mobile n'en avait **aucun** — l'utilisateur ne pouvait ni le lancer ni le mettre en pause.

## Ce que fait cette PR (cœur de parité)
- **Nouvel écran Minuteur** : cadran SVG qui se vide (`react-native-svg`), présets **2/5/10/20/45 min**, **Démarrer / Pause / Reprendre**, **Réinitialiser**.
- **Mode rapide** : présets en secondes (30/60/120/180) pour les petits défis (ranger, s'habiller…).
- **Alerte « bientôt fini »** (10 s, cadran rouge) + **vibration** à la fin.
- Entrée **« Minuteur visuel »** dans le menu Plus ; icône feuille pour « Minutes calmes » (cohérence).
- Design kit + tokens de thème (dark mode), copy française.

## À suivre (porté séparément)
Le « sequence runner » (chaîner les étapes minutées d'une routine + auto-cocher) et les **compagnons/critters** de la PWA — features L, dans la feuille de route de parité.

## Vérification
Typecheck OK, bundle JS généré sans erreur. ⚠️ Vérification sur appareil en attente (téléphone en veille au moment du build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)