### PR TITLE
feat(mobile): gestion propre du mode paysage sur téléphone

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -4,7 +4,7 @@
     "slug": "toko",
     "scheme": "toko",
     "version": "0.1.0",
-    "orientation": "portrait",
+    "orientation": "default",
     "userInterfaceStyle": "automatic",
     "icon": "./assets/icon.png",
     "platforms": ["android"],

--- a/apps/mobile/src/components/ui.tsx
+++ b/apps/mobile/src/components/ui.tsx
@@ -35,7 +35,7 @@ export const fonts = {
 export function Screen({
   children,
   scroll = false,
-  edges = ["top", "bottom"],
+  edges = ["top", "bottom", "left", "right"],
   fab,
 }: {
   children: ReactNode;
@@ -45,18 +45,21 @@ export function Screen({
 }) {
   const c = useTheme();
   const s = useMemo(() => makeStyles(c), [c]);
+  // Both branches scroll: in landscape the viewport is short, so even a
+  // "non-scroll" screen's content must stay reachable rather than clip. The
+  // non-scroll branch uses flexGrow so its content still fills the height (and
+  // stays vertically centered) in portrait, and only scrolls when it overflows.
+  // `left`/`right` safe-area edges keep content clear of a side notch in
+  // landscape, and the column is width-capped so it doesn't stretch into one
+  // very wide row on a rotated phone.
   return (
     <SafeAreaView style={s.flex} edges={edges}>
-      {scroll ? (
-        <ScrollView
-          contentContainerStyle={s.scrollContent}
-          keyboardShouldPersistTaps="handled"
-        >
-          {children}
-        </ScrollView>
-      ) : (
-        <View style={[s.flex, s.padded]}>{children}</View>
-      )}
+      <ScrollView
+        contentContainerStyle={scroll ? s.scrollContent : s.fillContent}
+        keyboardShouldPersistTaps="handled"
+      >
+        <View style={scroll ? s.column : s.fillColumn}>{children}</View>
+      </ScrollView>
       {fab}
     </SafeAreaView>
   );
@@ -441,8 +444,13 @@ export function ChildSwitcher() {
 const makeStyles = (c: Palette) =>
   StyleSheet.create({
     flex: { flex: 1, backgroundColor: c.bg },
-    padded: { padding: 24, gap: 16 },
-    scrollContent: { padding: 20, gap: 14 },
+    // Scrolling content, centered and width-capped for landscape/wide screens.
+    scrollContent: { padding: 20, alignItems: "center" },
+    column: { width: "100%", maxWidth: 600, gap: 14 },
+    // Fill-or-scroll content (the old non-scroll branch): grows to fill the
+    // height in portrait, scrolls when it overflows in landscape.
+    fillContent: { flexGrow: 1, padding: 24, alignItems: "center" },
+    fillColumn: { width: "100%", maxWidth: 600, gap: 16, flexGrow: 1 },
     headerWrap: { gap: 4, marginBottom: 4 },
     headerRow: {
       flexDirection: "row",

--- a/apps/mobile/src/screens/CrisisListScreen.tsx
+++ b/apps/mobile/src/screens/CrisisListScreen.tsx
@@ -84,7 +84,7 @@ export function CrisisListScreen({ navigation, route }: CrisisListProps) {
   if (crisisMode && list.length > 0) {
     const item = list[Math.min(index, list.length - 1)];
     return (
-      <SafeAreaView style={styles.crisisContainer} edges={["top", "bottom"]}>
+      <SafeAreaView style={styles.crisisContainer} edges={["top", "bottom", "left", "right"]}>
         <Pressable
           style={styles.crisisClose}
           onPress={() => setCrisisMode(false)}
@@ -120,7 +120,7 @@ export function CrisisListScreen({ navigation, route }: CrisisListProps) {
   }
 
   return (
-    <SafeAreaView style={styles.container} edges={["top", "bottom"]}>
+    <SafeAreaView style={styles.container} edges={["top", "bottom", "left", "right"]}>
       <View style={styles.header}>
         <Pressable onPress={() => navigation.goBack()} hitSlop={12} style={styles.headerSide}>
           <Text style={styles.back}>‹ {childName}</Text>


### PR DESCRIPTION
## Résumé

L'app mobile était **verrouillée en portrait** : une rotation produisait des écrans tronqués (contenu coupé, non scrollable) et masqués par l'encoche latérale. Cette PR gère **proprement le mode paysage sur téléphone**, tout en conservant l'UX simple à colonne unique (principe ADHD).

## Changements
- **`app.json`** : `orientation` `portrait` → `default` (rotation autorisée).
- **Primitive `Screen`** (utilisée par ~30 écrans) :
  - Les deux variantes scrollent désormais → le contenu n'est **jamais tronqué** dans la hauteur réduite du paysage. La variante « non-scroll » utilise `flexGrow` pour préserver le remplissage/centrage en portrait et ne scroller qu'en cas de débordement.
  - Ajout des `edges` de safe-area **gauche/droite** (encoche latérale en paysage).
  - **Colonne centrée `maxWidth: 600`** pour éviter une ligne unique très large sur écran rotaté.
- **`CrisisListScreen`** (layout autonome) : ajout des safe-area gauche/droite (l'écran scrolle déjà).

## Notes
- Aucun écran n'imbrique de liste/scroll dans la branche non-scroll (vérifié : loader / empty-state / écran de fin uniquement) → pas de double scroll.
- Aucun usage de `Dimensions.get`/`useWindowDimensions` → pas de largeur figée qui resterait bloquée après rotation.
- En portrait, le rendu est **inchangé** (téléphones < 600px, insets latéraux ~0).
- ⚠️ Changement de config **native** : nécessite `expo prebuild` + rebuild pour prendre effet. À valider visuellement sur appareil (portrait + paysage) avant publication store.

## Vérification
- ✅ `npm run typecheck` (app mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
