### PR TITLE
docs(android): e-mail de contact Play Store

### DIFF
--- a/docs/play-store-listing.md
+++ b/docs/play-store-listing.md
@@ -11,7 +11,7 @@ principale du Store*. Respecte les limites de caractères de Google Play.
 | Éditeur | auto-entreprise Battistella |
 | Catégorie | Parentalité (*Parenting*) |
 | Tags | TDAH, parentalité, routines, enfants, suivi |
-| E-mail de contact | _(à confirmer — ex. `contact@battistella.ovh`)_ |
+| E-mail de contact | `battistella@proton.me` |
 | Site web | `https://toko.battistella.ovh` |
 | Politique de confidentialité | `https://toko.battistella.ovh/confidentialite` |
 


### PR DESCRIPTION
Renseigne l'e-mail de contact de la fiche Play Store : battistella@proton.me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)