### PR TITLE
feat(mobile): Connaissances — à la une + à lire ensuite

### DIFF
--- a/apps/mobile/src/lib/knowledge.ts
+++ b/apps/mobile/src/lib/knowledge.ts
@@ -2303,3 +2303,34 @@ export const knowledgeArticles: KnowledgeArticle[] = [
     ]
   }
 ];
+
+// Article metadata (featured flag + related slugs + last review date) ported
+// from apps/web/src/lib/resources-data.tsx for the featured hero and the
+// "À lire ensuite" section.
+export const ARTICLE_META: Record<string, { featured?: boolean; related?: string[]; lastReviewedAt?: string }> = {
+  "crise-tdah-enfant-guide-complet": { featured: true, related: ["apres-le-diagnostic-tdah-parcours-de-soins", "dysregulation-emotionnelle-tdah", "co-regulation-parent-enfant-tdah", "deconnexion-emotionnelle-tdah"] },
+  "dysregulation-emotionnelle-tdah": { related: ["crise-tdah-enfant-guide-complet", "co-regulation-parent-enfant-tdah", "deconnexion-emotionnelle-tdah"] },
+  "co-regulation-parent-enfant-tdah": { related: ["crise-tdah-enfant-guide-complet", "dysregulation-emotionnelle-tdah"] },
+  "deconnexion-emotionnelle-tdah": { related: ["dysregulation-emotionnelle-tdah", "crise-tdah-enfant-guide-complet"] },
+  "fonctions-executives-tdah-enfant": { related: ["apres-le-diagnostic-tdah-parcours-de-soins", "troubles-sommeil-tdah-enfant", "dysregulation-emotionnelle-tdah"] },
+  "hypersensibilite-sensorielle-tdah": { related: ["troubles-sommeil-tdah-enfant", "dysregulation-emotionnelle-tdah"] },
+  "troubles-sommeil-tdah-enfant": { related: ["hypersensibilite-sensorielle-tdah", "dysregulation-emotionnelle-tdah"] },
+  "mini-guide-grands-parents-tdah": { related: ["dysregulation-emotionnelle-tdah", "co-regulation-parent-enfant-tdah"] },
+  "mini-guide-co-parent-tdah": { related: ["co-regulation-parent-enfant-tdah", "dysregulation-emotionnelle-tdah"] },
+  "mini-guide-parrains-marraines-tdah": { related: ["mini-guide-grands-parents-tdah", "co-regulation-parent-enfant-tdah"] },
+  "apres-le-diagnostic-tdah-parcours-de-soins": { related: ["crise-tdah-enfant-guide-complet", "fonctions-executives-tdah-enfant"], lastReviewedAt: "2026-04-05" },
+  "medication-tdah-mythes-parents": { related: ["apres-le-diagnostic-tdah-parcours-de-soins", "dysregulation-emotionnelle-tdah", "motivation-delai-tdah-pourquoi-punition-echoue"], lastReviewedAt: "2026-04-07" },
+  "tdah-ecrans-ne-causent-pas": { related: ["medication-tdah-mythes-parents", "fonctions-executives-tdah-enfant", "dysregulation-emotionnelle-tdah"], lastReviewedAt: "2026-04-07" },
+  "motivation-delai-tdah-pourquoi-punition-echoue": { related: ["medication-tdah-mythes-parents", "fonctions-executives-tdah-enfant", "co-regulation-parent-enfant-tdah"], lastReviewedAt: "2026-04-07" },
+  "parent-tdah-gerer-mes-propres-crises": { related: ["co-regulation-parent-enfant-tdah", "dysregulation-emotionnelle-tdah", "crise-tdah-enfant-guide-complet"], lastReviewedAt: "2026-04-07" },
+};
+
+export const featuredArticle = (): KnowledgeArticle | undefined =>
+  knowledgeArticles.find((a) => ARTICLE_META[a.slug]?.featured);
+
+export function relatedArticles(slug: string): KnowledgeArticle[] {
+  const slugs = ARTICLE_META[slug]?.related ?? [];
+  return slugs
+    .map((s) => knowledgeArticles.find((a) => a.slug === s))
+    .filter((a): a is KnowledgeArticle => !!a);
+}

--- a/apps/mobile/src/screens/ConnaissancesArticleScreen.tsx
+++ b/apps/mobile/src/screens/ConnaissancesArticleScreen.tsx
@@ -1,10 +1,16 @@
 import { useState, useMemo } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 
-import { Card, EmptyState, Screen, ScreenHeader } from "../components/ui";
+import { Card, EmptyState, Screen, ScreenHeader, fonts } from "../components/ui";
 import { useTheme, type Palette } from "../lib/theme";
 import type { Block } from "../lib/knowledge";
-import { knowledgeArticles } from "../lib/knowledge";
+import {
+  ARTICLE_META,
+  knowledgeArticles,
+  relatedArticles,
+} from "../lib/knowledge";
+import { useReadArticles } from "../lib/reading";
+import { formatFrDate } from "../lib/date";
 import type { ConnaissancesArticleProps } from "../navigation/types";
 
 function BlockView({ block }: { block: Block }) {
@@ -120,6 +126,14 @@ export function ConnaissancesArticleScreen({
   const { slug, title } = route.params;
   const article = knowledgeArticles.find((a) => a.slug === slug);
   const [openFaq, setOpenFaq] = useState<number | null>(null);
+  const { markRead } = useReadArticles();
+  const related = relatedArticles(slug);
+  const reviewedAt = ARTICLE_META[slug]?.lastReviewedAt;
+
+  function openRelated(s: string, t: string) {
+    markRead(s);
+    navigation.push("ConnaissancesArticle", { slug: s, title: t });
+  }
 
   if (!article) {
     return (
@@ -138,6 +152,11 @@ export function ConnaissancesArticleScreen({
         onBack={() => navigation.goBack()}
       />
       <Text style={styles.excerpt}>{article.excerpt}</Text>
+      {reviewedAt ? (
+        <Text style={styles.reviewed}>
+          ✓ Revu le {formatFrDate(reviewedAt)}
+        </Text>
+      ) : null}
 
       {article.body.map((b, i) => (
         <BlockView key={i} block={b} />
@@ -163,6 +182,20 @@ export function ConnaissancesArticleScreen({
         </View>
       ) : null}
 
+      {related.length > 0 ? (
+        <View style={styles.relatedWrap}>
+          <Text style={styles.h2}>À lire ensuite</Text>
+          {related.map((r) => (
+            <Pressable key={r.slug} onPress={() => openRelated(r.slug, r.title)}>
+              <Card style={styles.relatedCard}>
+                <Text style={styles.relatedTitle}>{r.title}</Text>
+                <Text style={styles.relatedMeta}>{r.readTime} de lecture ›</Text>
+              </Card>
+            </Pressable>
+          ))}
+        </View>
+      ) : null}
+
       <Text style={styles.disclaimer}>
         Cet article est informatif et ne remplace pas l'avis d'un professionnel
         de santé.
@@ -179,6 +212,11 @@ const makeStyles = (c: Palette) =>
       fontStyle: "italic",
       lineHeight: 24,
     },
+    reviewed: { fontSize: 12, color: c.success, fontFamily: fonts.medium, marginTop: -4 },
+    relatedWrap: { gap: 10, marginTop: 12 },
+    relatedCard: { gap: 2 },
+    relatedTitle: { fontSize: 15, color: c.text, fontFamily: fonts.semibold },
+    relatedMeta: { fontSize: 13, color: c.action, fontFamily: fonts.medium },
     h2: { fontSize: 20, fontWeight: "700", color: c.text, marginTop: 12 },
     h3: { fontSize: 17, fontWeight: "600", color: c.text, marginTop: 6 },
     p: { fontSize: 16, color: c.text, lineHeight: 24 },

--- a/apps/mobile/src/screens/ConnaissancesScreen.tsx
+++ b/apps/mobile/src/screens/ConnaissancesScreen.tsx
@@ -1,9 +1,9 @@
 import { useMemo } from "react";
 import { Pressable, StyleSheet, Text, View } from "react-native";
 
-import { Card, Screen, ScreenHeader } from "../components/ui";
+import { Card, Screen, ScreenHeader, fonts } from "../components/ui";
 import { useTheme, type Palette } from "../lib/theme";
-import { knowledgeArticles } from "../lib/knowledge";
+import { featuredArticle, knowledgeArticles } from "../lib/knowledge";
 import { useReadArticles } from "../lib/reading";
 import type { ConnaissancesProps } from "../navigation/types";
 
@@ -26,9 +26,12 @@ export function ConnaissancesScreen({ navigation }: ConnaissancesProps) {
   const c = useTheme();
   const styles = useMemo(() => makeStyles(c), [c]);
   const { markRead } = useReadArticles();
+  const featured = featuredArticle();
   const groups = SUBJECT_ORDER.map((subject) => ({
     subject,
-    items: knowledgeArticles.filter((a) => subjectOf(a.cluster) === subject),
+    items: knowledgeArticles.filter(
+      (a) => subjectOf(a.cluster) === subject && a.slug !== featured?.slug,
+    ),
   })).filter((g) => g.items.length > 0);
 
   function openArticle(slug: string, title: string) {
@@ -47,6 +50,23 @@ export function ConnaissancesScreen({ navigation }: ConnaissancesProps) {
           pas pour vous juger.
         </Text>
       </View>
+
+      {featured ? (
+        <Pressable onPress={() => openArticle(featured.slug, featured.title)}>
+          <Card style={styles.featuredCard}>
+            <Text style={styles.featuredLabel}>À LA UNE</Text>
+            <Text style={styles.featuredTitle}>{featured.title}</Text>
+            {featured.excerpt ? (
+              <Text style={styles.featuredExcerpt} numberOfLines={3}>
+                {featured.excerpt}
+              </Text>
+            ) : null}
+            <Text style={styles.readMore}>
+              {featured.readTime} de lecture · Lire ›
+            </Text>
+          </Card>
+        </Pressable>
+      ) : null}
 
       {groups.map((group) => (
         <View key={group.subject} style={styles.group}>
@@ -91,6 +111,15 @@ const makeStyles = (c: Palette) =>
       color: c.text,
       marginTop: 8,
     },
+    featuredCard: { gap: 6, borderColor: c.brand, backgroundColor: c.secondary },
+    featuredLabel: {
+      fontSize: 11,
+      letterSpacing: 0.8,
+      color: c.brand,
+      fontFamily: fonts.bold,
+    },
+    featuredTitle: { fontSize: 19, color: c.text, fontFamily: fonts.heading },
+    featuredExcerpt: { fontSize: 14, color: c.subtext, lineHeight: 20 },
     articleCard: { gap: 4 },
     articleTitle: { fontSize: 16, fontWeight: "600", color: c.text },
     readTime: { fontSize: 12, color: c.muted },


### PR DESCRIPTION
Article « à la une » sur la liste, section « À lire ensuite » (liés) + date de relecture sur l'article. Champs featured/related/lastReviewedAt re-portés (ARTICLE_META). Typecheck + bundle OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)