### PR TITLE
feat: lien Discord de marque via redirection /discord

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -203,4 +203,9 @@ app.route("/api/companions", companionsRoutes);
 // the developer docs and the Tokō MCP server.
 app.get("/api/openapi.json", (c) => c.json(openApiSpec));
 
+// Branded short link for the parents' community. Server-side redirect so the
+// invite can change without shipping a new mobile build (the app and the web
+// footers point here). Registered before the SPA fallback (index.ts).
+app.get("/discord", (c) => c.redirect("https://discord.gg/Vf9Kdxr5TK", 302));
+
 export { app };

--- a/apps/mobile/src/screens/PlusMenuScreen.tsx
+++ b/apps/mobile/src/screens/PlusMenuScreen.tsx
@@ -38,7 +38,9 @@ import { authClient } from "../lib/auth";
 import { WEB_URL } from "../lib/config";
 import type { PlusMenuProps } from "../navigation/types";
 
-const DISCORD_URL = "https://discord.gg/Vf9Kdxr5TK";
+// Via la redirection serveur (app.ts) : l'invitation peut changer sans
+// republier l'app.
+const DISCORD_URL = `${WEB_URL}/discord`;
 
 const ic = (Icon: typeof Library, color: string) => <Icon size={22} color={color} />;
 

--- a/apps/web/src/routes/landing-sections.tsx
+++ b/apps/web/src/routes/landing-sections.tsx
@@ -428,7 +428,7 @@ export function LandingFooter() {
             {t("landing.footer.developers")}
           </Link>
           <a
-            href="https://discord.gg/Vf9Kdxr5TK"
+            href="/discord"
             target="_blank"
             rel="noopener noreferrer"
             className="transition-colors hover:text-foreground"

--- a/apps/web/src/routes/ressources/footer.tsx
+++ b/apps/web/src/routes/ressources/footer.tsx
@@ -31,7 +31,7 @@ export function Footer() {
             Contact
           </Link>
           <a
-            href="https://discord.gg/Vf9Kdxr5TK"
+            href="/discord"
             target="_blank"
             rel="noopener noreferrer"
             className="transition-colors hover:text-foreground"

--- a/apps/web/src/routes/tarifs-footer.tsx
+++ b/apps/web/src/routes/tarifs-footer.tsx
@@ -31,7 +31,7 @@ export function Footer() {
             Contact
           </Link>
           <a
-            href="https://discord.gg/Vf9Kdxr5TK"
+            href="/discord"
             target="_blank"
             rel="noopener noreferrer"
             className="transition-colors hover:text-foreground"


### PR DESCRIPTION
Redirection serveur GET /discord → invitation Discord ; app mobile + footers web pointent vers /discord (invitation modifiable sans republier l'app). Typecheck OK (api/web/mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)