### PR TITLE
feat(mobile): phase 2 — compagnons minuteur, éditions, sélecteur de période, burn-out

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -59,6 +59,7 @@ import { EditRoutineScreen } from "./src/screens/EditRoutineScreen";
 // Plus (grouped menu + every secondary screen)
 import { PlusMenuScreen } from "./src/screens/PlusMenuScreen";
 import { TimerScreen } from "./src/screens/TimerScreen";
+import { CompanionCollectionScreen } from "./src/screens/CompanionCollectionScreen";
 import { MedicationsScreen } from "./src/screens/MedicationsScreen";
 import { CalmMinutesScreen } from "./src/screens/CalmMinutesScreen";
 import { InsightsScreen } from "./src/screens/InsightsScreen";
@@ -127,6 +128,10 @@ function RoutinesNavigator() {
       <RoutinesStack.Screen name="AddRoutine" component={AddRoutineScreen} />
       <RoutinesStack.Screen name="EditRoutine" component={EditRoutineScreen} />
       <RoutinesStack.Screen name="Timer" component={TimerScreen} />
+      <RoutinesStack.Screen
+        name="CompanionCollection"
+        component={CompanionCollectionScreen}
+      />
     </RoutinesStack.Navigator>
   );
 }
@@ -136,6 +141,10 @@ function PlusNavigator() {
     <PlusStack.Navigator screenOptions={stackOptions}>
       <PlusStack.Screen name="PlusMenu" component={PlusMenuScreen} />
       <PlusStack.Screen name="Timer" component={TimerScreen} />
+      <PlusStack.Screen
+        name="CompanionCollection"
+        component={CompanionCollectionScreen}
+      />
       <PlusStack.Screen name="Medications" component={MedicationsScreen} />
       <PlusStack.Screen name="CalmMinutes" component={CalmMinutesScreen} />
       <PlusStack.Screen name="Insights" component={InsightsScreen} />

--- a/apps/mobile/src/components/period-switcher.tsx
+++ b/apps/mobile/src/components/period-switcher.tsx
@@ -1,0 +1,76 @@
+import { useMemo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { Lock } from "lucide-react-native";
+
+import { fonts } from "./ui";
+import { useTheme, type Palette } from "../lib/theme";
+
+export type StatsPeriod = "week" | "month" | "quarter";
+
+export const PERIOD_LABELS: Record<StatsPeriod, string> = {
+  week: "Semaine",
+  month: "Mois",
+  quarter: "Trimestre",
+};
+
+// month/quarter are premium on the web; mirror that gating on mobile.
+const LOCKED: StatsPeriod[] = ["month", "quarter"];
+
+// Segmented period selector with premium-locked options. Tapping a locked
+// period (non-premium) calls onLocked instead of changing the value.
+export function PeriodSwitcher({
+  value,
+  onChange,
+  isPremium,
+  onLocked,
+}: {
+  value: StatsPeriod;
+  onChange: (p: StatsPeriod) => void;
+  isPremium: boolean;
+  onLocked?: () => void;
+}) {
+  const c = useTheme();
+  const s = useMemo(() => makeStyles(c), [c]);
+  const periods: StatsPeriod[] = ["week", "month", "quarter"];
+
+  return (
+    <View style={s.row}>
+      {periods.map((p) => {
+        const on = p === value;
+        const locked = !isPremium && LOCKED.includes(p);
+        return (
+          <Pressable
+            key={p}
+            onPress={() => (locked ? onLocked?.() : onChange(p))}
+            style={[s.chip, on && s.chipOn]}
+            accessibilityRole="button"
+            accessibilityState={{ selected: on }}
+          >
+            {locked ? <Lock size={12} color={on ? "#fff" : c.muted} /> : null}
+            <Text style={[s.text, on && s.textOn]}>{PERIOD_LABELS[p]}</Text>
+          </Pressable>
+        );
+      })}
+    </View>
+  );
+}
+
+const makeStyles = (c: Palette) =>
+  StyleSheet.create({
+    row: { flexDirection: "row", gap: 8 },
+    chip: {
+      flex: 1,
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 5,
+      paddingVertical: 9,
+      borderRadius: 999,
+      borderWidth: 1,
+      borderColor: c.border,
+      backgroundColor: c.card,
+    },
+    chipOn: { backgroundColor: c.brand, borderColor: c.brand },
+    text: { fontSize: 14, color: c.subtext, fontFamily: fonts.medium },
+    textOn: { color: "#fff", fontFamily: fonts.semibold },
+  });

--- a/apps/mobile/src/hooks/use-billing.ts
+++ b/apps/mobile/src/hooks/use-billing.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { fetchBillingStatus } from "../lib/api";
+
+// Entitlement check, mirroring the web: a user is premium when their
+// subscription is active OR access was granted (solidarity / admin).
+export function usePremium() {
+  const billing = useQuery({ queryKey: ["billing"], queryFn: fetchBillingStatus });
+  return {
+    isPremium: !!(billing.data?.active || billing.data?.granted),
+    isLoading: billing.isLoading,
+  };
+}

--- a/apps/mobile/src/hooks/use-companions.ts
+++ b/apps/mobile/src/hooks/use-companions.ts
@@ -1,0 +1,28 @@
+import type {
+  CompanionDiscovery,
+  RecordCompanionDiscovery,
+} from "@focusflow/validators";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { api } from "../lib/api";
+
+// Mirrors apps/web/src/hooks/use-companions.ts: list a child's discovered
+// timer companions and record a new discovery when a timer completes.
+const key = (childId: string) => ["companions", childId] as const;
+
+export function useCompanions(childId: string) {
+  return useQuery({
+    queryKey: key(childId),
+    queryFn: () => api.get<CompanionDiscovery[]>(`/companions/${childId}`),
+    enabled: !!childId,
+  });
+}
+
+export function useRecordCompanion(childId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: RecordCompanionDiscovery) =>
+      api.post<{ alreadyDiscovered: boolean }>("/companions", data),
+    onSettled: () => qc.invalidateQueries({ queryKey: key(childId) }),
+  });
+}

--- a/apps/mobile/src/hooks/use-crisis-list.ts
+++ b/apps/mobile/src/hooks/use-crisis-list.ts
@@ -1,4 +1,8 @@
-import type { CreateCrisisItem, CrisisItem } from "@focusflow/validators";
+import type {
+  CreateCrisisItem,
+  CrisisItem,
+  UpdateCrisisItem,
+} from "@focusflow/validators";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { api } from "../lib/api";
@@ -42,6 +46,21 @@ export function useCreateCrisisItem() {
         queryClient.setQueryData(context.key, context.previous);
       }
     },
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({ queryKey: crisisKey(variables.childId) });
+    },
+  });
+}
+
+export function useUpdateCrisisItem() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      childId: _childId,
+      ...data
+    }: UpdateCrisisItem & { id: string; childId: string }) =>
+      api.patch<CrisisItem>(`/crisis-list/${id}`, data),
     onSettled: (_data, _err, variables) => {
       queryClient.invalidateQueries({ queryKey: crisisKey(variables.childId) });
     },

--- a/apps/mobile/src/hooks/use-journal.ts
+++ b/apps/mobile/src/hooks/use-journal.ts
@@ -1,6 +1,7 @@
 import type {
   CreateJournalEntry,
   JournalEntry,
+  UpdateJournalEntry,
 } from "@focusflow/validators";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
@@ -48,6 +49,21 @@ export function useCreateJournalEntry() {
         queryClient.setQueryData(context.key, context.previous);
       }
     },
+    onSettled: (_data, _err, variables) => {
+      queryClient.invalidateQueries({ queryKey: journalKey(variables.childId) });
+    },
+  });
+}
+
+export function useUpdateJournalEntry() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      childId: _childId,
+      ...data
+    }: UpdateJournalEntry & { id: string; childId: string }) =>
+      api.patch<JournalEntry>(`/journal/${id}`, data),
     onSettled: (_data, _err, variables) => {
       queryClient.invalidateQueries({ queryKey: journalKey(variables.childId) });
     },

--- a/apps/mobile/src/lib/copy.ts
+++ b/apps/mobile/src/lib/copy.ts
@@ -97,6 +97,18 @@ export const timer = {
   sequenceFinished: "Routine terminée !",
   quitSequence: "Quitter la routine",
   launchTimer: "Lancer le minuteur",
+  // Companions (collectible critters that hatch when a timer finishes).
+  companionOn: "Compagnon activé",
+  companionOff: "Compagnon",
+  companionNew: "Bravo, un nouveau compagnon est arrivé !",
+  companionAgain: "Tu as retrouvé un compagnon !",
+  viewCollection: "Voir mes compagnons",
+  collectionTitle: "Mes compagnons",
+  collectionIntro: (n: number) =>
+    n === 0
+      ? "Termine un minuteur pour rencontrer ton premier compagnon."
+      : `Tu as rencontré ${n} compagnon${n > 1 ? "s" : ""}.`,
+  collectionLocked: "À découvrir",
 } as const;
 
 export const eveningCheck = {

--- a/apps/mobile/src/lib/critters.ts
+++ b/apps/mobile/src/lib/critters.ts
@@ -1,0 +1,32 @@
+// The pool of friendly critters the timer companion can hatch into, ported
+// from the PWA (apps/web/src/components/timer/critters.ts + i18n critters.*).
+// Each has a stable `id` (persisted via /companions) and a French name shown
+// in the reveal and the collection. Kept short and universally recognizable
+// so a young child reads the reward instantly.
+export type Critter = {
+  id: string;
+  emoji: string;
+  name: string;
+};
+
+export const CRITTER_CATALOG: readonly Critter[] = [
+  { id: "chick", emoji: "🐥", name: "Le poussin" },
+  { id: "butterfly", emoji: "🦋", name: "Le papillon" },
+  { id: "fox", emoji: "🦊", name: "Le renard" },
+  { id: "rabbit", emoji: "🐰", name: "Le lapin" },
+  { id: "turtle", emoji: "🐢", name: "La tortue" },
+  { id: "dog", emoji: "🐶", name: "Le chien" },
+  { id: "cat", emoji: "🐱", name: "Le chat" },
+  { id: "penguin", emoji: "🐧", name: "Le manchot" },
+  { id: "panda", emoji: "🐼", name: "Le panda" },
+  { id: "hedgehog", emoji: "🦔", name: "Le hérisson" },
+] as const;
+
+/** Random critter for a fresh discovery. */
+export function pickCritter(): Critter {
+  return CRITTER_CATALOG[Math.floor(Math.random() * CRITTER_CATALOG.length)]!;
+}
+
+export function critterById(id: string): Critter | undefined {
+  return CRITTER_CATALOG.find((cr) => cr.id === id);
+}

--- a/apps/mobile/src/navigation/types.ts
+++ b/apps/mobile/src/navigation/types.ts
@@ -44,6 +44,7 @@ export type RootStackParamList = {
         };
       }
     | undefined;
+  CompanionCollection: ChildParams;
   Barkley: ChildParams;
   BarkleyStep: ChildParams & { stepNumber: number };
   Rewards: ChildParams;
@@ -77,6 +78,7 @@ type S<T extends keyof RootStackParamList> = NativeStackScreenProps<
 export type HomeProps = S<"Home">;
 export type PlusMenuProps = S<"PlusMenu">;
 export type TimerProps = S<"Timer">;
+export type CompanionCollectionProps = S<"CompanionCollection">;
 export type CheckinProps = S<"Checkin">;
 export type SymptomsProps = S<"Symptoms">;
 export type SymptomFormProps = S<"SymptomForm">;

--- a/apps/mobile/src/screens/BurnoutScreen.tsx
+++ b/apps/mobile/src/screens/BurnoutScreen.tsx
@@ -1,308 +1,213 @@
-import type { ParentMoodScore } from "@focusflow/validators";
 import { useMemo, useState } from "react";
-import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+import { Linking, Pressable, StyleSheet, Text, View } from "react-native";
 
 import {
+  Button,
+  CalloutCard,
   Card,
-  ErrorNote,
-  Loader,
-  PrimaryButton,
   Screen,
   ScreenHeader,
+  fonts,
 } from "../components/ui";
 import { useTheme, type Palette } from "../lib/theme";
-import {
-  useParentMood,
-  useUpsertParentMood,
-} from "../hooks/use-parent-mood";
 import type { BurnoutProps } from "../navigation/types";
 
-// Score 1–5 mirroring parentMoodScoreSchema
-type ScoreOption = {
-  value: ParentMoodScore;
-  emoji: string;
-  label: string;
+// Parental burn-out self-assessment, ported from the PWA /burnout (Roskam &
+// Mikolajczak inspired). 7 questions on a 0–3 scale, total /21, three zones.
+// Client-side only — nothing is stored (a guilt-free mirror, not a diagnosis).
+// The parent mood logger (1–5) lives on the Home dashboard, not here.
+const QUESTIONS = [
+  "Je me sens épuisé·e dès le matin quand je pense à la journée avec mon enfant.",
+  "À la fin de la journée, mes ressources émotionnelles sont vides.",
+  "Je me sens distant·e affectivement avec mon enfant, comme en retrait.",
+  "Je ne reconnais plus le parent que j'étais avant.",
+  "Je culpabilise souvent d'être un·e mauvais·e parent.",
+  "Je n'ai plus d'énergie pour les moments simples : jeu, câlin, rire.",
+  "Je pense parfois que je ne peux plus assumer ce rôle.",
+];
+const SCALE = ["Jamais", "Parfois", "Souvent", "Tout le temps"];
+
+type Zone = "green" | "orange" | "red";
+function zoneFromScore(score: number): Zone {
+  if (score <= 6) return "green";
+  if (score <= 13) return "orange";
+  return "red";
+}
+const ZONE = {
+  green: {
+    variant: "success" as const,
+    label: "Vous tenez bon",
+    title: "Pas de signaux d'épuisement marqués.",
+    body: "Vous traversez la parentalité TDAH avec des ressources. Ne sous-estimez pas pour autant la fatigue : prenez les pauses dont vous avez besoin, même quand tout semble aller.",
+  },
+  orange: {
+    variant: "alert" as const,
+    label: "Fatigue notable",
+    title: "Des signes de fatigue qui méritent attention.",
+    body: "Ce que vous ressentez est réel, et c'est le bon moment pour ralentir. Diminuez ce qui peut l'être, parlez-en à un proche, et envisagez d'en parler à votre médecin si la fatigue s'installe.",
+  },
+  red: {
+    variant: "alert" as const,
+    label: "Signaux forts",
+    title: "Vous portez beaucoup. Vous n'êtes pas seul·e.",
+    body: "Ce que vous traversez ressemble à un épuisement parental significatif. Ce n'est pas une faiblesse, ce n'est pas votre responsabilité. C'est un signal d'alerte qui mérite un échange avec un professionnel — médecin traitant, psychologue, ou un des numéros d'écoute ci-dessous.",
+  },
 };
 
-const SCORE_OPTIONS: ScoreOption[] = [
-  { value: 1, emoji: "😩", label: "Épuisé(e)" },
-  { value: 2, emoji: "😔", label: "Fatigué(e)" },
-  { value: 3, emoji: "😐", label: "Neutre" },
-  { value: 4, emoji: "🙂", label: "En forme" },
-  { value: 5, emoji: "😊", label: "Super bien" },
+const SUPPORT = [
+  { label: "3114 — Prévention du suicide", hint: "Gratuit, 24h/24, anonyme", url: "tel:3114" },
+  { label: "Allô Parents Bébé", hint: "0 800 235 236 · écoute parentale", url: "tel:0800235236" },
+  { label: "HyperSupers TDAH France", hint: "Soutien et orientation TDAH", url: "https://www.tdah-france.fr/" },
 ];
-
-function todayISO() {
-  return new Date().toISOString().slice(0, 10);
-}
 
 export function BurnoutScreen({ navigation }: BurnoutProps) {
   const c = useTheme();
   const styles = useMemo(() => makeStyles(c), [c]);
 
-  const history = useParentMood(7);
-  const upsert = useUpsertParentMood();
-
-  const [selectedScore, setSelectedScore] = useState<ParentMoodScore | null>(
-    null,
+  const [answers, setAnswers] = useState<(number | null)[]>(
+    () => QUESTIONS.map(() => null),
   );
-  const [note, setNote] = useState("");
   const [submitted, setSubmitted] = useState(false);
 
-  // Today's existing entry (if already logged today)
-  const todayEntry = history.data?.find((e) => e.date === todayISO());
+  const total = answers.reduce<number>((sum, v) => sum + (v ?? 0), 0);
+  const allAnswered = answers.every((a) => a !== null);
 
-  const handleSubmit = () => {
-    if (!selectedScore) return;
-    upsert.mutate(
-      { date: todayISO(), score: selectedScore, note: note.trim() || undefined },
-      {
-        onSuccess: () => {
-          setSubmitted(true);
-        },
-      },
-    );
-  };
-
-  const handleRetake = () => {
-    setSelectedScore(null);
-    setNote("");
+  function setAnswer(i: number, v: number) {
+    setAnswers((prev) => {
+      const next = [...prev];
+      next[i] = v;
+      return next;
+    });
+  }
+  function reset() {
+    setAnswers(QUESTIONS.map(() => null));
     setSubmitted(false);
-  };
+  }
+
+  if (submitted) {
+    const zone = ZONE[zoneFromScore(total)];
+    return (
+      <Screen scroll>
+        <ScreenHeader
+          title="Est-ce un burn-out parental ?"
+          onBack={() => navigation.goBack()}
+        />
+        <CalloutCard variant={zone.variant} label={zone.label}>
+          <Text style={styles.score}>Score : {total} sur 21</Text>
+          <Text style={styles.zoneTitle}>{zone.title}</Text>
+          <Text style={styles.zoneBody}>{zone.body}</Text>
+        </CalloutCard>
+
+        <Card>
+          <Text style={styles.supportTitle}>Vous pouvez en parler maintenant</Text>
+          <Text style={styles.supportBody}>
+            Ces lignes sont gratuites, anonymes et ouvertes aux parents en
+            difficulté. Vous n'avez pas besoin d'avoir trouvé les bons mots pour
+            appeler.
+          </Text>
+          {SUPPORT.map((s) => (
+            <Pressable
+              key={s.url}
+              onPress={() => Linking.openURL(s.url)}
+              style={styles.supportRow}
+              accessibilityRole="button"
+            >
+              <Text style={styles.supportLink}>{s.label}</Text>
+              <Text style={styles.supportHint}>{s.hint}</Text>
+            </Pressable>
+          ))}
+        </Card>
+
+        <Button label="Refaire le test" variant="secondary" onPress={reset} />
+      </Screen>
+    );
+  }
 
   return (
     <Screen scroll>
       <ScreenHeader
-        title="Mon énergie de parent"
+        title="Est-ce un burn-out parental ?"
         onBack={() => navigation.goBack()}
       />
+      <Text style={styles.subtitle}>
+        Sept questions courtes pour mettre des mots sur ce que vous traversez.
+        Aucun jugement, aucune mémorisation de votre réponse.
+      </Text>
 
-      {/* Guilt-free intro */}
-      <Card style={styles.infoCard}>
-        <Text style={styles.infoText}>
-          Prendre un instant pour soi, c'est aussi prendre soin de son enfant.
-          Il n'y a pas de bonne ou de mauvaise réponse — juste un miroir pour
-          mieux vous connaître.
+      <CalloutCard variant="info" label="À lire d'abord">
+        <Text style={styles.disclaimer}>
+          Ce test n'est pas un diagnostic médical. C'est un miroir : il vous aide
+          à reconnaître ce que vous ressentez. Seul un médecin ou un psychologue
+          peut évaluer un burn-out parental.
         </Text>
-      </Card>
+      </CalloutCard>
 
-      {history.isLoading ? (
-        <Loader />
-      ) : submitted || (todayEntry && !selectedScore) ? (
-        /* Result / confirmation view */
-        <SubmittedView
-          score={
-            submitted && selectedScore
-              ? selectedScore
-              : (todayEntry?.score as ParentMoodScore)
-          }
-          note={submitted ? note : (todayEntry?.note ?? "")}
-          onRetake={handleRetake}
-        />
-      ) : (
-        /* Check-in form */
-        <Card>
+      <Text style={styles.formTitle}>Au cours des deux dernières semaines</Text>
+
+      {QUESTIONS.map((q, i) => (
+        <Card key={i}>
           <Text style={styles.question}>
-            Comment vous sentez-vous aujourd'hui en tant que parent ?
+            {i + 1}. {q}
           </Text>
-
-          <View style={styles.scoreRow}>
-            {SCORE_OPTIONS.map((opt) => {
-              const active = selectedScore === opt.value;
+          <View style={styles.scaleRow}>
+            {SCALE.map((label, v) => {
+              const on = answers[i] === v;
               return (
                 <Pressable
-                  key={opt.value}
-                  onPress={() => setSelectedScore(opt.value)}
-                  style={[styles.scoreOption, active && styles.scoreOptionOn]}
+                  key={v}
+                  onPress={() => setAnswer(i, v)}
+                  style={[styles.scaleChip, on && styles.scaleChipOn]}
+                  accessibilityRole="button"
+                  accessibilityState={{ selected: on }}
                 >
-                  <Text style={styles.scoreEmoji}>{opt.emoji}</Text>
-                  <Text
-                    style={[styles.scoreLabel, active && styles.scoreLabelOn]}
-                  >
-                    {opt.label}
+                  <Text style={[styles.scaleText, on && styles.scaleTextOn]}>
+                    {label}
                   </Text>
                 </Pressable>
               );
             })}
           </View>
-
-          <TextInput
-            style={styles.noteInput}
-            placeholder="Une pensée à noter ? (optionnel)"
-            placeholderTextColor={c.muted}
-            value={note}
-            onChangeText={setNote}
-            multiline
-            numberOfLines={3}
-            maxLength={500}
-          />
-
-          {upsert.isError ? (
-            <ErrorNote message="Impossible d'enregistrer. Réessayez." />
-          ) : null}
-
-          <PrimaryButton
-            label="Valider"
-            onPress={handleSubmit}
-            loading={upsert.isPending}
-            disabled={!selectedScore}
-          />
         </Card>
-      )}
+      ))}
 
-      {/* 7-day history strip */}
-      {history.data && history.data.length > 0 && (
-        <Card>
-          <Text style={styles.historyTitle}>Cette semaine</Text>
-          <View style={styles.historyRow}>
-            {[...history.data].reverse().map((entry) => {
-              const opt = SCORE_OPTIONS.find((o) => o.value === entry.score);
-              const label = entry.date.slice(5); // MM-DD
-              return (
-                <View key={entry.id} style={styles.historyDot}>
-                  <Text style={styles.historyEmoji}>{opt?.emoji ?? "·"}</Text>
-                  <Text style={styles.historyDate}>{label}</Text>
-                </View>
-              );
-            })}
-          </View>
-        </Card>
-      )}
+      <Button
+        label="Voir le résultat"
+        onPress={() => setSubmitted(true)}
+        disabled={!allAnswered}
+      />
     </Screen>
-  );
-}
-
-function SubmittedView({
-  score,
-  note,
-  onRetake,
-}: {
-  score: ParentMoodScore;
-  note: string | null;
-  onRetake: () => void;
-}) {
-  const c = useTheme();
-  const styles = useMemo(() => makeStyles(c), [c]);
-
-  const opt = SCORE_OPTIONS.find((o) => o.value === score);
-  const zone = score <= 2 ? "low" : score === 3 ? "mid" : "high";
-
-  const zoneMessages: Record<string, { title: string; body: string }> = {
-    low: {
-      title: "Vous méritez du soutien.",
-      body: "Les journées difficiles font partie du chemin. Accorder quelques minutes à vous-même peut déjà aider.",
-    },
-    mid: {
-      title: "C'est correct, et c'est déjà bien.",
-      body: "Tenir bon au quotidien, c'est une force en soi.",
-    },
-    high: {
-      title: "Vous êtes en pleine forme !",
-      body: "Profitez de cette énergie. Votre enfant en bénéficie aussi.",
-    },
-  };
-
-  const msg = zoneMessages[zone]!;
-
-  return (
-    <Card
-      style={
-        zone === "low"
-          ? styles.zoneCardLow
-          : zone === "mid"
-            ? styles.zoneCardMid
-            : styles.zoneCardHigh
-      }
-    >
-      <Text style={styles.zoneEmoji}>{opt?.emoji ?? "·"}</Text>
-      <Text style={styles.zoneTitle}>{msg.title}</Text>
-      <Text style={styles.zoneBody}>{msg.body}</Text>
-      {note ? <Text style={styles.zoneNote}>"{note}"</Text> : null}
-      <Pressable onPress={onRetake} hitSlop={8} style={styles.retakeBtn}>
-        <Text style={styles.retakeText}>Refaire l'évaluation</Text>
-      </Pressable>
-    </Card>
   );
 }
 
 const makeStyles = (c: Palette) =>
   StyleSheet.create({
-    // successSurface/successBorder tokens are green — match the intent of the original #f0fdf9/#bbf7e4
-    infoCard: { backgroundColor: c.successSurface, borderColor: c.successBorder },
-    infoText: { fontSize: 14, color: c.successFg, lineHeight: 20 },
-    question: {
-      fontSize: 16,
-      fontWeight: "600",
-      color: c.text,
-      lineHeight: 22,
-    },
-    scoreRow: {
-      flexDirection: "row",
-      flexWrap: "wrap",
-      gap: 8,
-      justifyContent: "center",
-      paddingVertical: 4,
-    },
-    scoreOption: {
-      alignItems: "center",
-      padding: 10,
-      borderRadius: 12,
-      borderWidth: 1,
-      borderColor: c.border,
-      minWidth: 60,
-      gap: 4,
-    },
-    scoreOptionOn: {
-      borderColor: c.brand,
-      backgroundColor: c.secondary,
-    },
-    scoreEmoji: { fontSize: 28 },
-    scoreLabel: { fontSize: 11, color: c.subtext, textAlign: "center" },
-    scoreLabelOn: { color: c.brand, fontWeight: "600" },
-    noteInput: {
-      borderWidth: 1,
-      borderColor: c.border,
+    subtitle: { fontSize: 14, color: c.muted, fontFamily: fonts.body, lineHeight: 20 },
+    disclaimer: { fontSize: 13, color: c.infoFg, fontFamily: fonts.body, lineHeight: 19 },
+    formTitle: { fontSize: 16, color: c.text, fontFamily: fonts.semibold, marginTop: 4 },
+    question: { fontSize: 15, color: c.text, fontFamily: fonts.medium, lineHeight: 21 },
+    scaleRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, marginTop: 4 },
+    scaleChip: {
+      flexGrow: 1,
+      paddingVertical: 9,
+      paddingHorizontal: 10,
       borderRadius: 10,
-      padding: 12,
-      fontSize: 15,
-      color: c.text,
-      backgroundColor: c.card,
-      textAlignVertical: "top",
-      minHeight: 72,
+      borderWidth: 1,
+      borderColor: c.border,
+      alignItems: "center",
     },
-    historyTitle: {
-      fontSize: 14,
-      fontWeight: "600",
-      color: c.subtext,
-      marginBottom: 4,
+    scaleChipOn: { backgroundColor: c.brand, borderColor: c.brand },
+    scaleText: { fontSize: 13, color: c.subtext, fontFamily: fonts.medium },
+    scaleTextOn: { color: "#fff", fontFamily: fonts.semibold },
+    score: { fontSize: 15, color: c.text, fontFamily: fonts.bold },
+    zoneTitle: { fontSize: 16, color: c.text, fontFamily: fonts.semibold },
+    zoneBody: { fontSize: 14, color: c.subtext, fontFamily: fonts.body, lineHeight: 21 },
+    supportTitle: { fontSize: 16, color: c.text, fontFamily: fonts.semibold },
+    supportBody: { fontSize: 13, color: c.muted, fontFamily: fonts.body, lineHeight: 19 },
+    supportRow: {
+      paddingVertical: 8,
+      borderTopWidth: StyleSheet.hairlineWidth,
+      borderTopColor: c.border,
     },
-    historyRow: { flexDirection: "row", gap: 10, flexWrap: "wrap" },
-    historyDot: { alignItems: "center", gap: 2 },
-    historyEmoji: { fontSize: 20 },
-    historyDate: { fontSize: 10, color: c.muted },
-    // Result zone cards — themed semantic surfaces (adapt to dark mode)
-    zoneCardLow: { borderColor: c.dangerBorder, backgroundColor: c.dangerSurface },
-    zoneCardMid: { borderColor: c.alertBorder, backgroundColor: c.alertSurface },
-    zoneCardHigh: { borderColor: c.successBorder, backgroundColor: c.successSurface },
-    zoneEmoji: { fontSize: 40, textAlign: "center" },
-    zoneTitle: {
-      fontSize: 17,
-      fontWeight: "700",
-      color: c.text,
-      textAlign: "center",
-    },
-    zoneBody: {
-      fontSize: 14,
-      color: c.subtext,
-      lineHeight: 20,
-      textAlign: "center",
-    },
-    zoneNote: {
-      fontSize: 13,
-      color: c.muted,
-      fontStyle: "italic",
-      textAlign: "center",
-    },
-    retakeBtn: { alignSelf: "center", paddingVertical: 4 },
-    retakeText: { color: c.action, fontSize: 14 },
+    supportLink: { fontSize: 15, color: c.brand, fontFamily: fonts.semibold },
+    supportHint: { fontSize: 12, color: c.muted, fontFamily: fonts.body, marginTop: 1 },
   });

--- a/apps/mobile/src/screens/CalmMinutesScreen.tsx
+++ b/apps/mobile/src/screens/CalmMinutesScreen.tsx
@@ -1,4 +1,5 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
+import * as WebBrowser from "expo-web-browser";
 import { StyleSheet, Text, View } from "react-native";
 import { Leaf } from "lucide-react-native";
 
@@ -10,9 +11,15 @@ import {
   ScreenHeader,
   fonts,
 } from "../components/ui";
+import {
+  PeriodSwitcher,
+  type StatsPeriod,
+} from "../components/period-switcher";
 import { calmMinutes as copy } from "../lib/copy";
 import { useCalmMinutes } from "../hooks/use-stats";
+import { usePremium } from "../hooks/use-billing";
 import { useTheme, type Palette } from "../lib/theme";
+import { WEB_URL } from "../lib/config";
 import type { CalmMinutesProps } from "../navigation/types";
 
 // Business rule H1: the north-star KPI — minutes of calm earned, shown over the
@@ -58,7 +65,9 @@ function last7Days(byDate: Map<string, number>): Day[] {
 
 export function CalmMinutesScreen({ navigation, route }: CalmMinutesProps) {
   const { childId, childName } = route.params;
-  const { data, isLoading } = useCalmMinutes(childId, "week");
+  const [period, setPeriod] = useState<StatsPeriod>("week");
+  const { data, isLoading } = useCalmMinutes(childId, period);
+  const { isPremium } = usePremium();
   const c = useTheme();
   const styles = useMemo(() => makeStyles(c), [c]);
 
@@ -82,6 +91,13 @@ export function CalmMinutesScreen({ navigation, route }: CalmMinutesProps) {
         onBack={goBack}
       />
 
+      <PeriodSwitcher
+        value={period}
+        onChange={setPeriod}
+        isPremium={isPremium}
+        onLocked={() => WebBrowser.openBrowserAsync(`${WEB_URL}/abonnement`)}
+      />
+
       {isLoading || !data ? (
         <Loader />
       ) : (
@@ -89,7 +105,9 @@ export function CalmMinutesScreen({ navigation, route }: CalmMinutesProps) {
           <Card style={styles.hero}>
             <View style={styles.headRow}>
               <Leaf size={16} color={c.success} />
-              <Text style={styles.weekLabel}>{copy.weekLabel}</Text>
+              <Text style={styles.weekLabel}>
+                {data.periodDays} derniers jours
+              </Text>
             </View>
 
             <Text style={styles.total}>{copy.total(data.totalMinutes)}</Text>
@@ -99,6 +117,7 @@ export function CalmMinutesScreen({ navigation, route }: CalmMinutesProps) {
                 : copy.empty}
             </Text>
 
+            {period === "week" ? (
             <View style={styles.chart}>
               {days.map((d) => {
                 const ratio = cap ? Math.min(d.minutes / cap, 1) : 0;
@@ -128,6 +147,7 @@ export function CalmMinutesScreen({ navigation, route }: CalmMinutesProps) {
                 );
               })}
             </View>
+            ) : null}
           </Card>
 
           <CalloutCard

--- a/apps/mobile/src/screens/CompanionCollectionScreen.tsx
+++ b/apps/mobile/src/screens/CompanionCollectionScreen.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+import { Loader, Screen, ScreenHeader, fonts } from "../components/ui";
+import { timer as copy } from "../lib/copy";
+import { CRITTER_CATALOG } from "../lib/critters";
+import { useTheme, type Palette } from "../lib/theme";
+import { useCompanions } from "../hooks/use-companions";
+import type { CompanionCollectionProps } from "../navigation/types";
+
+// The child's critter collection: every catalog animal, discovered ones in
+// colour, the rest as a muted "à découvrir" silhouette. Mirrors the PWA
+// CompanionCollection — a gentle, no-pressure reward mirror.
+export function CompanionCollectionScreen({
+  navigation,
+  route,
+}: CompanionCollectionProps) {
+  const { childId, childName } = route.params;
+  const c = useTheme();
+  const styles = useMemo(() => makeStyles(c), [c]);
+
+  const { data, isLoading } = useCompanions(childId);
+  const discovered = useMemo(
+    () => new Set((data ?? []).map((d) => d.animalId)),
+    [data],
+  );
+
+  return (
+    <Screen scroll>
+      <ScreenHeader
+        title={copy.collectionTitle}
+        subtitle={childName}
+        onBack={() => navigation.goBack()}
+      />
+      {isLoading ? (
+        <Loader />
+      ) : (
+        <>
+          <Text style={styles.intro}>{copy.collectionIntro(discovered.size)}</Text>
+          <View style={styles.grid}>
+            {CRITTER_CATALOG.map((cr) => {
+              const found = discovered.has(cr.id);
+              return (
+                <View
+                  key={cr.id}
+                  style={[styles.cell, found ? styles.cellFound : styles.cellLocked]}
+                >
+                  <Text style={[styles.emoji, !found && styles.emojiLocked]}>
+                    {found ? cr.emoji : "❔"}
+                  </Text>
+                  <Text style={[styles.name, !found && styles.nameLocked]}>
+                    {found ? cr.name : copy.collectionLocked}
+                  </Text>
+                </View>
+              );
+            })}
+          </View>
+        </>
+      )}
+    </Screen>
+  );
+}
+
+const makeStyles = (c: Palette) =>
+  StyleSheet.create({
+    intro: { fontSize: 14, color: c.muted, fontFamily: fonts.body, lineHeight: 20 },
+    grid: { flexDirection: "row", flexWrap: "wrap", gap: 12, marginTop: 4 },
+    cell: {
+      width: "47%",
+      flexGrow: 1,
+      borderRadius: 14,
+      borderWidth: 1,
+      paddingVertical: 20,
+      alignItems: "center",
+      gap: 8,
+    },
+    cellFound: { backgroundColor: c.card, borderColor: c.brand },
+    cellLocked: { backgroundColor: c.bg, borderColor: c.border, borderStyle: "dashed" },
+    emoji: { fontSize: 44 },
+    emojiLocked: { opacity: 0.4 },
+    name: { fontSize: 14, color: c.text, fontFamily: fonts.semibold },
+    nameLocked: { color: c.muted, fontFamily: fonts.medium },
+  });

--- a/apps/mobile/src/screens/CrisisListScreen.tsx
+++ b/apps/mobile/src/screens/CrisisListScreen.tsx
@@ -10,13 +10,15 @@ import {
   View,
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
-import { Trash2 } from "lucide-react-native";
+import { Pencil, Trash2 } from "lucide-react-native";
+import type { CrisisItem } from "@focusflow/validators";
 
 import { CRISIS_EMOJIS, crisis as copy } from "../lib/copy";
 import {
   useCreateCrisisItem,
   useCrisisItems,
   useDeleteCrisisItem,
+  useUpdateCrisisItem,
 } from "../hooks/use-crisis-list";
 import { confirmDelete, fonts } from "../components/ui";
 import { useTheme, type Palette } from "../lib/theme";
@@ -32,31 +34,50 @@ export function CrisisListScreen({ navigation, route }: CrisisListProps) {
   const { childId, childName } = route.params;
   const { data: items, isLoading } = useCrisisItems(childId);
   const createItem = useCreateCrisisItem();
+  const updateItem = useUpdateCrisisItem();
   const deleteItem = useDeleteCrisisItem();
   const c = useTheme();
   const styles = useMemo(() => makeStyles(c), [c]);
 
   const [composing, setComposing] = useState(false);
+  const [editing, setEditing] = useState<CrisisItem | null>(null);
   const [label, setLabel] = useState("");
   const [emoji, setEmoji] = useState(CRISIS_EMOJIS[0]);
   const [crisisMode, setCrisisMode] = useState(false);
   const [index, setIndex] = useState(0);
 
   const list = items ?? [];
+  const isEditing = !!editing;
+  const pending = createItem.isPending || updateItem.isPending;
+
+  function closeComposer() {
+    setLabel("");
+    setEmoji(CRISIS_EMOJIS[0]);
+    setEditing(null);
+    setComposing(false);
+  }
+
+  function startEdit(item: CrisisItem) {
+    setEditing(item);
+    setLabel(item.label);
+    setEmoji(item.emoji ?? CRISIS_EMOJIS[0]);
+    setComposing(true);
+  }
 
   function submit() {
     const trimmed = label.trim();
     if (!trimmed) return;
-    createItem.mutate(
-      { childId, label: trimmed, emoji },
-      {
-        onSuccess: () => {
-          setLabel("");
-          setEmoji(CRISIS_EMOJIS[0]);
-          setComposing(false);
-        },
-      },
-    );
+    if (isEditing && editing) {
+      updateItem.mutate(
+        { id: editing.id, childId, label: trimmed, emoji },
+        { onSuccess: closeComposer },
+      );
+    } else {
+      createItem.mutate(
+        { childId, label: trimmed, emoji },
+        { onSuccess: closeComposer },
+      );
+    }
   }
 
   // Full-screen calm carousel for an active meltdown.
@@ -128,6 +149,9 @@ export function CrisisListScreen({ navigation, route }: CrisisListProps) {
 
       {composing ? (
         <View style={styles.composer}>
+          <Text style={styles.composerTitle}>
+            {isEditing ? "Modifier l'élément" : copy.add}
+          </Text>
           <View style={styles.emojiRow}>
             {CRISIS_EMOJIS.map((e) => (
               <Pressable
@@ -148,15 +172,17 @@ export function CrisisListScreen({ navigation, route }: CrisisListProps) {
             autoFocus
           />
           <View style={styles.composerActions}>
-            <Pressable onPress={() => setComposing(false)}>
+            <Pressable onPress={closeComposer}>
               <Text style={styles.cancel}>{copy.cancel}</Text>
             </Pressable>
             <Pressable
-              style={[styles.button, createItem.isPending && styles.disabled]}
-              disabled={createItem.isPending}
+              style={[styles.button, pending && styles.disabled]}
+              disabled={pending}
               onPress={submit}
             >
-              <Text style={styles.buttonText}>{copy.addToList}</Text>
+              <Text style={styles.buttonText}>
+                {isEditing ? "Enregistrer" : copy.addToList}
+              </Text>
             </Pressable>
           </View>
         </View>
@@ -176,17 +202,30 @@ export function CrisisListScreen({ navigation, route }: CrisisListProps) {
               <View key={item.id} style={styles.card}>
                 <Text style={styles.cardEmoji}>{item.emoji ?? "💙"}</Text>
                 <Text style={styles.cardLabel}>{item.label}</Text>
-                <Pressable
-                  onPress={() =>
-                    confirmDelete(() => deleteItem.mutate({ id: item.id, childId }))
-                  }
-                  style={styles.iconBtn}
-                  accessibilityRole="button"
-                  accessibilityLabel="Supprimer cet élément"
-                  hitSlop={8}
-                >
-                  <Trash2 size={18} color={c.muted} />
-                </Pressable>
+                <View style={styles.cardActions}>
+                  <Pressable
+                    onPress={() => startEdit(item)}
+                    style={styles.iconBtn}
+                    accessibilityRole="button"
+                    accessibilityLabel="Modifier cet élément"
+                    hitSlop={8}
+                  >
+                    <Pencil size={18} color={c.muted} />
+                  </Pressable>
+                  <Pressable
+                    onPress={() =>
+                      confirmDelete(() =>
+                        deleteItem.mutate({ id: item.id, childId }),
+                      )
+                    }
+                    style={styles.iconBtn}
+                    accessibilityRole="button"
+                    accessibilityLabel="Supprimer cet élément"
+                    hitSlop={8}
+                  >
+                    <Trash2 size={18} color={c.muted} />
+                  </Pressable>
+                </View>
               </View>
             ))
           )}
@@ -229,6 +268,7 @@ const makeStyles = (c: Palette) =>
       padding: 16,
       backgroundColor: c.card,
     },
+    composerTitle: { fontSize: 16, fontFamily: fonts.semibold, color: c.text },
     emojiRow: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
     emojiChip: {
       width: 44,
@@ -281,7 +321,8 @@ const makeStyles = (c: Palette) =>
     },
     cardEmoji: { fontSize: 24 },
     cardLabel: { flex: 1, fontSize: 16, color: c.text, fontFamily: fonts.body },
-    iconBtn: { width: 44, height: 44, alignItems: "center", justifyContent: "center", marginRight: -10 },
+    cardActions: { flexDirection: "row", alignItems: "center", marginRight: -10 },
+    iconBtn: { width: 44, height: 44, alignItems: "center", justifyContent: "center" },
     support: {
       marginTop: 12,
       gap: 8,

--- a/apps/mobile/src/screens/InsightsScreen.tsx
+++ b/apps/mobile/src/screens/InsightsScreen.tsx
@@ -1,5 +1,5 @@
 import * as WebBrowser from "expo-web-browser";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
 
 import {
@@ -11,10 +11,21 @@ import {
   Screen,
   ScreenHeader,
 } from "../components/ui";
+import {
+  PeriodSwitcher,
+  type StatsPeriod,
+} from "../components/period-switcher";
 import { useTheme, type Palette } from "../lib/theme";
 import { useCorrelations, useInsights } from "../hooks/use-insights";
+import { usePremium } from "../hooks/use-billing";
 import { WEB_URL } from "../lib/config";
 import type { InsightsProps } from "../navigation/types";
+
+const PERIOD_TITLE: Record<StatsPeriod, string> = {
+  week: "Cette semaine",
+  month: "Ce mois",
+  quarter: "Ce trimestre",
+};
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -116,8 +127,10 @@ function MoodGrid({
 
 export function InsightsScreen({ navigation, route }: InsightsProps) {
   const { childId, childName } = route.params;
-  const stats = useInsights(childId, "week");
+  const [period, setPeriod] = useState<StatsPeriod>("week");
+  const stats = useInsights(childId, period);
   const correlations = useCorrelations(childId);
+  const { isPremium } = usePremium();
   const c = useTheme();
   const styles = useMemo(() => makeStyles(c), [c]);
 
@@ -131,6 +144,13 @@ export function InsightsScreen({ navigation, route }: InsightsProps) {
         title="Aperçu"
         subtitle={childName}
         onBack={() => navigation.goBack()}
+      />
+
+      <PeriodSwitcher
+        value={period}
+        onChange={setPeriod}
+        isPremium={isPremium}
+        onLocked={() => WebBrowser.openBrowserAsync(`${WEB_URL}/abonnement`)}
       />
 
       {isLoading ? (
@@ -159,9 +179,9 @@ export function InsightsScreen({ navigation, route }: InsightsProps) {
             </Text>
           </Card>
 
-          {/* Suivi cette semaine */}
+          {/* Suivi sur la période */}
           <Card>
-            <Text style={styles.sectionTitle}>Cette semaine</Text>
+            <Text style={styles.sectionTitle}>{PERIOD_TITLE[period]}</Text>
             <StatRow
               label="Observations enregistrées"
               value={String(data.symptoms.length)}

--- a/apps/mobile/src/screens/JournalScreen.tsx
+++ b/apps/mobile/src/screens/JournalScreen.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState } from "react";
-import type { JournalTag } from "@focusflow/validators";
+import type { JournalEntry, JournalTag } from "@focusflow/validators";
 import { journalTagSchema } from "@focusflow/validators";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
-import { Plus, Trash2 } from "lucide-react-native";
+import { Pencil, Plus, Trash2 } from "lucide-react-native";
 
 import { journal as copy, journalTagLabels } from "../lib/copy";
 import { formatFrDate, todayISO } from "../lib/date";
@@ -24,6 +24,7 @@ import {
   useCreateJournalEntry,
   useDeleteJournalEntry,
   useJournal,
+  useUpdateJournalEntry,
 } from "../hooks/use-journal";
 import { useActiveChild } from "../lib/active-child";
 import {
@@ -56,12 +57,17 @@ export function JournalScreen({ route }: JournalProps) {
   const styles = useMemo(() => makeStyles(c), [c]);
 
   const createEntry = useCreateJournalEntry();
+  const updateEntry = useUpdateJournalEntry();
   const deleteEntry = useDeleteJournalEntry();
 
   const [filterTag, setFilterTag] = useState<string>("all");
   const [composing, setComposing] = useState(false);
+  const [editing, setEditing] = useState<JournalEntry | null>(null);
   const [text, setText] = useState("");
   const [tags, setTags] = useState<JournalTag[]>([]);
+
+  const isEditing = !!editing;
+  const pending = createEntry.isPending || updateEntry.isPending;
 
   const visible = (entries ?? []).filter(
     (e) => filterTag === "all" || e.tags.includes(filterTag as JournalTag),
@@ -73,17 +79,32 @@ export function JournalScreen({ route }: JournalProps) {
     );
   }
 
+  function closeComposer() {
+    setText("");
+    setTags([]);
+    setEditing(null);
+    setComposing(false);
+  }
+
+  function startEdit(entry: JournalEntry) {
+    setEditing(entry);
+    setText(entry.text);
+    setTags(entry.tags);
+    setComposing(true);
+  }
+
   function submit() {
-    createEntry.mutate(
-      { childId, date: todayISO(), text: text.trim(), tags },
-      {
-        onSuccess: () => {
-          setText("");
-          setTags([]);
-          setComposing(false);
-        },
-      },
-    );
+    if (isEditing && editing) {
+      updateEntry.mutate(
+        { id: editing.id, childId, text: text.trim(), tags },
+        { onSuccess: closeComposer },
+      );
+    } else {
+      createEntry.mutate(
+        { childId, date: todayISO(), text: text.trim(), tags },
+        { onSuccess: closeComposer },
+      );
+    }
   }
 
   return (
@@ -103,6 +124,9 @@ export function JournalScreen({ route }: JournalProps) {
 
       {composing ? (
         <Card>
+          <Text style={styles.formTitle}>
+            {isEditing ? "Modifier l'entrée" : copy.title}
+          </Text>
           <TextInput
             style={styles.input}
             placeholder={copy.notesPlaceholder}
@@ -129,16 +153,19 @@ export function JournalScreen({ route }: JournalProps) {
             })}
           </View>
           <View style={styles.composerActions}>
-            <Pressable
-              onPress={() => setComposing(false)}
-              style={styles.cancelHit}
-            >
+            <Pressable onPress={closeComposer} style={styles.cancelHit}>
               <Text style={styles.cancel}>{copy.cancel}</Text>
             </Pressable>
             <Button
-              label={createEntry.isPending ? copy.saving : copy.addEntry}
+              label={
+                pending
+                  ? copy.saving
+                  : isEditing
+                    ? "Enregistrer"
+                    : copy.addEntry
+              }
               onPress={submit}
-              loading={createEntry.isPending}
+              loading={pending}
               disabled={!text.trim()}
               size="sm"
             />
@@ -164,19 +191,30 @@ export function JournalScreen({ route }: JournalProps) {
           <Card key={item.id}>
             <View style={styles.cardHead}>
               <Text style={styles.cardDate}>{relativeDate(item.date)}</Text>
-              <Pressable
-                onPress={() =>
-                  confirmDelete(() =>
-                    deleteEntry.mutate({ id: item.id, childId }),
-                  )
-                }
-                style={styles.iconBtn}
-                accessibilityRole="button"
-                accessibilityLabel="Supprimer l'entrée"
-                hitSlop={8}
-              >
-                <Trash2 size={18} color={c.muted} />
-              </Pressable>
+              <View style={styles.cardActions}>
+                <Pressable
+                  onPress={() => startEdit(item)}
+                  style={styles.iconBtn}
+                  accessibilityRole="button"
+                  accessibilityLabel="Modifier l'entrée"
+                  hitSlop={8}
+                >
+                  <Pencil size={18} color={c.muted} />
+                </Pressable>
+                <Pressable
+                  onPress={() =>
+                    confirmDelete(() =>
+                      deleteEntry.mutate({ id: item.id, childId }),
+                    )
+                  }
+                  style={styles.iconBtn}
+                  accessibilityRole="button"
+                  accessibilityLabel="Supprimer l'entrée"
+                  hitSlop={8}
+                >
+                  <Trash2 size={18} color={c.muted} />
+                </Pressable>
+              </View>
             </View>
             {item.text ? <Text style={styles.cardText}>{item.text}</Text> : null}
             {item.tags.length > 0 ? (
@@ -211,6 +249,7 @@ const makeStyles = (c: Palette) =>
       backgroundColor: c.bg,
       fontFamily: fonts.body,
     },
+    formTitle: { fontSize: 16, fontFamily: fonts.semibold, color: c.text },
     tagRow: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
     tag: {
       borderWidth: 1,
@@ -241,13 +280,12 @@ const makeStyles = (c: Palette) =>
       textTransform: "capitalize",
       fontFamily: fonts.semibold,
     },
+    cardActions: { flexDirection: "row", alignItems: "center", marginTop: -10 },
     iconBtn: {
       width: 44,
       height: 44,
       alignItems: "center",
       justifyContent: "center",
-      marginRight: -10,
-      marginTop: -10,
     },
     cardText: { fontSize: 15, color: c.text, fontFamily: fonts.body, lineHeight: 22 },
     cardTag: {

--- a/apps/mobile/src/screens/StrengthsScreen.tsx
+++ b/apps/mobile/src/screens/StrengthsScreen.tsx
@@ -1,7 +1,7 @@
-import type { StrengthCategory } from "@focusflow/validators";
+import type { Strength, StrengthCategory } from "@focusflow/validators";
 import { useMemo, useState } from "react";
 import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
-import { Trash2 } from "lucide-react-native";
+import { Pencil, Trash2 } from "lucide-react-native";
 
 import {
   Card,
@@ -18,6 +18,7 @@ import {
   useCreateStrength,
   useDeleteStrength,
   useStrengths,
+  useUpdateStrength,
 } from "../hooks/use-strengths";
 import type { StrengthsProps } from "../navigation/types";
 
@@ -42,38 +43,79 @@ export function StrengthsScreen({ navigation, route }: StrengthsProps) {
   const { childId, childName } = route.params;
   const list = useStrengths(childId);
   const create = useCreateStrength(childId);
+  const update = useUpdateStrength(childId);
   const remove = useDeleteStrength(childId);
 
   const c = useTheme();
   const styles = useMemo(() => makeStyles(c), [c]);
 
   const [adding, setAdding] = useState(false);
+  const [editing, setEditing] = useState<Strength | null>(null);
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
   const [emoji, setEmoji] = useState("");
   const [category, setCategory] = useState<StrengthCategory>("talent");
 
+  const isEditing = !!editing;
+  const pending = create.isPending || update.isPending;
+
+  function reset() {
+    setEditing(null);
+    setTitle("");
+    setDescription("");
+    setEmoji("");
+    setCategory("talent");
+    setAdding(false);
+  }
+
+  function startCreate() {
+    if (adding && !isEditing) {
+      reset();
+    } else {
+      setEditing(null);
+      setTitle("");
+      setDescription("");
+      setEmoji("");
+      setCategory("talent");
+      setAdding(true);
+    }
+  }
+
+  function startEdit(s: Strength) {
+    setEditing(s);
+    setTitle(s.title);
+    setDescription(s.description ?? "");
+    setEmoji(s.emoji ?? "");
+    setCategory(s.category);
+    setAdding(true);
+  }
+
   function submit() {
     if (!title.trim()) return;
-    create.mutate(
-      {
-        childId,
-        category,
-        title: title.trim(),
-        description: description.trim() || undefined,
-        emoji: emoji.trim() || undefined,
-        occurredOn: todayISO(),
-      },
-      {
-        onSuccess: () => {
-          setTitle("");
-          setDescription("");
-          setEmoji("");
-          setCategory("talent");
-          setAdding(false);
+    if (isEditing && editing) {
+      update.mutate(
+        {
+          id: editing.id,
+          category,
+          title: title.trim(),
+          description: description.trim() || undefined,
+          emoji: emoji.trim() || undefined,
         },
-      },
-    );
+        { onSuccess: reset },
+      );
+    } else {
+      create.mutate(
+        {
+          childId,
+          category,
+          title: title.trim(),
+          description: description.trim() || undefined,
+          emoji: emoji.trim() || undefined,
+          occurredOn: todayISO(),
+        },
+        { onSuccess: reset },
+      );
+    }
   }
 
   return (
@@ -83,14 +125,19 @@ export function StrengthsScreen({ navigation, route }: StrengthsProps) {
         subtitle={childName}
         onBack={() => navigation.goBack()}
         right={
-          <Pressable onPress={() => setAdding((v) => !v)} hitSlop={10}>
-            <Text style={styles.add}>{adding ? "Fermer" : "+ Ajouter"}</Text>
+          <Pressable onPress={startCreate} hitSlop={10}>
+            <Text style={styles.add}>
+              {adding && !isEditing ? "Fermer" : "+ Ajouter"}
+            </Text>
           </Pressable>
         }
       />
 
       {adding ? (
         <Card>
+          <Text style={styles.formTitle}>
+            {isEditing ? "Modifier la force" : "Nouvelle force"}
+          </Text>
           <TextInput
             style={styles.input}
             placeholder="Ce qu'il ou elle fait bien"
@@ -130,15 +177,20 @@ export function StrengthsScreen({ navigation, route }: StrengthsProps) {
               );
             })}
           </View>
-          {create.isError ? (
-            <ErrorNote message="Impossible d'ajouter cette force." />
+          {create.isError || update.isError ? (
+            <ErrorNote message="Impossible d'enregistrer cette force." />
           ) : null}
           <PrimaryButton
-            label="Ajouter"
+            label={isEditing ? "Enregistrer" : "Ajouter"}
             onPress={submit}
-            loading={create.isPending}
+            loading={pending}
             disabled={!title.trim()}
           />
+          {isEditing ? (
+            <Pressable onPress={reset} style={styles.cancelRow}>
+              <Text style={styles.cancelText}>Annuler</Text>
+            </Pressable>
+          ) : null}
         </Card>
       ) : null}
 
@@ -157,15 +209,26 @@ export function StrengthsScreen({ navigation, route }: StrengthsProps) {
                   {categoryLabel(s.category)}
                 </Text>
               </View>
-              <Pressable
-                onPress={() => confirmDelete(() => remove.mutate(s.id))}
-                style={styles.iconBtn}
-                accessibilityRole="button"
-                accessibilityLabel="Supprimer cette force"
-                hitSlop={8}
-              >
-                <Trash2 size={18} color={c.muted} />
-              </Pressable>
+              <View style={styles.cardActions}>
+                <Pressable
+                  onPress={() => startEdit(s)}
+                  style={styles.iconBtn}
+                  accessibilityRole="button"
+                  accessibilityLabel="Modifier cette force"
+                  hitSlop={8}
+                >
+                  <Pencil size={18} color={c.muted} />
+                </Pressable>
+                <Pressable
+                  onPress={() => confirmDelete(() => remove.mutate(s.id))}
+                  style={styles.iconBtn}
+                  accessibilityRole="button"
+                  accessibilityLabel="Supprimer cette force"
+                  hitSlop={8}
+                >
+                  <Trash2 size={18} color={c.muted} />
+                </Pressable>
+              </View>
             </View>
             {s.description ? (
               <Text style={styles.description}>{s.description}</Text>
@@ -185,6 +248,7 @@ export function StrengthsScreen({ navigation, route }: StrengthsProps) {
 const makeStyles = (c: Palette) =>
   StyleSheet.create({
     add: { color: c.action, fontSize: 16, fontWeight: "600" },
+    formTitle: { fontSize: 16, fontWeight: "600", color: c.text },
     input: {
       borderWidth: 1,
       borderColor: c.border,
@@ -210,7 +274,10 @@ const makeStyles = (c: Palette) =>
     pillText: { color: c.subtext },
     pillTextOn: { color: "#fff", fontWeight: "600" },
     cardHead: { flexDirection: "row", alignItems: "center", gap: 12 },
-    iconBtn: { width: 44, height: 44, alignItems: "center", justifyContent: "center", marginRight: -10 },
+    cardActions: { flexDirection: "row", alignItems: "center", marginRight: -10 },
+    cancelRow: { alignItems: "center", paddingVertical: 8 },
+    cancelText: { color: c.muted },
+    iconBtn: { width: 44, height: 44, alignItems: "center", justifyContent: "center" },
     cardEmoji: { fontSize: 28 },
     cardBody: { flex: 1 },
     name: { fontSize: 17, fontWeight: "600", color: c.text },

--- a/apps/mobile/src/screens/TimerScreen.tsx
+++ b/apps/mobile/src/screens/TimerScreen.tsx
@@ -1,13 +1,26 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Pressable, StyleSheet, Text, Vibration, View } from "react-native";
 import Svg, { Circle } from "react-native-svg";
-import { Check, ChevronRight, Pause, Play, RotateCcw, Zap } from "lucide-react-native";
+import {
+  Check,
+  ChevronRight,
+  Egg,
+  EggOff,
+  Pause,
+  PawPrint,
+  Play,
+  RotateCcw,
+  Zap,
+} from "lucide-react-native";
 
-import { Button, Screen, ScreenHeader, fonts } from "../components/ui";
+import { Button, CalloutCard, Screen, ScreenHeader, fonts } from "../components/ui";
 import { timer as copy } from "../lib/copy";
 import { todayISO } from "../lib/date";
 import { useTheme, type Palette } from "../lib/theme";
+import { useActiveChild } from "../lib/active-child";
+import { pickCritter, type Critter } from "../lib/critters";
 import { useCompleteStep } from "../hooks/use-routines";
+import { useRecordCompanion } from "../hooks/use-companions";
 import type { TimerProps } from "../navigation/types";
 
 // React Native port of the PWA visual timer (apps/web/src/components/timer).
@@ -39,6 +52,17 @@ export function TimerScreen({ navigation, route }: TimerProps) {
 
   const seq = route.params?.sequence;
   const completeStep = useCompleteStep();
+
+  // Child scope for companions: explicit (sequence) or the active child (free).
+  const activeChild = useActiveChild().active;
+  const childId = seq?.childId ?? activeChild?.id ?? "";
+  const childName = activeChild?.name ?? "";
+  const recordCompanion = useRecordCompanion(childId);
+
+  // Companion reward (collectible critters that hatch when a timer finishes).
+  const [companionEnabled, setCompanionEnabled] = useState(true);
+  const [revealed, setRevealed] = useState<Critter | null>(null);
+  const revealedRef = useRef(false);
 
   // Sequence position (sequence mode only).
   const [stepIndex, setStepIndex] = useState(0);
@@ -93,11 +117,17 @@ export function TimerScreen({ navigation, route }: TimerProps) {
     return clear;
   }, [running, clear, seq, finishStep]);
 
+  function clearReveal() {
+    revealedRef.current = false;
+    setRevealed(null);
+  }
+
   function selectDuration(sec: number) {
     clear();
     setRunning(false);
     setDurationSec(sec);
     setRemainingSec(sec);
+    clearReveal();
   }
 
   function toggleSpeedUp() {
@@ -108,6 +138,7 @@ export function TimerScreen({ navigation, route }: TimerProps) {
 
   function toggleRun() {
     if (remainingSec === 0 && !seq) {
+      clearReveal();
       setRemainingSec(durationSec);
       setRunning(true);
       return;
@@ -119,6 +150,7 @@ export function TimerScreen({ navigation, route }: TimerProps) {
     clear();
     setRunning(false);
     setRemainingSec(durationSec);
+    clearReveal();
   }
 
   // Advance to the next sequence step and auto-start it.
@@ -145,16 +177,43 @@ export function TimerScreen({ navigation, route }: TimerProps) {
 
   const dialColor = isFinished ? c.success : almostDone ? c.danger : c.brand;
 
+  // Hatch a companion once a timer (free) or the whole sequence completes.
+  useEffect(() => {
+    const done = seq ? finished : isFinished;
+    if (!done || revealedRef.current || !companionEnabled || !childId) return;
+    revealedRef.current = true;
+    const cr = pickCritter();
+    setRevealed(cr);
+    recordCompanion.mutate({ childId, animalId: cr.id });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [seq, finished, isFinished, companionEnabled, childId]);
+
+  const goCollection = () =>
+    navigation.navigate("CompanionCollection", { childId, childName });
+
   // ── Sequence finished screen ───────────────────────────────────────────
   if (seq && finished) {
     return (
       <Screen>
         <ScreenHeader title={seq.name} onBack={() => navigation.goBack()} />
         <View style={styles.finishWrap}>
-          <View style={styles.finishBadge}>
-            <Check size={40} color="#fff" />
-          </View>
-          <Text style={styles.finishTitle}>{copy.sequenceFinished}</Text>
+          {revealed ? (
+            <>
+              <Text style={styles.revealEmoji}>{revealed.emoji}</Text>
+              <Text style={styles.finishTitle}>{copy.sequenceFinished}</Text>
+              <Text style={styles.revealName}>
+                {copy.companionNew} {revealed.name}
+              </Text>
+              <Button label={copy.viewCollection} onPress={goCollection} />
+            </>
+          ) : (
+            <>
+              <View style={styles.finishBadge}>
+                <Check size={40} color="#fff" />
+              </View>
+              <Text style={styles.finishTitle}>{copy.sequenceFinished}</Text>
+            </>
+          )}
           <Button label={copy.quitSequence} variant="secondary" onPress={() => navigation.goBack()} />
         </View>
       </Screen>
@@ -228,6 +287,20 @@ export function TimerScreen({ navigation, route }: TimerProps) {
         </View>
       </View>
 
+      {/* Companion reveal — free mode */}
+      {revealed && !seq ? (
+        <CalloutCard
+          variant="success"
+          label={copy.companionNew}
+          icon={<Text style={styles.revealIcon}>{revealed.emoji}</Text>}
+        >
+          <Text style={styles.revealName}>{revealed.name}</Text>
+          <Pressable onPress={goCollection} accessibilityRole="button">
+            <Text style={styles.collectionLink}>{copy.viewCollection} ›</Text>
+          </Pressable>
+        </CalloutCard>
+      ) : null}
+
       {/* Primary control */}
       {stepCompleted && seq ? (
         <Button
@@ -270,6 +343,33 @@ export function TimerScreen({ navigation, route }: TimerProps) {
             </Text>
           </Pressable>
           {speedUp ? <Text style={styles.speedHint}>{copy.speedUpHint}</Text> : null}
+
+          {/* Companion controls */}
+          <Pressable
+            onPress={() => setCompanionEnabled((v) => !v)}
+            style={[styles.speedRow, companionEnabled && styles.companionRowOn]}
+            accessibilityRole="button"
+            accessibilityState={{ selected: companionEnabled }}
+          >
+            {companionEnabled ? (
+              <Egg size={16} color={c.infoFg} />
+            ) : (
+              <EggOff size={16} color={c.muted} />
+            )}
+            <Text style={[styles.speedText, companionEnabled && styles.companionTextOn]}>
+              {companionEnabled ? copy.companionOn : copy.companionOff}
+            </Text>
+          </Pressable>
+          {childId ? (
+            <Pressable
+              onPress={goCollection}
+              style={styles.collectionRow}
+              accessibilityRole="button"
+            >
+              <PawPrint size={15} color={c.muted} />
+              <Text style={styles.collectionLink}>{copy.viewCollection}</Text>
+            </Pressable>
+          ) : null}
         </>
       ) : null}
     </Screen>
@@ -338,4 +438,17 @@ const makeStyles = (c: Palette) =>
       justifyContent: "center",
     },
     finishTitle: { fontSize: 24, color: c.text, fontFamily: fonts.heading, textAlign: "center" },
+    revealEmoji: { fontSize: 88 },
+    revealIcon: { fontSize: 22 },
+    revealName: { fontSize: 16, color: c.text, fontFamily: fonts.semibold, textAlign: "center" },
+    companionRowOn: { backgroundColor: c.infoSurface, borderColor: c.infoBorder },
+    companionTextOn: { color: c.infoFg, fontFamily: fonts.semibold },
+    collectionRow: {
+      flexDirection: "row",
+      alignItems: "center",
+      justifyContent: "center",
+      gap: 6,
+      paddingVertical: 8,
+    },
+    collectionLink: { color: c.action, fontFamily: fonts.semibold, fontSize: 14 },
   });


### PR DESCRIPTION
Phase 2 de parité PWA. Typecheck + bundle OK (vérification appareil à suivre — téléphone indisponible au moment du merge).

- 🐾 **Compagnons du minuteur** : 10 animaux, éclosion à la fin d'un minuteur/routine (POST /companions), toggle on/off, écran « Mes compagnons » (collection).
- ✏️ **Édition** inline (crayon → PATCH) sur **Journal**, **Forces**, **Liste de crise**.
- 📊 **Sélecteur de période** (Semaine/Mois/Trimestre) sur **Insights** et **Minutes de calme**, avec **verrou premium** (Mois/Trimestre) → /abonnement, comme le web.
- 🔋 **« Mon énergie de parent »** : remplace le doublon du logger d'humeur par le **questionnaire burn-out** (7 questions, /21, zones + lignes d'écoute), client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)