### PR TITLE
feat(mobile): minuteur de routine (sequence runner) — étapes enchaînées + auto-coche

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -126,6 +126,7 @@ function RoutinesNavigator() {
       <RoutinesStack.Screen name="Routines" component={RoutinesScreen} />
       <RoutinesStack.Screen name="AddRoutine" component={AddRoutineScreen} />
       <RoutinesStack.Screen name="EditRoutine" component={EditRoutineScreen} />
+      <RoutinesStack.Screen name="Timer" component={TimerScreen} />
     </RoutinesStack.Navigator>
   );
 }

--- a/apps/mobile/src/lib/copy.ts
+++ b/apps/mobile/src/lib/copy.ts
@@ -90,6 +90,13 @@ export const timer = {
   speedUpHint: "Pour les petits défis : ranger, s'habiller, brossage de dents.",
   minutesLabel: (m: number) => `${m} min`,
   secondsLabel: (s: number) => (s < 60 ? `${s} s` : `${s / 60} min`),
+  // Sequence runner (a routine's timed steps chained back-to-back).
+  stepCounter: (cur: number, total: number) => `Étape ${cur}/${total}`,
+  nextStep: "Étape suivante",
+  stepDone: "Étape terminée",
+  sequenceFinished: "Routine terminée !",
+  quitSequence: "Quitter la routine",
+  launchTimer: "Lancer le minuteur",
 } as const;
 
 export const eveningCheck = {
@@ -151,6 +158,7 @@ export const routines = {
   add: "Ajouter une routine",
   others: "Autres routines",
   inactive: "En pause",
+  launchTimer: "Lancer le minuteur",
 } as const;
 
 // Copy for the "add a routine from a template" screen.

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -29,7 +29,21 @@ export type RootStackParamList = {
   Report: ChildParams;
   // Plus (grouped menu)
   PlusMenu: undefined;
-  Timer: undefined;
+  Timer:
+    | {
+        sequence?: {
+          routineId: string;
+          childId: string;
+          name: string;
+          steps: {
+            label: string;
+            emoji?: string;
+            durationSec: number;
+            routineStepId: string;
+          }[];
+        };
+      }
+    | undefined;
   Barkley: ChildParams;
   BarkleyStep: ChildParams & { stepNumber: number };
   Rewards: ChildParams;

--- a/apps/mobile/src/screens/RoutinesScreen.tsx
+++ b/apps/mobile/src/screens/RoutinesScreen.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import type { Routine, RoutineStep } from "@focusflow/validators";
 import { Pressable, StyleSheet, Text, View } from "react-native";
-import { Pencil, Plus } from "lucide-react-native";
+import { Pencil, Play, Plus } from "lucide-react-native";
 
 import {
   Button,
@@ -106,6 +106,10 @@ export function RoutinesScreen({ navigation, route }: RoutinesProps) {
           const steps = [...routine.steps].sort((a, b) => a.position - b.position);
           const doneCount = steps.filter((s) => doneStepIds.has(s.id)).length;
           const allDone = steps.length > 0 && doneCount === steps.length;
+          // Timed steps not yet done today → runnable as a chained timer.
+          const timed = steps.filter(
+            (s) => (s.durationMinutes ?? 0) > 0 && !doneStepIds.has(s.id),
+          );
           return (
             <Card key={routine.id}>
               <View style={styles.head}>
@@ -155,6 +159,29 @@ export function RoutinesScreen({ navigation, route }: RoutinesProps) {
                   </Pressable>
                 );
               })}
+
+              {timed.length > 0 ? (
+                <Button
+                  label={copy.launchTimer}
+                  icon={<Play size={18} color="#fff" fill="#fff" />}
+                  size="sm"
+                  onPress={() =>
+                    navigation.navigate("Timer", {
+                      sequence: {
+                        routineId: routine.id,
+                        childId,
+                        name: routine.name,
+                        steps: timed.map((s) => ({
+                          label: s.label,
+                          emoji: s.emoji ?? undefined,
+                          durationSec: (s.durationMinutes ?? 0) * 60,
+                          routineStepId: s.id,
+                        })),
+                      },
+                    })
+                  }
+                />
+              ) : null}
             </Card>
           );
         })

--- a/apps/mobile/src/screens/TimerScreen.tsx
+++ b/apps/mobile/src/screens/TimerScreen.tsx
@@ -1,17 +1,21 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Pressable, StyleSheet, Text, Vibration, View } from "react-native";
 import Svg, { Circle } from "react-native-svg";
-import { Pause, Play, RotateCcw, Zap } from "lucide-react-native";
+import { Check, ChevronRight, Pause, Play, RotateCcw, Zap } from "lucide-react-native";
 
 import { Button, Screen, ScreenHeader, fonts } from "../components/ui";
 import { timer as copy } from "../lib/copy";
+import { todayISO } from "../lib/date";
 import { useTheme, type Palette } from "../lib/theme";
+import { useCompleteStep } from "../hooks/use-routines";
+import type { TimerProps } from "../navigation/types";
 
 // React Native port of the PWA visual timer (apps/web/src/components/timer).
-// Core parity: presets, a depleting dial, start/pause/reset, a "speed-up" mode
-// for short challenges, an "almost done" warning and a vibration on finish.
-// (Companion/critter gamification and routine sequence-chaining from the web
-// are tracked as follow-ups.)
+// Two modes:
+//  • free timer — presets, depleting dial, start/pause/reset, speed-up.
+//  • sequence runner — chains a routine's timed steps, auto-completing each
+//    step (POST /routines/:id/complete) as its countdown ends (the "killer
+//    feature" for the exhausted parent).
 const PRESET_MINUTES = [2, 5, 10, 20, 45] as const;
 const PRESET_SPEEDUP_SECONDS = [30, 60, 120, 180] as const;
 const DEFAULT_SEC = 10 * 60;
@@ -29,12 +33,22 @@ function fmt(total: number): string {
   return `${m}:${String(s).padStart(2, "0")}`;
 }
 
-export function TimerScreen() {
+export function TimerScreen({ navigation, route }: TimerProps) {
   const c = useTheme();
   const styles = useMemo(() => makeStyles(c), [c]);
 
-  const [durationSec, setDurationSec] = useState(DEFAULT_SEC);
-  const [remainingSec, setRemainingSec] = useState(DEFAULT_SEC);
+  const seq = route.params?.sequence;
+  const completeStep = useCompleteStep();
+
+  // Sequence position (sequence mode only).
+  const [stepIndex, setStepIndex] = useState(0);
+  const [finished, setFinished] = useState(false); // whole sequence done
+
+  const seqStep = seq?.steps[stepIndex];
+  const initialSec = seq ? (seqStep?.durationSec ?? DEFAULT_SEC) : DEFAULT_SEC;
+
+  const [durationSec, setDurationSec] = useState(initialSec);
+  const [remainingSec, setRemainingSec] = useState(initialSec);
   const [running, setRunning] = useState(false);
   const [speedUp, setSpeedUp] = useState(false);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -48,7 +62,20 @@ export function TimerScreen() {
 
   useEffect(() => clear, [clear]);
 
-  // The ticking loop. Re-created whenever `running` flips.
+  // Completes the current sequence step on the server (idempotent) and marks
+  // the whole sequence finished when it was the last one.
+  const finishStep = useCallback(() => {
+    if (!seq || !seqStep) return;
+    completeStep.mutate({
+      childId: seq.childId,
+      routineId: seq.routineId,
+      stepId: seqStep.routineStepId,
+      date: todayISO(),
+    });
+    if (stepIndex >= seq.steps.length - 1) setFinished(true);
+  }, [seq, seqStep, stepIndex, completeStep]);
+
+  // Ticking loop.
   useEffect(() => {
     if (!running) return;
     intervalRef.current = setInterval(() => {
@@ -57,13 +84,14 @@ export function TimerScreen() {
           clear();
           setRunning(false);
           Vibration.vibrate(VIBRATION_PATTERN);
+          if (seq) finishStep();
           return 0;
         }
         return prev - 1;
       });
     }, 1000);
     return clear;
-  }, [running, clear]);
+  }, [running, clear, seq, finishStep]);
 
   function selectDuration(sec: number) {
     clear();
@@ -75,13 +103,11 @@ export function TimerScreen() {
   function toggleSpeedUp() {
     const next = !speedUp;
     setSpeedUp(next);
-    const sec = next ? PRESET_SPEEDUP_SECONDS[1] : DEFAULT_SEC;
-    selectDuration(sec);
+    selectDuration(next ? PRESET_SPEEDUP_SECONDS[1] : DEFAULT_SEC);
   }
 
   function toggleRun() {
-    if (remainingSec === 0) {
-      // Restart from the chosen duration.
+    if (remainingSec === 0 && !seq) {
       setRemainingSec(durationSec);
       setRunning(true);
       return;
@@ -95,63 +121,93 @@ export function TimerScreen() {
     setRemainingSec(durationSec);
   }
 
-  const finished = remainingSec === 0;
+  // Advance to the next sequence step and auto-start it.
+  function nextStep() {
+    if (!seq) return;
+    const next = stepIndex + 1;
+    if (next >= seq.steps.length) {
+      setFinished(true);
+      return;
+    }
+    clear();
+    const sec = seq.steps[next]!.durationSec;
+    setStepIndex(next);
+    setDurationSec(sec);
+    setRemainingSec(sec);
+    setRunning(true);
+  }
+
+  const isFinished = remainingSec === 0;
   const almostDone = running && remainingSec > 0 && remainingSec <= ALMOST_DONE_SEC;
   const progress = durationSec > 0 ? remainingSec / durationSec : 0;
   const dashoffset = C * (1 - progress);
+  const stepCompleted = !!seq && isFinished; // current step's timer ended
 
-  const dialColor = finished
-    ? c.success
-    : almostDone
-      ? c.danger
-      : c.brand;
+  const dialColor = isFinished ? c.success : almostDone ? c.danger : c.brand;
 
-  const statusText = finished
-    ? copy.finished
-    : almostDone
-      ? copy.almostDone
-      : running
-        ? copy.running
-        : copy.ready;
+  // ── Sequence finished screen ───────────────────────────────────────────
+  if (seq && finished) {
+    return (
+      <Screen>
+        <ScreenHeader title={seq.name} onBack={() => navigation.goBack()} />
+        <View style={styles.finishWrap}>
+          <View style={styles.finishBadge}>
+            <Check size={40} color="#fff" />
+          </View>
+          <Text style={styles.finishTitle}>{copy.sequenceFinished}</Text>
+          <Button label={copy.quitSequence} variant="secondary" onPress={() => navigation.goBack()} />
+        </View>
+      </Screen>
+    );
+  }
+
+  const statusText = seq
+    ? copy.stepCounter(stepIndex + 1, seq.steps.length)
+    : isFinished
+      ? copy.finished
+      : almostDone
+        ? copy.almostDone
+        : running
+          ? copy.running
+          : copy.ready;
 
   const presets = speedUp ? PRESET_SPEEDUP_SECONDS : PRESET_MINUTES.map((m) => m * 60);
 
   return (
     <Screen scroll>
-      <ScreenHeader title={copy.title} />
-      <Text style={styles.subtitle}>{copy.subtitle}</Text>
+      <ScreenHeader
+        title={seq ? seq.name : copy.title}
+        subtitle={seq ? seqStep?.label : undefined}
+        onBack={seq ? () => navigation.goBack() : undefined}
+      />
+      {!seq ? <Text style={styles.subtitle}>{copy.subtitle}</Text> : null}
 
-      {/* Presets */}
-      <View style={styles.presets}>
-        {presets.map((sec) => {
-          const on = durationSec === sec;
-          return (
-            <Pressable
-              key={sec}
-              onPress={() => selectDuration(sec)}
-              style={[styles.chip, on && styles.chipOn]}
-              accessibilityRole="button"
-              accessibilityState={{ selected: on }}
-            >
-              <Text style={[styles.chipText, on && styles.chipTextOn]}>
-                {speedUp ? copy.secondsLabel(sec) : copy.minutesLabel(sec / 60)}
-              </Text>
-            </Pressable>
-          );
-        })}
-      </View>
+      {/* Presets — free mode only */}
+      {!seq ? (
+        <View style={styles.presets}>
+          {presets.map((sec) => {
+            const on = durationSec === sec;
+            return (
+              <Pressable
+                key={sec}
+                onPress={() => selectDuration(sec)}
+                style={[styles.chip, on && styles.chipOn]}
+                accessibilityRole="button"
+                accessibilityState={{ selected: on }}
+              >
+                <Text style={[styles.chipText, on && styles.chipTextOn]}>
+                  {speedUp ? copy.secondsLabel(sec) : copy.minutesLabel(sec / 60)}
+                </Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      ) : null}
 
       {/* Dial */}
       <View style={styles.dialWrap}>
         <Svg width={DIAL_SIZE} height={DIAL_SIZE}>
-          <Circle
-            cx={DIAL_SIZE / 2}
-            cy={DIAL_SIZE / 2}
-            r={R}
-            stroke={c.secondary}
-            strokeWidth={STROKE}
-            fill="none"
-          />
+          <Circle cx={DIAL_SIZE / 2} cy={DIAL_SIZE / 2} r={R} stroke={c.secondary} strokeWidth={STROKE} fill="none" />
           <Circle
             cx={DIAL_SIZE / 2}
             cy={DIAL_SIZE / 2}
@@ -166,61 +222,63 @@ export function TimerScreen() {
           />
         </Svg>
         <View style={styles.dialCenter} pointerEvents="none">
-          <Text style={[styles.time, { color: dialColor }]}>
-            {fmt(remainingSec)}
-          </Text>
+          {seq && seqStep?.emoji ? <Text style={styles.stepEmoji}>{seqStep.emoji}</Text> : null}
+          <Text style={[styles.time, { color: dialColor }]}>{fmt(remainingSec)}</Text>
           <Text style={styles.status}>{statusText}</Text>
         </View>
       </View>
 
-      {/* Controls */}
-      <Button
-        label={finished ? copy.start : running ? copy.pause : remainingSec < durationSec ? copy.resume : copy.start}
-        icon={
-          running ? (
-            <Pause size={20} color="#fff" fill="#fff" />
-          ) : (
-            <Play size={20} color="#fff" fill="#fff" />
-          )
-        }
-        onPress={toggleRun}
-      />
-      <Button
-        label={copy.reset}
-        variant="secondary"
-        icon={<RotateCcw size={18} color={c.text} />}
-        onPress={reset}
-      />
-
-      {/* Speed-up mode */}
-      <Pressable
-        onPress={toggleSpeedUp}
-        style={[styles.speedRow, speedUp && styles.speedRowOn]}
-        accessibilityRole="button"
-        accessibilityState={{ selected: speedUp }}
-      >
-        <Zap
-          size={16}
-          color={speedUp ? c.alertFg : c.muted}
-          fill={speedUp ? c.alertFg : "none"}
+      {/* Primary control */}
+      {stepCompleted && seq ? (
+        <Button
+          label={stepIndex >= seq.steps.length - 1 ? copy.sequenceFinished : copy.nextStep}
+          icon={<ChevronRight size={18} color="#fff" />}
+          onPress={nextStep}
         />
-        <Text style={[styles.speedText, speedUp && styles.speedTextOn]}>
-          {speedUp ? copy.speedUpOn : copy.speedUpOff}
-        </Text>
-      </Pressable>
-      {speedUp ? <Text style={styles.speedHint}>{copy.speedUpHint}</Text> : null}
+      ) : (
+        <Button
+          label={running ? copy.pause : remainingSec < durationSec ? copy.resume : copy.start}
+          icon={running ? <Pause size={20} color="#fff" fill="#fff" /> : <Play size={20} color="#fff" fill="#fff" />}
+          onPress={toggleRun}
+        />
+      )}
+
+      {/* Secondary control */}
+      {seq ? (
+        <Button label={copy.quitSequence} variant="secondary" onPress={() => navigation.goBack()} />
+      ) : (
+        <Button
+          label={copy.reset}
+          variant="secondary"
+          icon={<RotateCcw size={18} color={c.text} />}
+          onPress={reset}
+        />
+      )}
+
+      {/* Speed-up — free mode only */}
+      {!seq ? (
+        <>
+          <Pressable
+            onPress={toggleSpeedUp}
+            style={[styles.speedRow, speedUp && styles.speedRowOn]}
+            accessibilityRole="button"
+            accessibilityState={{ selected: speedUp }}
+          >
+            <Zap size={16} color={speedUp ? c.alertFg : c.muted} fill={speedUp ? c.alertFg : "none"} />
+            <Text style={[styles.speedText, speedUp && styles.speedTextOn]}>
+              {speedUp ? copy.speedUpOn : copy.speedUpOff}
+            </Text>
+          </Pressable>
+          {speedUp ? <Text style={styles.speedHint}>{copy.speedUpHint}</Text> : null}
+        </>
+      ) : null}
     </Screen>
   );
 }
 
 const makeStyles = (c: Palette) =>
   StyleSheet.create({
-    subtitle: {
-      fontSize: 14,
-      color: c.muted,
-      fontFamily: fonts.body,
-      lineHeight: 20,
-    },
+    subtitle: { fontSize: 14, color: c.muted, fontFamily: fonts.body, lineHeight: 20 },
     presets: {
       flexDirection: "row",
       flexWrap: "wrap",
@@ -249,17 +307,9 @@ const makeStyles = (c: Palette) =>
       height: DIAL_SIZE,
       alignSelf: "center",
     },
-    dialCenter: {
-      ...StyleSheet.absoluteFillObject,
-      alignItems: "center",
-      justifyContent: "center",
-      gap: 4,
-    },
-    time: {
-      fontSize: 56,
-      fontFamily: fonts.bold,
-      fontVariant: ["tabular-nums"],
-    },
+    dialCenter: { ...StyleSheet.absoluteFillObject, alignItems: "center", justifyContent: "center", gap: 4 },
+    stepEmoji: { fontSize: 30 },
+    time: { fontSize: 56, fontFamily: fonts.bold, fontVariant: ["tabular-nums"] },
     status: { fontSize: 14, color: c.muted, fontFamily: fonts.medium },
     speedRow: {
       flexDirection: "row",
@@ -277,11 +327,15 @@ const makeStyles = (c: Palette) =>
     speedRowOn: { backgroundColor: c.alertSurface, borderColor: c.alertBorder },
     speedText: { fontSize: 13, color: c.muted, fontFamily: fonts.medium },
     speedTextOn: { color: c.alertFg, fontFamily: fonts.semibold },
-    speedHint: {
-      fontSize: 12,
-      color: c.muted,
-      fontFamily: fonts.body,
-      textAlign: "center",
-      lineHeight: 17,
+    speedHint: { fontSize: 12, color: c.muted, fontFamily: fonts.body, textAlign: "center", lineHeight: 17 },
+    finishWrap: { flex: 1, alignItems: "center", justifyContent: "center", gap: 16 },
+    finishBadge: {
+      width: 88,
+      height: 88,
+      borderRadius: 44,
+      backgroundColor: c.success,
+      alignItems: "center",
+      justifyContent: "center",
     },
+    finishTitle: { fontSize: 24, color: c.text, fontFamily: fonts.heading, textAlign: "center" },
   });


### PR DESCRIPTION
Dernier item de la **vague 1** : le minuteur enchaîné sur une routine (la « killer feature » de la PWA pour le parent épuisé). **Vérifié sur appareil**.

- **CTA « Lancer le minuteur »** sur chaque routine du jour ayant ≥1 étape minutée non cochée.
- **TimerScreen en mode séquence** : décompte par étape (emoji + libellé + « Étape X/N »), **auto-complétion** de l'étape à la fin de son décompte (`POST /routines/:id/complete`), « Étape suivante », écran « Routine terminée ». Le mode minuteur libre (présets) est conservé.
- Timer enregistré aussi dans le RoutinesStack (navigation directe).

## Vérifié sur appareil
CTA visible ✓ · lancement → cadran « Coucher sans cris / Douche ou bain tiède 🛁 / 10:00 / Étape 1/8 » ✓. Typecheck + bundle OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)