### PR TITLE
feat(landing): renforcer la page d'accueil (CTA uniques, section finale, copy)

### DIFF
--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -37,7 +37,7 @@
       "resources": "Resources",
       "pricing": "Pricing",
       "login": "Sign in",
-      "getStarted": "Get started",
+      "getStarted": "Try for free",
       "menu": "Menu"
     },
     "trust": {
@@ -129,13 +129,12 @@
     },
     "pricing": {
       "title": "Simple, transparent pricing",
-      "subtitle": "Start free and change daily life at home. The Family plan unlocks long-term tracking, multi-child support and everything that helps bring lasting calm to family life.",
+      "subtitle": "Start free. The Family plan unlocks 90-day tracking, up to 3 children and the PDF report for your appointments.",
       "recommended": "Recommended",
       "trialBadge": "14 days free · no card",
       "intervalAnnual": "Annual",
       "intervalMonthly": "Monthly",
       "intervalSaveBadge": "−35%",
-      "annualEquivalent": "≈ €60/year — a few coffees a month to get your time back",
       "annualEquivalentPerMonth": "≈ €3.25/month · cancel anytime",
       "comparisonTitle": "Detailed comparison",
       "comparisonHead": {
@@ -184,6 +183,11 @@
         "ctaAnnual": "Try 14 days · €39/year",
         "ctaMonthly": "Try 14 days · €4.99/month"
       }
+    },
+    "finalCta": {
+      "title": "2 minutes tonight. A calmer day tomorrow.",
+      "description": "Create your free account and write your first note tonight.",
+      "cta": "Create my free account"
     },
     "footer": {
       "tagline": "Tokō — Fewer meltdowns, more time together",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -37,7 +37,7 @@
       "resources": "Ressources",
       "pricing": "Tarifs",
       "login": "Connexion",
-      "getStarted": "Commencer",
+      "getStarted": "Essayer gratuitement",
       "menu": "Menu"
     },
     "hero": {
@@ -129,13 +129,12 @@
     },
     "pricing": {
       "title": "Des tarifs simples et transparents",
-      "subtitle": "Commencez gratuitement et changez votre quotidien à la maison. L'abonnement Famille débloque le suivi long, le multi-enfants et tout ce qui aide à apaiser durablement la vie de famille.",
+      "subtitle": "Commencez gratuitement. L'abonnement Famille débloque le suivi sur 90 jours, jusqu'à 3 enfants et le rapport PDF pour vos rendez-vous.",
       "recommended": "Recommandé",
       "trialBadge": "14 jours offerts · sans CB",
       "intervalAnnual": "Annuel",
       "intervalMonthly": "Mensuel",
       "intervalSaveBadge": "−35 %",
-      "annualEquivalent": "≈ 60 €/an — quelques cafés par mois pour vous rendre du temps",
       "annualEquivalentPerMonth": "≈ 3,25 €/mois · résiliable à tout moment",
       "comparisonTitle": "Comparatif détaillé",
       "comparisonHead": {
@@ -184,6 +183,11 @@
         "ctaAnnual": "Essayer 14 jours · 39 €/an",
         "ctaMonthly": "Essayer 14 jours · 4,99 €/mois"
       }
+    },
+    "finalCta": {
+      "title": "2 minutes ce soir. Une journée plus calme demain.",
+      "description": "Créez votre compte gratuit et notez votre première observation dès ce soir.",
+      "cta": "Créer mon compte gratuit"
     },
     "footer": {
       "tagline": "Tokō — Moins de crises, plus de moments en famille",

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -9,6 +9,7 @@ import {
   ResourcesTeaser,
   FeaturesSection,
   TestimonialsSection,
+  FinalCtaSection,
   LandingFooter,
 } from "./landing-sections";
 
@@ -40,6 +41,7 @@ function LandingPage() {
       <FeaturesSection />
       <TestimonialsSection />
       <PricingSection />
+      <FinalCtaSection />
       <LandingFooter />
     </div>
   );

--- a/apps/web/src/routes/landing-sections.tsx
+++ b/apps/web/src/routes/landing-sections.tsx
@@ -188,7 +188,7 @@ export function HeroSection() {
           {t("landing.hero.description")}
         </p>
 
-        <div className="mt-10 flex w-full flex-col items-stretch justify-center gap-3 sm:w-auto sm:flex-row sm:items-center sm:gap-4">
+        <div className="mt-10 flex flex-col items-center justify-center gap-4">
           <Link to="/login" className="w-full sm:w-auto">
             <Button
               size="lg"
@@ -198,14 +198,15 @@ export function HeroSection() {
               <ArrowRight className="size-4" />
             </Button>
           </Link>
-          <a href="#fonctionnalites" className="w-full sm:w-auto">
-            <Button variant="outline" size="lg" className="w-full text-base sm:w-auto">
-              {t("landing.hero.ctaSecondary")}
-            </Button>
+          <a
+            href="#fonctionnalites"
+            className="px-3 py-2 text-sm font-medium text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
+          >
+            {t("landing.hero.ctaSecondary")}
           </a>
         </div>
 
-        <p className="mt-5 text-sm text-muted-foreground/80">
+        <p className="mt-3 text-sm text-muted-foreground/80">
           {t("landing.hero.noCard")}
         </p>
       </div>
@@ -317,7 +318,7 @@ export function ResourcesTeaser() {
           ))}
         </div>
         <div className="mt-8 text-center">
-          <Link to="/login">
+          <Link to="/ressources">
             <Button variant="outline" size="lg" className="gap-2">
               {t("landing.resourcesTeaser.cta")}
               <ArrowRight className="size-4" />
@@ -370,6 +371,37 @@ export function FeaturesSection() {
         </div>
         <p className="mx-auto mt-10 max-w-3xl text-center text-sm leading-relaxed text-muted-foreground">
           {t("landing.features.andMore")}
+        </p>
+      </div>
+    </section>
+  );
+}
+
+export function FinalCtaSection() {
+  const { t } = useTranslation();
+  return (
+    <section className="relative overflow-hidden border-t border-border/60 py-20 text-center lg:py-28">
+      <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_80%_60%_at_50%_120%,oklch(0.85_0.08_30_/_0.15),transparent)]" />
+      <div className="relative mx-auto max-w-2xl px-4">
+        <h2 className="font-heading text-3xl font-semibold tracking-tight lg:text-4xl">
+          {t("landing.finalCta.title")}
+        </h2>
+        <p className="mx-auto mt-4 max-w-xl text-lg text-muted-foreground">
+          {t("landing.finalCta.description")}
+        </p>
+        <div className="mt-8">
+          <Link to="/login" className="inline-block w-full sm:w-auto">
+            <Button
+              size="lg"
+              className="w-full gap-2 px-8 text-base shadow-md shadow-primary/20 transition-shadow hover:shadow-lg hover:shadow-primary/25 sm:w-auto"
+            >
+              {t("landing.finalCta.cta")}
+              <ArrowRight className="size-4" />
+            </Button>
+          </Link>
+        </div>
+        <p className="mt-4 text-sm text-muted-foreground/80">
+          {t("landing.hero.noCard")}
         </p>
       </div>
     </section>

--- a/apps/web/src/routes/tarifs-top-nav.tsx
+++ b/apps/web/src/routes/tarifs-top-nav.tsx
@@ -35,7 +35,7 @@ export function TopNav() {
           </Link>
           <Link to="/login">
             <Button className="gap-2 shadow-sm">
-              Commencer
+              Essayer gratuitement
               <ArrowRight className="size-3.5" />
             </Button>
           </Link>


### PR DESCRIPTION
## Contexte

Revue de la landing page Tokō au regard des « 31 Principles of a Viral Product » (Marc Lou). La plupart des principes étaient déjà respectés ; cette PR corrige les écarts qui relèvent du code, sans toucher au modèle économique.

## Changements

- **Un seul CTA par écran (principes 6, 22)** : dans le héro, le bouton secondaire « Voir comment ça marche » devient un lien texte discret sous le CTA principal.
- **Le CTA dit ce qui va se passer (principe 28)** : « Commencer » devient « Essayer gratuitement » dans la nav (landing + page Tarifs).
- **Correction de lien** : le bouton « Lire tous les guides » pointait vers `/login` au lieu de `/ressources`.
- **Finir fort (principe 4)** : nouvelle section de clôture avant le footer — « 2 minutes ce soir. Une journée plus calme demain. » avec un CTA unique et le rappel « sans carte bancaire ».
- **Des chiffres plutôt que des adjectifs (principes 3, 26)** : sous-titre de la section tarifs raccourci et concret (« suivi sur 90 jours, jusqu'à 3 enfants, rapport PDF ») ; suppression de la clé inutilisée `annualEquivalent` (« quelques cafés par mois » — formulation vague).

## Déjà conforme (aucun changement nécessaire)

Titre émotionnel de 7 mots compréhensible par tous (7, 17, 18, 30) · « Tarifs » dans le header (16) · témoignages (29) · essai sans paiement (25) · copy personnelle « construit par un parent » (9, 15, 21) · chiffres dans la copy (« 2 minutes », « 14 jours ») (3) · palette sobre à une couleur d'accent (2) · OG image 1200×630 en place (5).

## Non appliqué volontairement (décisions produit, pas de code)

Supprimer le plan gratuit (1), paywall dur (8), pas d'abonnement (27), être plus cher que la concurrence (31) — contraires au modèle freemium assumé de Tokō et à ses principes de design pour parents TDAH.

**Piste future (principe 10 — montrer le produit)** : ajouter une capture d'écran ou une courte démo du produit dans le héro ; aucun asset disponible dans le repo pour le faire proprement.

## Vérifications

- `pnpm typecheck` ✅ · `pnpm test` ✅ (105 tests) · locales fr/en validées (clés synchronisées, revue i18n FR OK)

https://claude.ai/code/session_015bDUD8bQrZEm4J1rPDR3qd

---
_Generated by [Claude Code](https://claude.ai/code/session_015bDUD8bQrZEm4J1rPDR3qd)_