### PR TITLE
feat(web): lien Discord dans les footers

### DIFF
--- a/apps/web/src/routes/landing-sections.tsx
+++ b/apps/web/src/routes/landing-sections.tsx
@@ -427,6 +427,14 @@ export function LandingFooter() {
           >
             {t("landing.footer.developers")}
           </Link>
+          <a
+            href="https://discord.gg/Vf9Kdxr5TK"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-foreground"
+          >
+            Discord
+          </a>
         </div>
       </div>
     </footer>

--- a/apps/web/src/routes/ressources/footer.tsx
+++ b/apps/web/src/routes/ressources/footer.tsx
@@ -30,6 +30,14 @@ export function Footer() {
           >
             Contact
           </Link>
+          <a
+            href="https://discord.gg/Vf9Kdxr5TK"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-foreground"
+          >
+            Discord
+          </a>
         </div>
       </div>
     </footer>

--- a/apps/web/src/routes/tarifs-footer.tsx
+++ b/apps/web/src/routes/tarifs-footer.tsx
@@ -30,6 +30,14 @@ export function Footer() {
           >
             Contact
           </Link>
+          <a
+            href="https://discord.gg/Vf9Kdxr5TK"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="transition-colors hover:text-foreground"
+          >
+            Discord
+          </a>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
Lien « Discord » (nouvel onglet) dans les footers landing / ressources / tarifs. Aligne la PWA sur la section Communauté du mobile. Typecheck OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)