### PR TITLE
feat(mobile): tableau de bord interactif + réglages (co-parent, export, suppression)

### DIFF
--- a/apps/mobile/src/components/home-widgets.tsx
+++ b/apps/mobile/src/components/home-widgets.tsx
@@ -1,0 +1,145 @@
+import { useMemo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Check } from "lucide-react-native";
+
+import { Card, SectionLabel, fonts } from "./ui";
+import { home as copy } from "../lib/copy";
+import { todayISO } from "../lib/date";
+import { useTheme, type Palette } from "../lib/theme";
+import { useMedicationAdherence, useLogMedication } from "../hooks/use-medications";
+import { useSymptoms } from "../hooks/use-symptoms";
+import { useJournal } from "../hooks/use-journal";
+
+// 1-tap medication log for today, mirroring the PWA MedicationQuickLog. Only
+// renders when the child has at least one treatment.
+export function MedicationQuickLog({ childId }: { childId: string }) {
+  const c = useTheme();
+  const s = useMemo(() => makeStyles(c), [c]);
+  const { data } = useMedicationAdherence(childId);
+  const log = useLogMedication(childId);
+  const today = todayISO();
+
+  const meds = data?.medications ?? [];
+  if (meds.length === 0) return null;
+
+  function set(medicationId: string, taken: boolean) {
+    log.mutate({ medicationId, date: today, taken });
+  }
+
+  return (
+    <View style={s.block}>
+      <SectionLabel>{copy.medsTitle}</SectionLabel>
+      {meds.map((m) => (
+        <Card key={m.id} style={s.row}>
+          <View style={s.info}>
+            <Text style={s.name}>{m.name}</Text>
+            {m.adherenceRate != null ? (
+              <Text style={s.meta}>{copy.adherence(m.adherenceRate)}</Text>
+            ) : null}
+          </View>
+          <View style={s.actions}>
+            <Pressable
+              onPress={() => set(m.id, true)}
+              style={[s.btn, m.todayTaken === true && s.btnTaken]}
+              accessibilityRole="button"
+              accessibilityLabel={`${m.name} ${copy.taken}`}
+            >
+              <Text style={[s.btnText, m.todayTaken === true && s.btnTextOn]}>
+                {copy.taken}
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={() => set(m.id, false)}
+              style={[s.btn, m.todayTaken === false && s.btnMissed]}
+              accessibilityRole="button"
+              accessibilityLabel={`${m.name} ${copy.missed}`}
+            >
+              <Text style={[s.btnText, m.todayTaken === false && s.btnTextOn]}>
+                {copy.missed}
+              </Text>
+            </Pressable>
+          </View>
+        </Card>
+      ))}
+    </View>
+  );
+}
+
+// Live "done today" checklist, mirroring the PWA DailyChecklist: evening logged,
+// journal written, medications all taken (the meds line only if any exist).
+export function DailyChecklist({ childId }: { childId: string }) {
+  const c = useTheme();
+  const s = useMemo(() => makeStyles(c), [c]);
+  const today = todayISO();
+
+  const symptoms = useSymptoms(childId);
+  const journal = useJournal(childId);
+  const adherence = useMedicationAdherence(childId);
+
+  const eveningDone = (symptoms.data ?? []).some((e) => e.date === today);
+  const journalDone = (journal.data ?? []).some((e) => e.date === today);
+  const meds = adherence.data?.medications ?? [];
+  const hasMeds = meds.length > 0;
+  const medsDone = hasMeds && meds.every((m) => m.todayTaken === true);
+
+  const items = [
+    { key: "evening", label: copy.checkEvening, done: eveningDone },
+    { key: "journal", label: copy.checkJournal, done: journalDone },
+    ...(hasMeds ? [{ key: "meds", label: copy.checkMeds, done: medsDone }] : []),
+  ];
+  const allDone = items.every((i) => i.done);
+
+  return (
+    <Card style={s.checklist}>
+      <Text style={s.checklistTitle}>{copy.checklistTitle}</Text>
+      {items.map((i) => (
+        <View key={i.key} style={s.checkRow}>
+          <View style={[s.tick, i.done && s.tickOn]}>
+            {i.done ? <Check size={14} color="#fff" /> : null}
+          </View>
+          <Text style={[s.checkLabel, i.done && s.checkLabelDone]}>{i.label}</Text>
+        </View>
+      ))}
+      {allDone ? <Text style={s.allDone}>{copy.checklistDone}</Text> : null}
+    </Card>
+  );
+}
+
+const makeStyles = (c: Palette) =>
+  StyleSheet.create({
+    block: { gap: 8 },
+    row: { flexDirection: "row", alignItems: "center", gap: 12 },
+    info: { flex: 1 },
+    name: { fontSize: 15, color: c.text, fontFamily: fonts.semibold },
+    meta: { fontSize: 12, color: c.muted, fontFamily: fonts.body, marginTop: 2 },
+    actions: { flexDirection: "row", gap: 8 },
+    btn: {
+      paddingHorizontal: 14,
+      paddingVertical: 8,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: c.border,
+      minWidth: 64,
+      alignItems: "center",
+    },
+    btnTaken: { backgroundColor: c.success, borderColor: c.success },
+    btnMissed: { backgroundColor: c.danger, borderColor: c.danger },
+    btnText: { fontSize: 13, color: c.subtext, fontFamily: fonts.semibold },
+    btnTextOn: { color: "#fff" },
+    checklist: { gap: 10 },
+    checklistTitle: { fontSize: 16, color: c.text, fontFamily: fonts.semibold },
+    checkRow: { flexDirection: "row", alignItems: "center", gap: 10 },
+    tick: {
+      width: 22,
+      height: 22,
+      borderRadius: 11,
+      borderWidth: 2,
+      borderColor: c.border,
+      alignItems: "center",
+      justifyContent: "center",
+    },
+    tickOn: { backgroundColor: c.success, borderColor: c.success },
+    checkLabel: { fontSize: 15, color: c.text, fontFamily: fonts.body },
+    checkLabelDone: { color: c.muted },
+    allDone: { fontSize: 13, color: c.success, fontFamily: fonts.medium },
+  });

--- a/apps/mobile/src/hooks/use-account.ts
+++ b/apps/mobile/src/hooks/use-account.ts
@@ -1,0 +1,21 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { api } from "../lib/api";
+
+// Mirrors apps/web/src/hooks/use-account.ts (export + delete). RGPD data export
+// and account deletion, both sensitive and rate-limited server-side.
+
+/** Full personal data export (RGPD Art. 20). Returns the JSON payload. */
+export function useExportAccount() {
+  return useMutation({
+    mutationFn: () => api.get<Record<string, unknown>>("/account/export"),
+  });
+}
+
+/** Permanently delete the account (cancels Stripe + cascade deletes data). */
+export function useDeleteAccount() {
+  return useMutation({
+    mutationFn: () =>
+      api.delete<{ ok: boolean }>("/account", { confirmation: "DELETE" }),
+  });
+}

--- a/apps/mobile/src/hooks/use-medications.ts
+++ b/apps/mobile/src/hooks/use-medications.ts
@@ -1,6 +1,8 @@
 import type {
   CreateMedication,
+  CreateMedicationLog,
   Medication,
+  MedicationLog,
   UpdateMedication,
 } from "@focusflow/validators";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -10,6 +12,43 @@ import { api } from "../lib/api";
 // Mirrors apps/web/src/hooks/use-medications.ts: list a child's treatments and
 // add / edit / remove them. Authoring is allowed on mobile (simple CRUD).
 const key = (childId: string) => ["medications", childId] as const;
+const adherenceKey = (childId: string) =>
+  ["medications", childId, "adherence"] as const;
+
+export interface MedicationAdherence {
+  id: string;
+  name: string;
+  dose: string | null;
+  schedule: string;
+  adherenceRate: number | null;
+  takenCount: number;
+  loggedCount: number;
+  todayTaken: boolean | null;
+}
+
+/** Today's status + adherence rate per treatment (last 30 days). */
+export function useMedicationAdherence(childId: string) {
+  return useQuery({
+    queryKey: adherenceKey(childId),
+    queryFn: () =>
+      api.get<{ medications: MedicationAdherence[] }>(
+        `/medications/${childId}/adherence`,
+      ),
+    enabled: !!childId,
+    staleTime: 60_000,
+  });
+}
+
+/** Log a medication as taken / missed for a date (1-tap from the dashboard). */
+export function useLogMedication(childId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateMedicationLog) =>
+      api.post<MedicationLog>("/medications/logs", data),
+    onSettled: () =>
+      qc.invalidateQueries({ queryKey: adherenceKey(childId) }),
+  });
+}
 
 export function useMedications(childId: string) {
   return useQuery({

--- a/apps/mobile/src/lib/api.ts
+++ b/apps/mobile/src/lib/api.ts
@@ -52,7 +52,11 @@ export const api = {
       method: "PATCH",
       body: data === undefined ? undefined : JSON.stringify(data),
     }),
-  delete: <T>(path: string) => request<T>(path, { method: "DELETE" }),
+  delete: <T>(path: string, data?: unknown) =>
+    request<T>(path, {
+      method: "DELETE",
+      body: data === undefined ? undefined : JSON.stringify(data),
+    }),
 };
 
 /** Subscription/entitlement status — drives premium unlock (no Play Billing). */

--- a/apps/mobile/src/lib/copy.ts
+++ b/apps/mobile/src/lib/copy.ts
@@ -2,6 +2,19 @@
 // (apps/web/src/lib/i18n/locales/fr.json → eveningCheck) so the mobile screen
 // keeps the exact guilt-free lexicon (business rule B7). Inlined rather than
 // pulling i18next into the mobile app for a single screen.
+// Copy for the dashboard interactive widgets (medication quick-log, checklist).
+export const home = {
+  medsTitle: "Médicaments du jour",
+  taken: "Pris",
+  missed: "Sauté",
+  adherence: (pct: number) => `${pct}% sur 30 j`,
+  checklistTitle: "Aujourd'hui",
+  checkEvening: "Soirée notée",
+  checkJournal: "Journal écrit",
+  checkMeds: "Médicaments pris",
+  checklistDone: "Tout est fait pour aujourd'hui 🎉",
+} as const;
+
 // Copy for the Barkley parent-training formation (10 steps + quiz).
 export const barkley = {
   title: "Programme Barkley",

--- a/apps/mobile/src/screens/HomeScreen.tsx
+++ b/apps/mobile/src/screens/HomeScreen.tsx
@@ -17,6 +17,7 @@ import { authClient } from "../lib/auth";
 import { reconcileLocalReminders } from "../lib/notifications";
 import { loadPhoneReminderPrefs } from "../hooks/use-phone-reminders";
 import { usePreferences } from "../hooks/use-preferences";
+import { DailyChecklist, MedicationQuickLog } from "../components/home-widgets";
 import { useInsights } from "../hooks/use-insights";
 import { useCalmMinutes } from "../hooks/use-stats";
 import { useParentMood, useUpsertParentMood } from "../hooks/use-parent-mood";
@@ -224,6 +225,10 @@ export function HomeScreen({ navigation }: HomeProps) {
             </View>
             <Text style={styles.actionChevron}>›</Text>
           </Pressable>
+
+          {/* Live "done today" checklist + 1-tap medication log */}
+          <DailyChecklist childId={childId} />
+          <MedicationQuickLog childId={childId} />
 
           {/* Daily tip */}
           <CalloutCard variant="tip" label="Conseil du jour">

--- a/apps/mobile/src/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/screens/SettingsScreen.tsx
@@ -1,19 +1,32 @@
 import { useEffect, useMemo, useState, type ReactNode } from "react";
-import { StyleSheet, Switch, Text, TextInput, View } from "react-native";
-import { Mail, Smartphone } from "lucide-react-native";
+import {
+  Alert,
+  Pressable,
+  Share,
+  StyleSheet,
+  Switch,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import { Download, Mail, Smartphone, Users } from "lucide-react-native";
 
 import {
+  Button,
   Card,
   ErrorNote,
   Loader,
   Screen,
   ScreenHeader,
+  fonts,
 } from "../components/ui";
 import { useTheme, type Palette } from "../lib/theme";
 import {
   usePreferences,
   useUpdatePreferences,
 } from "../hooks/use-preferences";
+import { useDeleteAccount, useExportAccount } from "../hooks/use-account";
+import { authClient } from "../lib/auth";
 import { usePhoneReminderPrefs } from "../hooks/use-phone-reminders";
 import {
   getNotificationPermissionStatus,
@@ -30,6 +43,11 @@ export function SettingsScreen({ navigation }: SettingsProps) {
   const prefs = usePreferences();
   const update = useUpdatePreferences();
   const phone = usePhoneReminderPrefs();
+  const exportAccount = useExportAccount();
+  const deleteAccount = useDeleteAccount();
+
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleteText, setDeleteText] = useState("");
 
   // Local state for time fields (committed on blur)
   const [morningTime, setMorningTime] = useState("09:00");
@@ -114,6 +132,29 @@ export function SettingsScreen({ navigation }: SettingsProps) {
 
   const anyPhoneOn = phone.prefs.morningPhone || phone.prefs.eveningPhone;
   const showPermissionHint = anyPhoneOn && permission === "denied";
+
+  async function handleExport() {
+    try {
+      const data = await exportAccount.mutateAsync();
+      await Share.share({
+        title: "Export Tokō",
+        message: JSON.stringify(data, null, 2),
+      });
+    } catch {
+      Alert.alert("Export impossible", "Réessayez dans un instant.");
+    }
+  }
+
+  function handleDelete() {
+    if (deleteText !== "DELETE") return;
+    deleteAccount.mutate(undefined, {
+      onSuccess: () => {
+        void authClient.signOut();
+      },
+      onError: () =>
+        Alert.alert("Suppression impossible", "Réessayez dans un instant."),
+    });
+  }
 
   return (
     <Screen scroll>
@@ -245,9 +286,86 @@ export function SettingsScreen({ navigation }: SettingsProps) {
             />
           </Card>
 
+          {/* Co-parent : partage de l'activité */}
+          <Card>
+            <Text style={styles.sectionTitle}>Co-parent</Text>
+            <Text style={styles.hint}>
+              Soyez prévenu(e) quand l'autre parent note quelque chose pour
+              votre enfant.
+            </Text>
+            <ChannelRow
+              styles={styles}
+              c={c}
+              icon={<Users size={18} color={c.muted} />}
+              label="Activité du co-parent"
+              sublabel="Notifications de l'autre parent"
+              value={prefs.data.coParentActivityOptIn}
+              onValueChange={(v) => update.mutate({ coParentActivityOptIn: v })}
+              disabled={update.isPending}
+            />
+          </Card>
+
           {update.isError ? (
             <ErrorNote message="Impossible d'enregistrer. Réessayez." />
           ) : null}
+
+          {/* Données & confidentialité */}
+          <Card>
+            <Text style={styles.sectionTitle}>Données &amp; confidentialité</Text>
+            <Text style={styles.hint}>
+              Exportez toutes vos données (RGPD) ou supprimez définitivement
+              votre compte.
+            </Text>
+            <Button
+              label={exportAccount.isPending ? "Préparation…" : "Exporter mes données"}
+              variant="secondary"
+              icon={<Download size={18} color={c.text} />}
+              onPress={handleExport}
+              loading={exportAccount.isPending}
+            />
+
+            {!confirmingDelete ? (
+              <Pressable
+                onPress={() => setConfirmingDelete(true)}
+                style={styles.deleteRow}
+                accessibilityRole="button"
+              >
+                <Text style={styles.deleteText}>Supprimer mon compte</Text>
+              </Pressable>
+            ) : (
+              <View style={styles.deleteBox}>
+                <Text style={styles.deleteWarn}>
+                  Action définitive : toutes vos données et celles de vos enfants
+                  seront supprimées. Tapez DELETE pour confirmer.
+                </Text>
+                <TextInput
+                  style={styles.deleteInput}
+                  value={deleteText}
+                  onChangeText={setDeleteText}
+                  placeholder="DELETE"
+                  placeholderTextColor={c.muted}
+                  autoCapitalize="characters"
+                  autoCorrect={false}
+                />
+                <Button
+                  label={deleteAccount.isPending ? "Suppression…" : "Supprimer définitivement"}
+                  onPress={handleDelete}
+                  loading={deleteAccount.isPending}
+                  disabled={deleteText !== "DELETE"}
+                />
+                <Pressable
+                  onPress={() => {
+                    setConfirmingDelete(false);
+                    setDeleteText("");
+                  }}
+                  style={styles.cancelRow}
+                  accessibilityRole="button"
+                >
+                  <Text style={styles.cancelText}>Annuler</Text>
+                </Pressable>
+              </View>
+            )}
+          </Card>
         </>
       ) : null}
     </Screen>
@@ -372,4 +490,30 @@ const makeStyles = (c: Palette) =>
       minWidth: 80,
       textAlign: "center",
     },
+    deleteRow: { alignItems: "center", paddingVertical: 12, marginTop: 2 },
+    deleteText: { color: c.danger, fontFamily: fonts.semibold, fontSize: 15 },
+    deleteBox: {
+      gap: 10,
+      marginTop: 8,
+      padding: 12,
+      borderRadius: 12,
+      borderWidth: 1,
+      borderColor: c.dangerBorder,
+      backgroundColor: c.dangerSurface,
+    },
+    deleteWarn: { fontSize: 13, color: c.dangerFg, fontFamily: fonts.body, lineHeight: 19 },
+    deleteInput: {
+      borderWidth: 1,
+      borderColor: c.dangerBorder,
+      borderRadius: 8,
+      paddingHorizontal: 12,
+      paddingVertical: 10,
+      fontSize: 16,
+      color: c.text,
+      backgroundColor: c.card,
+      textAlign: "center",
+      fontFamily: fonts.semibold,
+    },
+    cancelRow: { alignItems: "center", paddingVertical: 4 },
+    cancelText: { color: c.muted, fontFamily: fonts.medium },
   });


### PR DESCRIPTION
Vague 1 (suite), **vérifiée sur appareil** (dark mode).

### Tableau de bord — interactions inline (parité PWA)
- **Check-list « Aujourd'hui »** en live : Soirée notée / Journal écrit / Médicaments pris (ligne médoc seulement si traitements).
- **Log médicaments 1-tap** Pris/Sauté + taux d'adhérence 30 j (ne s'affiche que s'il y a des traitements).
- Hooks `useMedicationAdherence` + `useLogMedication`.

### Réglages / Compte — parité PWA
- **Opt-in co-parent** (toggle, PATCH /preferences).
- **Export RGPD** des données (GET /account/export → partage natif).
- **Suppression de compte** : flux destructif inline avec saisie « DELETE » → DELETE /account, puis déconnexion. `api.delete` étendu pour body.

## Vérifié sur appareil
Check-list live ✓ · Co-parent toggle ✓ · Export bouton ✓ · Suppression : confirmation par saisie « DELETE » révélée ✓ (non exécutée). Typecheck + bundle OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)