### PR TITLE
feat(mobile): distinguish phone and e-mail reminder channels in settings

### DIFF
--- a/apps/mobile/src/hooks/use-phone-reminders.ts
+++ b/apps/mobile/src/hooks/use-phone-reminders.ts
@@ -1,0 +1,76 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Phone-channel opt-ins for the daily reminders. Stored *locally* (per device)
+ * rather than on the account: a "notification sur le téléphone" is a local
+ * OS-scheduled notification owned by this device, so its on/off state belongs
+ * with the device — unlike the e-mail reminders, whose opt-in lives in the
+ * account preferences and drives the server-side cron jobs.
+ */
+
+const STORAGE_KEY = "toko.notifications.phone";
+
+export type PhoneReminderPrefs = {
+  morningPhone: boolean;
+  eveningPhone: boolean;
+};
+
+// Evening defaults ON to preserve the historically always-scheduled evening
+// check-in (the decisive reason the app is native). Morning is a new, opt-in
+// capability so it starts OFF.
+export const PHONE_REMINDER_DEFAULTS: PhoneReminderPrefs = {
+  morningPhone: false,
+  eveningPhone: true,
+};
+
+/** Reads the stored phone-reminder opt-ins, falling back to the defaults. */
+export async function loadPhoneReminderPrefs(): Promise<PhoneReminderPrefs> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (!raw) return PHONE_REMINDER_DEFAULTS;
+    const parsed = JSON.parse(raw) as Partial<PhoneReminderPrefs>;
+    return {
+      morningPhone: parsed.morningPhone ?? PHONE_REMINDER_DEFAULTS.morningPhone,
+      eveningPhone: parsed.eveningPhone ?? PHONE_REMINDER_DEFAULTS.eveningPhone,
+    };
+  } catch {
+    // Corrupt/unavailable storage — fall back to defaults, nothing is lost.
+    return PHONE_REMINDER_DEFAULTS;
+  }
+}
+
+/** Stateful access to the phone-reminder opt-ins, persisted in AsyncStorage. */
+export function usePhoneReminderPrefs() {
+  const [prefs, setPrefs] = useState<PhoneReminderPrefs>(
+    PHONE_REMINDER_DEFAULTS,
+  );
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadPhoneReminderPrefs().then((p) => {
+      if (cancelled) return;
+      setPrefs(p);
+      setLoaded(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const update = useCallback((patch: Partial<PhoneReminderPrefs>) => {
+    setPrefs((prev) => {
+      const next = { ...prev, ...patch };
+      void AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next)).catch(
+        () => {
+          // Fail silent — the toggle still applies for this session and the
+          // OS schedule is reconciled regardless.
+        },
+      );
+      return next;
+    });
+  }, []);
+
+  return { prefs, loaded, update };
+}

--- a/apps/mobile/src/lib/notifications.ts
+++ b/apps/mobile/src/lib/notifications.ts
@@ -8,10 +8,21 @@ import { Platform } from "react-native";
  * rather than a TWA: a *scheduled, time-sensitive* notification that must fire
  * reliably even when the app is closed. PWAs cannot guarantee this; the OS can.
  * See docs/android-app.md.
+ *
+ * These are *phone* notifications (local, scheduled by the OS on this device).
+ * They are the counterpart of the *e-mail* reminders sent server-side by the
+ * cron jobs — the Réglages screen lets the parent choose either channel, or
+ * both, per reminder. Phone opt-in is stored locally (per device) because the
+ * schedule lives on the device; e-mail opt-in lives in the account
+ * preferences. The reminder times are shared so both channels fire together.
  */
 
-const EVENING_CHECKIN_ID = "evening-checkin";
+const MORNING_ID = "morning-reminder";
+// Historical identifier — kept so existing installs replace, not duplicate.
+const EVENING_ID = "evening-checkin";
 const ANDROID_CHANNEL_ID = "checkin-reminders";
+
+const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
 
 Notifications.setNotificationHandler({
   handleNotification: async () => ({
@@ -22,13 +33,20 @@ Notifications.setNotificationHandler({
   }),
 });
 
+/** Parses an "HH:mm" string into { hour, minute }, or null when malformed. */
+function parseHhmm(time: string): { hour: number; minute: number } | null {
+  if (!TIME_REGEX.test(time)) return null;
+  const [hour, minute] = time.split(":").map((n) => Number.parseInt(n, 10));
+  return { hour: hour!, minute: minute! };
+}
+
 /** Requests OS permission + sets up the Android notification channel. */
 export async function ensureNotificationPermissions(): Promise<boolean> {
   if (!Device.isDevice) return false;
 
   if (Platform.OS === "android") {
     await Notifications.setNotificationChannelAsync(ANDROID_CHANNEL_ID, {
-      name: "Rappels du soir",
+      name: "Rappels",
       importance: Notifications.AndroidImportance.HIGH,
       enableVibrate: true,
     });
@@ -41,20 +59,69 @@ export async function ensureNotificationPermissions(): Promise<boolean> {
   return status === "granted";
 }
 
-/**
- * Schedules (or replaces) the daily evening check-in reminder. Defaults to
- * 18h30, inside the 16h30–21h00 window from the offline-strategy business rule.
- */
-export async function scheduleEveningCheckin(hour = 18, minute = 30): Promise<void> {
+/** Current OS permission status, used to surface a hint in the settings UI. */
+export async function getNotificationPermissionStatus(): Promise<
+  "granted" | "denied" | "undetermined" | "unsupported"
+> {
+  if (!Device.isDevice) return "unsupported";
+  const { status } = await Notifications.getPermissionsAsync();
+  if (status === "granted") return "granted";
+  if (status === "denied") return "denied";
+  return "undetermined";
+}
+
+/** Schedules (or replaces) the daily morning reminder. Defaults to 09h00. */
+export async function scheduleMorningReminder(
+  hour = 9,
+  minute = 0,
+): Promise<void> {
   const granted = await ensureNotificationPermissions();
   if (!granted) return;
 
-  await Notifications.cancelScheduledNotificationAsync(EVENING_CHECKIN_ID).catch(
+  await Notifications.cancelScheduledNotificationAsync(MORNING_ID).catch(
     () => undefined,
   );
 
   await Notifications.scheduleNotificationAsync({
-    identifier: EVENING_CHECKIN_ID,
+    identifier: MORNING_ID,
+    content: {
+      title: "Un nouveau jour commence",
+      body: "Prends un petit moment pour démarrer la journée avec ton enfant.",
+      data: { url: Linking.createURL("home") },
+    },
+    trigger: {
+      type: Notifications.SchedulableTriggerInputTypes.DAILY,
+      hour,
+      minute,
+      channelId: ANDROID_CHANNEL_ID,
+    },
+  });
+}
+
+/** Cancels the morning reminder. */
+export async function cancelMorningReminder(): Promise<void> {
+  await Notifications.cancelScheduledNotificationAsync(MORNING_ID).catch(
+    () => undefined,
+  );
+}
+
+/**
+ * Schedules (or replaces) the daily evening check-in reminder. Defaults to
+ * 20h30, inside the 16h30–21h00 window from the offline-strategy business rule.
+ */
+export async function scheduleEveningReminder(
+  hour = 20,
+  minute = 30,
+): Promise<void> {
+  const granted = await ensureNotificationPermissions();
+  if (!granted) return;
+
+  await Notifications.cancelScheduledNotificationAsync(EVENING_ID).catch(
+    () => undefined,
+  );
+
+  await Notifications.scheduleNotificationAsync({
+    identifier: EVENING_ID,
     content: {
       title: "C'est l'heure du point du soir",
       body: "Prends un instant pour noter la journée.",
@@ -72,8 +139,34 @@ export async function scheduleEveningCheckin(hour = 18, minute = 30): Promise<vo
 }
 
 /** Cancels the evening reminder. */
-export async function cancelEveningCheckin(): Promise<void> {
-  await Notifications.cancelScheduledNotificationAsync(EVENING_CHECKIN_ID).catch(
+export async function cancelEveningReminder(): Promise<void> {
+  await Notifications.cancelScheduledNotificationAsync(EVENING_ID).catch(
     () => undefined,
   );
+}
+
+/**
+ * Brings the OS-scheduled phone reminders in line with the parent's choices:
+ * enables/schedules the ones turned on (at their configured time) and cancels
+ * the rest. Idempotent — safe to call on every launch and on every settings
+ * change. A malformed time leaves that reminder untouched-but-cancelled rather
+ * than throwing.
+ */
+export async function reconcileLocalReminders(opts: {
+  morning: { enabled: boolean; time: string };
+  evening: { enabled: boolean; time: string };
+}): Promise<void> {
+  const morning = parseHhmm(opts.morning.time);
+  if (opts.morning.enabled && morning) {
+    await scheduleMorningReminder(morning.hour, morning.minute);
+  } else {
+    await cancelMorningReminder();
+  }
+
+  const evening = parseHhmm(opts.evening.time);
+  if (opts.evening.enabled && evening) {
+    await scheduleEveningReminder(evening.hour, evening.minute);
+  } else {
+    await cancelEveningReminder();
+  }
 }

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -14,7 +14,9 @@ import {
 import { useTheme, type Palette } from "../lib/theme";
 import { useActiveChild } from "../lib/active-child";
 import { authClient } from "../lib/auth";
-import { scheduleEveningCheckin } from "../lib/notifications";
+import { reconcileLocalReminders } from "../lib/notifications";
+import { loadPhoneReminderPrefs } from "../hooks/use-phone-reminders";
+import { usePreferences } from "../hooks/use-preferences";
 import { useInsights } from "../hooks/use-insights";
 import { useCalmMinutes } from "../hooks/use-stats";
 import { useParentMood, useUpsertParentMood } from "../hooks/use-parent-mood";
@@ -62,10 +64,26 @@ export function HomeScreen({ navigation }: HomeProps) {
   const { active, isLoading } = useActiveChild();
   const { data: session } = authClient.useSession();
   const hour = new Date().getHours();
+  const prefs = usePreferences();
 
+  // Keep the OS-scheduled phone reminders fresh on every launch, honouring the
+  // device's phone opt-ins and the account's reminder times. Idempotent — the
+  // Réglages screen reconciles the same way on change.
   useEffect(() => {
-    void scheduleEveningCheckin();
-  }, []);
+    if (!prefs.data) return;
+    const { morningReminderTime, eveningReminderTime } = prefs.data;
+    let cancelled = false;
+    void loadPhoneReminderPrefs().then((phone) => {
+      if (cancelled) return;
+      void reconcileLocalReminders({
+        morning: { enabled: phone.morningPhone, time: morningReminderTime },
+        evening: { enabled: phone.eveningPhone, time: eveningReminderTime },
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [prefs.data]);
 
   const childId = active?.id ?? "";
   const insights = useInsights(childId, "week");

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { StyleSheet, Switch, Text, TextInput, View } from "react-native";
+import { Mail, Smartphone } from "lucide-react-native";
 
 import {
   Card,
@@ -13,6 +14,11 @@ import {
   usePreferences,
   useUpdatePreferences,
 } from "../hooks/use-preferences";
+import { usePhoneReminderPrefs } from "../hooks/use-phone-reminders";
+import {
+  getNotificationPermissionStatus,
+  reconcileLocalReminders,
+} from "../lib/notifications";
 import type { SettingsProps } from "../navigation/types";
 
 const TIME_REGEX = /^([01]\d|2[0-3]):[0-5]\d$/;
@@ -23,10 +29,16 @@ export function SettingsScreen({ navigation }: SettingsProps) {
 
   const prefs = usePreferences();
   const update = useUpdatePreferences();
+  const phone = usePhoneReminderPrefs();
 
   // Local state for time fields (committed on blur)
   const [morningTime, setMorningTime] = useState("09:00");
   const [eveningTime, setEveningTime] = useState("20:30");
+  // OS permission status — drives the "activez les notifications" hint when a
+  // phone reminder is on but the system permission is denied.
+  const [permission, setPermission] = useState<
+    "granted" | "denied" | "undetermined" | "unsupported" | null
+  >(null);
 
   useEffect(() => {
     if (prefs.data) {
@@ -34,6 +46,45 @@ export function SettingsScreen({ navigation }: SettingsProps) {
       setEveningTime(prefs.data.eveningReminderTime);
     }
   }, [prefs.data]);
+
+  useEffect(() => {
+    void getNotificationPermissionStatus().then(setPermission);
+  }, []);
+
+  // Re-aligns the OS-scheduled phone notifications after a toggle or time
+  // change. Optional overrides let callers reschedule with a value that is
+  // committed in the same tick (before React state has flushed).
+  const reschedule = (
+    overrides: {
+      morningPhone?: boolean;
+      eveningPhone?: boolean;
+      morning?: string;
+      evening?: string;
+    } = {},
+  ) => {
+    void reconcileLocalReminders({
+      morning: {
+        enabled: overrides.morningPhone ?? phone.prefs.morningPhone,
+        time: overrides.morning ?? morningTime,
+      },
+      evening: {
+        enabled: overrides.eveningPhone ?? phone.prefs.eveningPhone,
+        time: overrides.evening ?? eveningTime,
+      },
+    });
+  };
+
+  const toggleMorningPhone = (v: boolean) => {
+    phone.update({ morningPhone: v });
+    reschedule({ morningPhone: v });
+    if (v) void getNotificationPermissionStatus().then(setPermission);
+  };
+
+  const toggleEveningPhone = (v: boolean) => {
+    phone.update({ eveningPhone: v });
+    reschedule({ eveningPhone: v });
+    if (v) void getNotificationPermissionStatus().then(setPermission);
+  };
 
   const commitMorningTime = () => {
     if (!prefs.data) return;
@@ -45,6 +96,7 @@ export function SettingsScreen({ navigation }: SettingsProps) {
       return;
     }
     update.mutate({ morningReminderTime: morningTime });
+    reschedule({ morning: morningTime });
   };
 
   const commitEveningTime = () => {
@@ -57,14 +109,15 @@ export function SettingsScreen({ navigation }: SettingsProps) {
       return;
     }
     update.mutate({ eveningReminderTime: eveningTime });
+    reschedule({ evening: eveningTime });
   };
+
+  const anyPhoneOn = phone.prefs.morningPhone || phone.prefs.eveningPhone;
+  const showPermissionHint = anyPhoneOn && permission === "denied";
 
   return (
     <Screen scroll>
-      <ScreenHeader
-        title="Réglages"
-        onBack={() => navigation.goBack()}
-      />
+      <ScreenHeader title="Réglages" onBack={() => navigation.goBack()} />
 
       {prefs.isLoading ? (
         <Loader />
@@ -72,24 +125,48 @@ export function SettingsScreen({ navigation }: SettingsProps) {
         <ErrorNote message="Impossible de charger vos réglages." />
       ) : prefs.data ? (
         <>
+          <Text style={styles.intro}>
+            Choisissez comment être prévenu pour chaque rappel : sur le
+            téléphone (une notification sur cet appareil) ou par e-mail.
+          </Text>
+
+          {showPermissionHint ? (
+            <Text style={styles.permissionHint}>
+              Les notifications sont désactivées pour Tokō. Activez-les dans les
+              réglages de votre téléphone pour recevoir les rappels.
+            </Text>
+          ) : null}
+
           {/* Rappel du matin */}
           <Card>
             <Text style={styles.sectionTitle}>Rappel du matin</Text>
             <Text style={styles.hint}>
               Un petit rappel pour démarrer la journée avec votre enfant.
             </Text>
-            <View style={styles.row}>
-              <Text style={styles.label}>Activer</Text>
-              <Switch
-                value={prefs.data.dailyReminderOptIn}
-                onValueChange={(v) => update.mutate({ dailyReminderOptIn: v })}
-                trackColor={{ false: c.border, true: c.brand }}
-                thumbColor="#fff"
-                disabled={update.isPending}
-              />
-            </View>
-            {prefs.data.dailyReminderOptIn && (
-              <View style={styles.row}>
+
+            <ChannelRow
+              styles={styles}
+              c={c}
+              icon={<Smartphone size={18} color={c.muted} />}
+              label="Sur le téléphone"
+              sublabel="Notification sur cet appareil"
+              value={phone.prefs.morningPhone}
+              onValueChange={toggleMorningPhone}
+              disabled={!phone.loaded}
+            />
+            <ChannelRow
+              styles={styles}
+              c={c}
+              icon={<Mail size={18} color={c.muted} />}
+              label="Par e-mail"
+              sublabel="Dans votre boîte mail"
+              value={prefs.data.dailyReminderOptIn}
+              onValueChange={(v) => update.mutate({ dailyReminderOptIn: v })}
+              disabled={update.isPending}
+            />
+
+            {(phone.prefs.morningPhone || prefs.data.dailyReminderOptIn) && (
+              <View style={styles.timeRow}>
                 <Text style={styles.label}>Heure</Text>
                 <TextInput
                   style={styles.timeInput}
@@ -111,18 +188,30 @@ export function SettingsScreen({ navigation }: SettingsProps) {
             <Text style={styles.hint}>
               Pour faire le point en fin de journée.
             </Text>
-            <View style={styles.row}>
-              <Text style={styles.label}>Activer</Text>
-              <Switch
-                value={prefs.data.eveningReminderOptIn}
-                onValueChange={(v) => update.mutate({ eveningReminderOptIn: v })}
-                trackColor={{ false: c.border, true: c.brand }}
-                thumbColor="#fff"
-                disabled={update.isPending}
-              />
-            </View>
-            {prefs.data.eveningReminderOptIn && (
-              <View style={styles.row}>
+
+            <ChannelRow
+              styles={styles}
+              c={c}
+              icon={<Smartphone size={18} color={c.muted} />}
+              label="Sur le téléphone"
+              sublabel="Notification sur cet appareil"
+              value={phone.prefs.eveningPhone}
+              onValueChange={toggleEveningPhone}
+              disabled={!phone.loaded}
+            />
+            <ChannelRow
+              styles={styles}
+              c={c}
+              icon={<Mail size={18} color={c.muted} />}
+              label="Par e-mail"
+              sublabel="Dans votre boîte mail"
+              value={prefs.data.eveningReminderOptIn}
+              onValueChange={(v) => update.mutate({ eveningReminderOptIn: v })}
+              disabled={update.isPending}
+            />
+
+            {(phone.prefs.eveningPhone || prefs.data.eveningReminderOptIn) && (
+              <View style={styles.timeRow}>
                 <Text style={styles.label}>Heure</Text>
                 <TextInput
                   style={styles.timeInput}
@@ -138,22 +227,22 @@ export function SettingsScreen({ navigation }: SettingsProps) {
             )}
           </Card>
 
-          {/* Résumé hebdomadaire */}
+          {/* Résumé hebdomadaire — e-mail uniquement par nature */}
           <Card>
             <Text style={styles.sectionTitle}>Résumé de la semaine</Text>
             <Text style={styles.hint}>
               Un récapitulatif par e-mail chaque semaine.
             </Text>
-            <View style={styles.row}>
-              <Text style={styles.label}>Activer</Text>
-              <Switch
-                value={prefs.data.weeklyDigestOptIn}
-                onValueChange={(v) => update.mutate({ weeklyDigestOptIn: v })}
-                trackColor={{ false: c.border, true: c.brand }}
-                thumbColor="#fff"
-                disabled={update.isPending}
-              />
-            </View>
+            <ChannelRow
+              styles={styles}
+              c={c}
+              icon={<Mail size={18} color={c.muted} />}
+              label="Par e-mail"
+              sublabel="Dans votre boîte mail"
+              value={prefs.data.weeklyDigestOptIn}
+              onValueChange={(v) => update.mutate({ weeklyDigestOptIn: v })}
+              disabled={update.isPending}
+            />
           </Card>
 
           {update.isError ? (
@@ -165,8 +254,60 @@ export function SettingsScreen({ navigation }: SettingsProps) {
   );
 }
 
+function ChannelRow({
+  styles,
+  c,
+  icon,
+  label,
+  sublabel,
+  value,
+  onValueChange,
+  disabled,
+}: {
+  styles: ReturnType<typeof makeStyles>;
+  c: Palette;
+  icon: ReactNode;
+  label: string;
+  sublabel: string;
+  value: boolean;
+  onValueChange: (v: boolean) => void;
+  disabled?: boolean;
+}) {
+  return (
+    <View style={styles.channelRow}>
+      <View style={styles.channelIcon}>{icon}</View>
+      <View style={styles.channelText}>
+        <Text style={styles.channelLabel}>{label}</Text>
+        <Text style={styles.channelSublabel}>{sublabel}</Text>
+      </View>
+      <Switch
+        value={value}
+        onValueChange={onValueChange}
+        trackColor={{ false: c.border, true: c.brand }}
+        thumbColor="#fff"
+        disabled={disabled}
+      />
+    </View>
+  );
+}
+
 const makeStyles = (c: Palette) =>
   StyleSheet.create({
+    intro: {
+      fontSize: 14,
+      color: c.muted,
+      lineHeight: 20,
+    },
+    permissionHint: {
+      fontSize: 13,
+      color: c.alertFg,
+      backgroundColor: c.alertSurface,
+      borderColor: c.alertBorder,
+      borderWidth: 1,
+      borderRadius: 12,
+      padding: 12,
+      lineHeight: 18,
+    },
     sectionTitle: {
       fontSize: 16,
       fontWeight: "600",
@@ -176,11 +317,43 @@ const makeStyles = (c: Palette) =>
       fontSize: 13,
       color: c.muted,
     },
-    row: {
+    channelRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      gap: 12,
+      paddingTop: 8,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: c.border,
+      marginTop: 4,
+    },
+    channelIcon: {
+      width: 34,
+      height: 34,
+      borderRadius: 10,
+      backgroundColor: c.bg,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    channelText: {
+      flex: 1,
+    },
+    channelLabel: {
+      fontSize: 15,
+      color: c.text,
+    },
+    channelSublabel: {
+      fontSize: 12,
+      color: c.muted,
+      marginTop: 1,
+    },
+    timeRow: {
       flexDirection: "row",
       alignItems: "center",
       justifyContent: "space-between",
-      paddingTop: 4,
+      paddingTop: 10,
+      marginTop: 6,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: c.border,
     },
     label: {
       fontSize: 15,


### PR DESCRIPTION
## Pourquoi

Sur l'application Android, la page **Réglages** ne proposait qu'un seul interrupteur « Activer » par rappel, sans dire **par quel canal** le parent serait prévenu. Or l'app a deux canaux distincts :

- **Sur le téléphone** : une notification locale planifiée par l'OS sur cet appareil (le facteur décisif qui rend l'app native, cf. `docs/android-app.md`).
- **Par e-mail** : envoyée côté serveur par les tâches cron.

Cette PR rend la page plus complète et **fait clairement la différence entre les deux canaux**.

## Ce qui change

Page **Réglages** (`SettingsScreen`) :
- Chaque rappel quotidien (**matin**, **soir**) propose désormais deux canaux séparés :
  - **Sur le téléphone** — « Notification sur cet appareil »
  - **Par e-mail** — « Dans votre boîte mail »
- Le **Résumé de la semaine** reste **e-mail uniquement** (par nature).
- Une courte intro explique la différence, et un message d'aide apparaît si les notifications système sont refusées alors qu'un rappel téléphone est activé.
- L'heure d'un rappel est partagée par les deux canaux (téléphone + e-mail déclenchés ensemble).

Sous le capot :
- L'opt-in **téléphone** est stocké **par appareil** (`AsyncStorage`, nouveau hook `usePhoneReminderPrefs`), car une notification locale appartient à l'appareil — contrairement à l'opt-in **e-mail** qui vit dans les préférences du compte.
- `notifications.ts` gère maintenant un rappel **matin** + **soir** configurables, avec un `reconcileLocalReminders` idempotent appelé à chaque changement de réglage **et** au lancement (`HomeScreen`).
- Le rappel du soir téléphone **reste activé par défaut** (préserve le check-in du soir historiquement toujours planifié) ; le rappel du matin est nouveau et **opt-in**.
- Le rappel téléphone du soir suit désormais l'heure configurée (`eveningReminderTime`) au lieu d'un 18h30 codé en dur, cohérent avec l'e-mail.

## Notes

- Aucun changement backend / base de données : les canaux e-mail réutilisent les préférences existantes, le canal téléphone est local.
- Tout le texte est en français, conforme aux principes UI (charge cognitive minimale, libellés explicites).
- `tsc --noEmit` ne remonte aucune erreur sur les fichiers modifiés (les erreurs préexistantes `JournalScreen`/`SymptomsScreen` et la résolution de `zod` dans l'install isolée du mobile sont indépendantes de cette PR).

https://claude.ai/code/session_01DFLV3nJ2d5LQMpksju1Ys6

---
_Generated by [Claude Code](https://claude.ai/code/session_01DFLV3nJ2d5LQMpksju1Ys6)_