### PR TITLE
feat: conformité paiement Android et parité premium avec la grille tarifaire

### DIFF
--- a/apps/api/src/lib/premium.ts
+++ b/apps/api/src/lib/premium.ts
@@ -1,6 +1,14 @@
 import { eq } from "drizzle-orm";
 import { db, user, subscription } from "@focusflow/db";
 
+/**
+ * History window (in days) granted to the free plan. Premium ("Famille") gets
+ * the full history — this is the pricing-grid promise "Historique complet de
+ * suivi". Enforced server-side on the journal and symptom list endpoints so it
+ * can't be bypassed by the client.
+ */
+export const FREE_HISTORY_DAYS = 30;
+
 export type PremiumAccess = {
   /** True when the user may use plan-gated ("Famille") features right now. */
   active: boolean;

--- a/apps/api/src/routes/journal.ts
+++ b/apps/api/src/routes/journal.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { AppEnv } from "../types";
-import { eq, desc } from "drizzle-orm";
+import { eq, and, gte, desc } from "drizzle-orm";
 import { db, journalEntries } from "@focusflow/db";
 import {
   createJournalEntrySchema,
@@ -10,6 +10,8 @@ import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess, childIsShared } from "../lib/child-access";
 import { logAudit, getCreatorNames } from "../lib/audit";
+import { getPremiumAccess, FREE_HISTORY_DAYS } from "../lib/premium";
+import { getUserTimezone, localISODateDaysAgo } from "../lib/local-date";
 
 function formatFrDate(value: Date | string | null | undefined): string {
   if (!value) return "";
@@ -35,10 +37,20 @@ journalRoutes.get("/:childId", async (c) => {
   const limit = Math.min(Math.max(Number(c.req.query("limit")) || 100, 1), 500);
   const offset = Math.max(Number(c.req.query("offset")) || 0, 0);
 
+  // Free plan only sees the last FREE_HISTORY_DAYS; premium gets full history
+  // ("Historique complet de suivi" on the pricing grid).
+  const { active: isPremium } = await getPremiumAccess(user.id);
+  let where = eq(journalEntries.childId, childId);
+  if (!isPremium) {
+    const tz = await getUserTimezone(user.id);
+    const since = localISODateDaysAgo(tz, FREE_HISTORY_DAYS);
+    where = and(where, gte(journalEntries.date, since))!;
+  }
+
   const result = await db
     .select()
     .from(journalEntries)
-    .where(eq(journalEntries.childId, childId))
+    .where(where)
     .orderBy(desc(journalEntries.date))
     .limit(limit)
     .offset(offset);

--- a/apps/api/src/routes/stats.ts
+++ b/apps/api/src/routes/stats.ts
@@ -272,6 +272,10 @@ statsRoutes.get("/:childId/correlations", async (c) => {
   const childId = c.req.param("childId");
   const lookbackDays = 28; // 4 weeks
 
+  // Behaviour/well-being correlation is a Plan Famille feature
+  const planRes = await requirePlan(c, async () => {});
+  if (planRes) return planRes;
+
   await assertChildAccess(user.id, childId);
 
   const tz = await getUserTimezone(user.id);

--- a/apps/api/src/routes/symptoms.ts
+++ b/apps/api/src/routes/symptoms.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import type { AppEnv } from "../types";
-import { eq, desc } from "drizzle-orm";
+import { eq, and, gte, desc } from "drizzle-orm";
 import { db, symptoms } from "@focusflow/db";
 import {
   createSymptomSchema,
@@ -10,6 +10,8 @@ import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess, childIsShared } from "../lib/child-access";
 import { logAudit, getCreatorNames } from "../lib/audit";
+import { getPremiumAccess, FREE_HISTORY_DAYS } from "../lib/premium";
+import { getUserTimezone, localISODateDaysAgo } from "../lib/local-date";
 
 function formatFrDate(value: Date | string | null | undefined): string {
   if (!value) return "";
@@ -35,10 +37,20 @@ symptomsRoutes.get("/:childId", async (c) => {
   const limit = Math.min(Math.max(Number(c.req.query("limit")) || 100, 1), 500);
   const offset = Math.max(Number(c.req.query("offset")) || 0, 0);
 
+  // Free plan only sees the last FREE_HISTORY_DAYS; premium gets full history
+  // ("Historique complet de suivi" on the pricing grid).
+  const { active: isPremium } = await getPremiumAccess(user.id);
+  let where = eq(symptoms.childId, childId);
+  if (!isPremium) {
+    const tz = await getUserTimezone(user.id);
+    const since = localISODateDaysAgo(tz, FREE_HISTORY_DAYS);
+    where = and(where, gte(symptoms.date, since))!;
+  }
+
   const result = await db
     .select()
     .from(symptoms)
-    .where(eq(symptoms.childId, childId))
+    .where(where)
     .orderBy(desc(symptoms.date))
     .limit(limit)
     .offset(offset);

--- a/apps/mobile/src/components/history-limit-notice.tsx
+++ b/apps/mobile/src/components/history-limit-notice.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { Clock } from "lucide-react-native";
+
+import { fonts } from "./ui";
+import { usePremium } from "../hooks/use-billing";
+import { useTheme, type Palette } from "../lib/theme";
+
+// Honest footer shown to free users under a journal / symptom-history list:
+// the list only covers the last 30 days (enforced server-side). The Famille
+// plan unlocks the full history. No purchase CTA or payment link — the
+// abonnement is managed on the web only (Google Play consumption-only model,
+// see project_mobile_billing).
+export function HistoryLimitNotice() {
+  const { isPremium, isLoading } = usePremium();
+  const c = useTheme();
+  const s = useMemo(() => makeStyles(c), [c]);
+
+  if (isLoading || isPremium) return null;
+
+  return (
+    <View style={s.row}>
+      <Clock size={14} color={c.muted} />
+      <Text style={s.text}>
+        Vous voyez les 30 derniers jours. L'historique complet de suivi fait
+        partie du plan Famille, à gérer depuis votre espace Tokō sur le site web.
+      </Text>
+    </View>
+  );
+}
+
+const makeStyles = (c: Palette) =>
+  StyleSheet.create({
+    row: {
+      flexDirection: "row",
+      alignItems: "flex-start",
+      gap: 8,
+      paddingVertical: 8,
+    },
+    text: {
+      flex: 1,
+      fontSize: 12,
+      color: c.muted,
+      fontFamily: fonts.body,
+      lineHeight: 17,
+    },
+  });

--- a/apps/mobile/src/components/premium-gate.tsx
+++ b/apps/mobile/src/components/premium-gate.tsx
@@ -1,0 +1,68 @@
+import { useMemo, type ReactNode } from "react";
+import { StyleSheet, Text, View } from "react-native";
+import { Lock } from "lucide-react-native";
+
+import { fonts } from "./ui";
+import { usePremium } from "../hooks/use-billing";
+import { useTheme, type Palette } from "../lib/theme";
+
+// Reusable gate for premium-only sections, mirroring the web
+// (apps/web/src/components/shared/premium-gate.tsx). While billing resolves we
+// render nothing so premium users never flash the preview; premium users get
+// the real feature; everyone else gets an honest preview card (title + "what
+// you'd unlock" body — never a blur, per the freemium-ethics policy).
+//
+// Unlike the web, the locked state carries NO purchase CTA and NO payment
+// link: Google Play forbids steering to external payment from a non-GPB app,
+// so the abonnement is taken and managed on the web only (see
+// project_mobile_billing / consumption-only model).
+export function PremiumGate({
+  children,
+  previewTitle,
+  previewBody,
+}: {
+  children: ReactNode;
+  previewTitle: string;
+  previewBody: string;
+}) {
+  const { isPremium, isLoading } = usePremium();
+  const c = useTheme();
+  const s = useMemo(() => makeStyles(c), [c]);
+
+  if (isLoading) return null;
+  if (isPremium) return <>{children}</>;
+
+  return (
+    <View style={s.card}>
+      <View style={s.head}>
+        <Lock size={16} color={c.tipFg} />
+        <Text style={s.title}>{previewTitle}</Text>
+      </View>
+      <Text style={s.body}>{previewBody}</Text>
+      <Text style={s.note}>
+        Réservé au plan Famille, à gérer depuis votre espace Tokō sur le site web.
+      </Text>
+    </View>
+  );
+}
+
+const makeStyles = (c: Palette) =>
+  StyleSheet.create({
+    card: {
+      backgroundColor: c.tipSurface,
+      borderColor: c.tipBorder,
+      borderWidth: 1,
+      borderRadius: 16,
+      padding: 16,
+      gap: 8,
+    },
+    head: { flexDirection: "row", alignItems: "center", gap: 8 },
+    title: { fontSize: 16, color: c.text, fontFamily: fonts.semibold },
+    body: {
+      fontSize: 14,
+      color: c.subtext,
+      fontFamily: fonts.body,
+      lineHeight: 20,
+    },
+    note: { fontSize: 12, color: c.muted, fontFamily: fonts.body },
+  });

--- a/apps/mobile/src/hooks/use-insights.ts
+++ b/apps/mobile/src/hooks/use-insights.ts
@@ -60,12 +60,15 @@ export function useInsights(
   });
 }
 
-export function useCorrelations(childId: string) {
+// `enabled` lets callers skip the request for non-premium users — the
+// correlation insight is a Plan Famille feature, so free users never fetch it
+// (mirrors the web, where the gated component simply isn't rendered).
+export function useCorrelations(childId: string, options?: { enabled?: boolean }) {
   return useQuery({
     queryKey: ["insights", childId, "correlations"],
     queryFn: () =>
       api.get<CorrelationResponse>(`/stats/${childId}/correlations`),
-    enabled: !!childId,
+    enabled: !!childId && (options?.enabled ?? true),
     staleTime: 5 * 60_000,
   });
 }

--- a/apps/mobile/src/screens/CalmMinutesScreen.tsx
+++ b/apps/mobile/src/screens/CalmMinutesScreen.tsx
@@ -1,6 +1,5 @@
 import { useMemo, useState } from "react";
-import * as WebBrowser from "expo-web-browser";
-import { StyleSheet, Text, View } from "react-native";
+import { Alert, StyleSheet, Text, View } from "react-native";
 import { Leaf } from "lucide-react-native";
 
 import {
@@ -19,7 +18,6 @@ import { calmMinutes as copy } from "../lib/copy";
 import { useCalmMinutes } from "../hooks/use-stats";
 import { usePremium } from "../hooks/use-billing";
 import { useTheme, type Palette } from "../lib/theme";
-import { WEB_URL } from "../lib/config";
 import type { CalmMinutesProps } from "../navigation/types";
 
 // Business rule H1: the north-star KPI — minutes of calm earned, shown over the
@@ -95,7 +93,12 @@ export function CalmMinutesScreen({ navigation, route }: CalmMinutesProps) {
         value={period}
         onChange={setPeriod}
         isPremium={isPremium}
-        onLocked={() => WebBrowser.openBrowserAsync(`${WEB_URL}/abonnement`)}
+        onLocked={() =>
+          Alert.alert(
+            "Réservé au plan Famille",
+            "Les périodes Mois et Trimestre font partie du plan Famille, qui se gère depuis votre espace Tokō sur le site web.",
+          )
+        }
       />
 
       {isLoading || !data ? (

--- a/apps/mobile/src/screens/InsightsScreen.tsx
+++ b/apps/mobile/src/screens/InsightsScreen.tsx
@@ -1,6 +1,6 @@
 import * as WebBrowser from "expo-web-browser";
 import { useMemo, useState } from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { Alert, StyleSheet, Text, View } from "react-native";
 
 import {
   Card,
@@ -15,6 +15,7 @@ import {
   PeriodSwitcher,
   type StatsPeriod,
 } from "../components/period-switcher";
+import { PremiumGate } from "../components/premium-gate";
 import { useTheme, type Palette } from "../lib/theme";
 import { useCorrelations, useInsights } from "../hooks/use-insights";
 import { usePremium } from "../hooks/use-billing";
@@ -128,9 +129,9 @@ function MoodGrid({
 export function InsightsScreen({ navigation, route }: InsightsProps) {
   const { childId, childName } = route.params;
   const [period, setPeriod] = useState<StatsPeriod>("week");
-  const stats = useInsights(childId, period);
-  const correlations = useCorrelations(childId);
   const { isPremium } = usePremium();
+  const stats = useInsights(childId, period);
+  const correlations = useCorrelations(childId, { enabled: isPremium });
   const c = useTheme();
   const styles = useMemo(() => makeStyles(c), [c]);
 
@@ -150,7 +151,12 @@ export function InsightsScreen({ navigation, route }: InsightsProps) {
         value={period}
         onChange={setPeriod}
         isPremium={isPremium}
-        onLocked={() => WebBrowser.openBrowserAsync(`${WEB_URL}/abonnement`)}
+        onLocked={() =>
+          Alert.alert(
+            "Réservé au plan Famille",
+            "Les périodes Mois et Trimestre font partie du plan Famille, qui se gère depuis votre espace Tokō sur le site web.",
+          )
+        }
       />
 
       {isLoading ? (
@@ -259,47 +265,52 @@ export function InsightsScreen({ navigation, route }: InsightsProps) {
             </Card>
           ) : null}
 
-          {/* Corrélation comportements */}
-          {!correlations.isLoading && correlations.data ? (
-            <Card>
-              <Text style={styles.sectionTitle}>Comportement & bien-être</Text>
-              {correlations.data.insufficientData ? (
-                <Text style={styles.helpText}>
-                  Pas encore assez de données (min. 10 observations + comportements Barkley actifs sur 4 semaines).
-                </Text>
-              ) : (
-                <>
+          {/* Corrélation comportements — réservé au plan Famille (mirroir web) */}
+          <PremiumGate
+            previewTitle="Comportement & bien-être"
+            previewBody="Découvrez quels comportements du programme Barkley améliorent le plus l'humeur et l'attention de votre enfant."
+          >
+            {!correlations.isLoading && correlations.data ? (
+              <Card>
+                <Text style={styles.sectionTitle}>Comportement & bien-être</Text>
+                {correlations.data.insufficientData ? (
                   <Text style={styles.helpText}>
-                    Quand{" "}
-                    <Text style={styles.bold}>
-                      {correlations.data.insight.behaviorName}
-                    </Text>{" "}
-                    est complété, {correlations.data.insight.dimensionLabel} s'améliore
-                    de{" "}
-                    <Text style={[styles.bold, { color: c.success }]}>
-                      +{correlations.data.insight.delta}
-                    </Text>{" "}
-                    pts en moyenne.
+                    Pas encore assez de données (min. 10 observations + comportements Barkley actifs sur 4 semaines).
                   </Text>
-                  <View style={styles.correlRow}>
-                    <View style={styles.correlBlock}>
-                      <Text style={styles.correlNum}>
-                        {correlations.data.insight.onValue}
-                      </Text>
-                      <Text style={styles.correlLeg}>Avec</Text>
+                ) : (
+                  <>
+                    <Text style={styles.helpText}>
+                      Quand{" "}
+                      <Text style={styles.bold}>
+                        {correlations.data.insight.behaviorName}
+                      </Text>{" "}
+                      est complété, {correlations.data.insight.dimensionLabel} s'améliore
+                      de{" "}
+                      <Text style={[styles.bold, { color: c.success }]}>
+                        +{correlations.data.insight.delta}
+                      </Text>{" "}
+                      pts en moyenne.
+                    </Text>
+                    <View style={styles.correlRow}>
+                      <View style={styles.correlBlock}>
+                        <Text style={styles.correlNum}>
+                          {correlations.data.insight.onValue}
+                        </Text>
+                        <Text style={styles.correlLeg}>Avec</Text>
+                      </View>
+                      <Text style={styles.correlArrow}>→</Text>
+                      <View style={styles.correlBlock}>
+                        <Text style={styles.correlNum}>
+                          {correlations.data.insight.offValue}
+                        </Text>
+                        <Text style={styles.correlLeg}>Sans</Text>
+                      </View>
                     </View>
-                    <Text style={styles.correlArrow}>→</Text>
-                    <View style={styles.correlBlock}>
-                      <Text style={styles.correlNum}>
-                        {correlations.data.insight.offValue}
-                      </Text>
-                      <Text style={styles.correlLeg}>Sans</Text>
-                    </View>
-                  </View>
-                </>
-              )}
-            </Card>
-          ) : null}
+                  </>
+                )}
+              </Card>
+            ) : null}
+          </PremiumGate>
 
           {/* Link to web for full charts */}
           <PrimaryButton

--- a/apps/mobile/src/screens/JournalScreen.tsx
+++ b/apps/mobile/src/screens/JournalScreen.tsx
@@ -39,6 +39,7 @@ import {
   confirmDelete,
   fonts,
 } from "../components/ui";
+import { HistoryLimitNotice } from "../components/history-limit-notice";
 import { useTheme, type Palette } from "../lib/theme";
 import type { JournalProps } from "../navigation/types";
 
@@ -231,6 +232,8 @@ export function JournalScreen({ route }: JournalProps) {
           </Card>
         ))
       )}
+
+      {!composing && (entries?.length ?? 0) > 0 ? <HistoryLimitNotice /> : null}
     </Screen>
   );
 }

--- a/apps/mobile/src/screens/PlusMenuScreen.tsx
+++ b/apps/mobile/src/screens/PlusMenuScreen.tsx
@@ -100,12 +100,9 @@ export function PlusMenuScreen({ navigation }: PlusMenuProps) {
       <MenuRow icon={ic(SettingsIcon, c.brand)} label="Réglages" onPress={goPlain("Settings")} />
 
       {billing.isSuccess && !isPremium ? (
-        <MenuRow
-          icon={ic(Sparkles, c.brand)}
-          label="S'abonner à Premium"
-          hint="L'abonnement se prend sur le site"
-          onPress={() => WebBrowser.openBrowserAsync(`${WEB_URL}/abonnement`)}
-        />
+        <Text style={styles.planNote}>
+          Premium se gère depuis votre espace Tokō sur le site web.
+        </Text>
       ) : null}
       {isPremium ? <Text style={styles.premium}>✓ Premium actif</Text> : null}
 
@@ -126,6 +123,7 @@ export function PlusMenuScreen({ navigation }: PlusMenuProps) {
 const makeStyles = (c: Palette) =>
   StyleSheet.create({
     premium: { color: c.success, fontFamily: fonts.semibold, marginTop: 4 },
+    planNote: { color: c.muted, fontSize: 13, fontFamily: fonts.body, marginTop: 4 },
     signout: {
       flexDirection: "row",
       alignItems: "center",

--- a/apps/mobile/src/screens/ReportScreen.tsx
+++ b/apps/mobile/src/screens/ReportScreen.tsx
@@ -188,18 +188,13 @@ export function ReportScreen({ navigation, route }: ReportProps) {
         )}
       </Card>
 
-      {/* Premium upsell (server enforces too) */}
+      {/* Premium state (server enforces too) */}
       {!isPremium ? (
         <CalloutCard variant="tip" label="Plan Famille">
           <Text style={styles.infoBody}>
-            L'envoi du carnet par e-mail est réservé au plan Famille.
+            L'envoi du carnet par e-mail est réservé au plan Famille, qui se
+            gère depuis votre espace Tokō sur le site web.
           </Text>
-          <Pressable
-            onPress={() => WebBrowser.openBrowserAsync(`${WEB_URL}/abonnement`)}
-            accessibilityRole="button"
-          >
-            <Text style={styles.upsellLink}>Découvrir le plan Famille ›</Text>
-          </Pressable>
         </CalloutCard>
       ) : null}
 
@@ -303,7 +298,6 @@ const makeStyles = (c: Palette) =>
     avgLabel: { fontSize: 14, color: c.subtext, fontFamily: fonts.body },
     avgValue: { fontSize: 14, color: c.text, fontFamily: fonts.semibold },
     questionsInput: { minHeight: 72, textAlignVertical: "top", marginTop: 8 },
-    upsellLink: { color: c.action, fontFamily: fonts.semibold, fontSize: 14, marginTop: 4 },
     hint: {
       fontSize: 13,
       color: c.muted,

--- a/apps/mobile/src/screens/SymptomsScreen.tsx
+++ b/apps/mobile/src/screens/SymptomsScreen.tsx
@@ -16,6 +16,7 @@ import {
   confirmDelete,
   fonts,
 } from "../components/ui";
+import { HistoryLimitNotice } from "../components/history-limit-notice";
 import { useTheme, type Palette } from "../lib/theme";
 import { useDeleteSymptom, useSymptoms } from "../hooks/use-symptoms";
 import { useActiveChild } from "../lib/active-child";
@@ -217,6 +218,8 @@ export function SymptomsScreen({ navigation, route }: SymptomsProps) {
           />
         ))
       )}
+
+      {sorted.length > 0 ? <HistoryLimitNotice /> : null}
     </Screen>
   );
 }

--- a/apps/web/src/components/shared/history-limit-notice.tsx
+++ b/apps/web/src/components/shared/history-limit-notice.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from "react-i18next";
+import { Clock, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useBillingStatus, useCheckout } from "@/hooks/use-billing";
+
+// Honest notice shown to free users below a journal / symptom-history list:
+// the list only covers the last 30 days (FREE_HISTORY_DAYS, enforced server
+// side). The Famille plan unlocks the full history. Surfacing the limit rather
+// than silently truncating is required by the freemium-ethics policy.
+export function HistoryLimitNotice() {
+  const { t } = useTranslation();
+  const billing = useBillingStatus();
+  const checkout = useCheckout();
+
+  if (billing.isLoading || billing.data?.active) return null;
+
+  return (
+    <div className="rounded-xl border border-primary/20 bg-gradient-to-br from-accent/10 to-transparent p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+          <Clock className="size-4" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm text-muted-foreground">
+            {t("history.freeLimitNotice")}
+          </p>
+          <Button
+            size="sm"
+            className="mt-3 gap-1.5"
+            onClick={() => checkout.mutate()}
+            disabled={checkout.isPending}
+          >
+            {t("history.freeLimitCta")}
+            <ArrowRight className="size-3.5" />
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -670,6 +670,10 @@
     "copyFailed": "Copy failed",
     "shareFailed": "Share failed"
   },
+  "history": {
+    "freeLimitNotice": "You're seeing the last 30 days. The Family plan unlocks your full tracking history.",
+    "freeLimitCta": "See full history with Family"
+  },
   "journal": {
     "title": "Journal",
     "subtitle": "Daily notes and observations",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -728,6 +728,10 @@
       }
     }
   },
+  "history": {
+    "freeLimitNotice": "Vous voyez les 30 derniers jours. L'offre Famille débloque l'historique complet de suivi.",
+    "freeLimitCta": "Voir tout l'historique avec Famille"
+  },
   "insights": {
     "title": "Analyses",
     "subtitle": "Les tendances de votre enfant sur 30 et 90 jours, et les patterns qui se dessinent quand on prend du recul.",

--- a/apps/web/src/routes/_authenticated/journal/index.tsx
+++ b/apps/web/src/routes/_authenticated/journal/index.tsx
@@ -20,6 +20,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { JournalCard } from "@/components/journal/journal-card";
 import { tagConfig } from "@/components/journal/journal-card-data";
 import { JournalForm } from "@/components/journal/journal-form";
+import { HistoryLimitNotice } from "@/components/shared/history-limit-notice";
 import { useJournal, useDeleteJournalEntry } from "@/hooks/use-journal";
 import { useUiStore } from "@/stores/ui-store";
 import type { JournalEntry, JournalTag } from "@focusflow/validators";
@@ -223,6 +224,8 @@ export function JournalPage() {
           ))}
         </div>
       )}
+
+      {entries && entries.length > 0 ? <HistoryLimitNotice /> : null}
 
       {/* Create / Edit dialog */}
       <Dialog

--- a/apps/web/src/routes/_authenticated/symptoms/index.tsx
+++ b/apps/web/src/routes/_authenticated/symptoms/index.tsx
@@ -15,6 +15,7 @@ import { PageHeader } from "@/components/layout/page-header";
 import { SymptomForm } from "@/components/symptoms/symptom-form";
 import { SymptomCard } from "@/components/symptoms/symptom-card";
 import { useSymptoms } from "@/hooks/use-symptoms";
+import { HistoryLimitNotice } from "@/components/shared/history-limit-notice";
 import { useUiStore } from "@/stores/ui-store";
 import type { Symptom } from "@focusflow/validators";
 
@@ -179,6 +180,8 @@ function SymptomsPage() {
           ))}
         </div>
       )}
+
+      {symptoms && symptoms.length > 0 ? <HistoryLimitNotice /> : null}
     </div>
   );
 }


### PR DESCRIPTION
## Contexte
L'app Android est en place. Cette PR aligne le paiement Stripe et la représentation des features premium sur Android avec les contraintes Google Play, puis fait correspondre le code à toutes les promesses de la grille tarifaire.

## Changements

### Conformité Google Play (app Android, modèle consumption-only)
- Retrait de **tout lien de paiement** (`/abonnement`) : menu, période verrouillée, rapport → état neutre non cliquable. L'abonnement se gère sur le web.
- Nouveau composant **`PremiumGate` mobile** (preview honnête, sans CTA d'achat).
- Corrélation « Comportement & bien-être » désormais gatée comme sur le web.

### Enforcement serveur
- `/stats/:childId/correlations` protégé par `requirePlan`.
- **Historique de suivi** : `FREE_HISTORY_DAYS=30` ; fenêtre 30 jours appliquée aux endpoints **journal** et **symptômes** pour les non-premium (premium = illimité).

### Honnêteté UI (anti-dark-pattern, pas de troncature silencieuse)
- **Web** : `HistoryLimitNotice` (avec CTA checkout) sur journal + symptômes.
- **Mobile** : `HistoryLimitNotice` (informatif, sans lien de paiement) sur journal + symptômes.

## Grille tarifaire — désormais 100 % honorée par le code
| Promesse Famille | Statut |
|---|---|
| Rapport PDF rendez-vous | ✅ déjà enforced |
| Tendances mois & trimestre | ✅ déjà enforced |
| Profils enfant (1 → 3) | ✅ déjà enforced |
| Historique complet de suivi | ✅ **implémenté ici** |

## Tests
- ✅ Typecheck **api**, **web**, **mobile** (tous verts)
- ⏭️ E2E non exécutés (environnement local indisponible — port 5432 occupé par un autre projet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)