### PR TITLE
feat: capture RGPD consent at signup and child creation

### DIFF
--- a/apps/api/src/lib/auth.ts
+++ b/apps/api/src/lib/auth.ts
@@ -5,9 +5,10 @@ import { twoFactor } from "better-auth/plugins";
 import { passkey } from "@better-auth/passkey";
 import { expo } from "@better-auth/expo";
 import { eq } from "drizzle-orm";
-import { db, user } from "@focusflow/db";
+import { db, user, consents } from "@focusflow/db";
 import { env } from "./env";
 import { sendEmail } from "./email";
+import { TERMS_VERSION, PRIVACY_VERSION } from "./consent-versions";
 import {
   resetPasswordEmail,
   verificationEmail,
@@ -188,6 +189,21 @@ export const auth = betterAuth({
     }),
   ],
   databaseHooks: {
+    user: {
+      create: {
+        // Record consent to the terms of service and privacy policy at account
+        // creation (business rule F4 / RGPD). The sign-up UI requires the user
+        // to accept both before submitting (email form: a required checkbox;
+        // OAuth: an explicit notice), so every new account carries the proof.
+        // Fires for both email and Google sign-up.
+        after: async (createdUser) => {
+          await db.insert(consents).values([
+            { userId: createdUser.id, type: "terms", version: TERMS_VERSION },
+            { userId: createdUser.id, type: "privacy", version: PRIVACY_VERSION },
+          ]);
+        },
+      },
+    },
     session: {
       create: {
         // A blocked user must never obtain a new session — this rejects

--- a/apps/api/src/lib/consent-versions.ts
+++ b/apps/api/src/lib/consent-versions.ts
@@ -1,0 +1,15 @@
+// Consent document versions. Each constant is bumped whenever the wording of
+// the corresponding document or attestation changes, so a consent row always
+// pins the exact text the user agreed to (business rule F4). Opaque strings —
+// the schema treats them as free-form identifiers.
+
+// Terms of service / CGU (page: /mentions-legales).
+export const TERMS_VERSION = "2026-07-13";
+// Privacy policy (page: /confidentialite).
+export const PRIVACY_VERSION = "2026-07-13";
+// Owner attests they hold parental authority over the child they create
+// (Art. 371-1 C. civ.).
+export const OWNER_PARENTAL_AUTHORITY_VERSION = "2026-07-13";
+// Owner's explicit Art. 9(2)(a) RGPD consent to process their child's health
+// data, captured at child-profile creation.
+export const OWNER_HEALTH_VERSION = "2026-07-13";

--- a/apps/api/src/routes/children.ts
+++ b/apps/api/src/routes/children.ts
@@ -1,12 +1,16 @@
 import { Hono } from "hono";
 import type { AppEnv } from "../types";
 import { eq, inArray } from "drizzle-orm";
-import { db, children, childAccess } from "@focusflow/db";
+import { db, children, childAccess, consents } from "@focusflow/db";
 import { createChildSchema, updateChildSchema } from "@focusflow/validators";
 import { authMiddleware } from "../middleware/auth";
 import { AppError } from "../middleware/error-handler";
 import { getPremiumAccess } from "../lib/premium";
 import { seedBarkleyStarterPack } from "../lib/barkley-defaults";
+import {
+  OWNER_PARENTAL_AUTHORITY_VERSION,
+  OWNER_HEALTH_VERSION,
+} from "../lib/consent-versions";
 import {
   assertChildAccess,
   assertChildOwner,
@@ -43,6 +47,20 @@ childrenRoutes.post("/", async (c) => {
     );
   }
 
+  // RGPD Art. 9(2)(a): the owner must explicitly consent to processing their
+  // child's health data (and attest parental authority) before we create the
+  // profile. The UI gates the submit button on a required checkbox; we also
+  // enforce it server-side so the consent proof is never missing.
+  if (body?.healthDataConsent !== true) {
+    return c.json(
+      {
+        error:
+          "Le consentement au traitement des données de santé de l'enfant est requis.",
+      },
+      422
+    );
+  }
+
   // Enforce child limit based on subscription plan
   const existingChildren = await db
     .select()
@@ -74,6 +92,20 @@ childrenRoutes.post("/", async (c) => {
       role: "owner",
       grantedBy: user.id,
     });
+    // Persist the owner's Art. 9 health-data consent and parental-authority
+    // attestation alongside the child, in the same transaction.
+    await tx.insert(consents).values([
+      {
+        userId: user.id,
+        type: "parental_authority_attestation",
+        version: OWNER_PARENTAL_AUTHORITY_VERSION,
+      },
+      {
+        userId: user.id,
+        type: "owner_health_processing",
+        version: OWNER_HEALTH_VERSION,
+      },
+    ]);
     await seedBarkleyStarterPack(created.id, tx);
     return created;
   });

--- a/apps/web/src/components/shared/child-form.tsx
+++ b/apps/web/src/components/shared/child-form.tsx
@@ -4,6 +4,7 @@ import { Shuffle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Select,
   SelectTrigger,
@@ -48,9 +49,13 @@ export function ChildForm({
   const [diagnosisType, setDiagnosisType] = useState<string>(
     initialData?.diagnosisType ?? "undefined"
   );
+  const [consent, setConsent] = useState(false);
 
   const isPending = createChild.isPending || updateChild.isPending;
   const showAdditionalFields = name.length > 0 || isEdit;
+  // Consent to process the child's health data (RGPD Art. 9) is required only
+  // when creating a new profile, not when editing an existing one.
+  const showConsent = !isEdit && showAdditionalFields;
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -69,12 +74,16 @@ export function ChildForm({
         { onSuccess: () => onSuccess() }
       );
     } else {
-      createChild.mutate(payload, {
-        onSuccess: (data) => {
-          setActiveChild(data.id);
-          onSuccess();
-        },
-      });
+      if (!consent) return;
+      createChild.mutate(
+        { ...payload, healthDataConsent: true },
+        {
+          onSuccess: (data) => {
+            setActiveChild(data.id);
+            onSuccess();
+          },
+        }
+      );
     }
   };
 
@@ -215,10 +224,26 @@ export function ChildForm({
           </div>
         </details>
       )}
+      {showConsent && (
+        <div className="flex items-start gap-2 rounded-lg border border-border/60 bg-muted/30 p-3">
+          <Checkbox
+            id="child-health-consent"
+            checked={consent}
+            onCheckedChange={(v) => setConsent(v === true)}
+            className="mt-0.5"
+          />
+          <Label
+            htmlFor="child-health-consent"
+            className="text-xs font-normal leading-relaxed text-muted-foreground"
+          >
+            {t("child.healthConsentLabel")}
+          </Label>
+        </div>
+      )}
       <Button
         type="submit"
         className="w-full"
-        disabled={isPending}
+        disabled={isPending || (showConsent && !consent)}
       >
         {isPending
           ? (isEdit ? t("child.saving") : t("child.adding"))

--- a/apps/web/src/components/shared/legal-consent-text.tsx
+++ b/apps/web/src/components/shared/legal-consent-text.tsx
@@ -1,0 +1,32 @@
+import { Trans } from "react-i18next";
+
+// Renders a translated consent sentence whose <terms> and <privacy> tags are
+// turned into links to the legal notice and privacy policy. Shared by the
+// registration form and the auth page so the legal URLs and link styling live
+// in one place. The i18n string must use the <terms> and <privacy> tags, e.g.
+// "J'accepte les <terms>conditions</terms> et la <privacy>confidentialité</privacy>."
+export function LegalConsentText({ i18nKey }: { i18nKey: string }) {
+  return (
+    <Trans
+      i18nKey={i18nKey}
+      components={{
+        terms: (
+          <a
+            href="/mentions-legales"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="underline hover:text-foreground"
+          />
+        ),
+        privacy: (
+          <a
+            href="/confidentialite"
+            target="_blank"
+            rel="noreferrer noopener"
+            className="underline hover:text-foreground"
+          />
+        ),
+      }}
+    />
+  );
+}

--- a/apps/web/src/hooks/use-children.ts
+++ b/apps/web/src/hooks/use-children.ts
@@ -27,7 +27,8 @@ export function useChild(id: string) {
 export function useCreateChild() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (data: CreateChild) => api.post<Child>("/children", data),
+    mutationFn: (data: CreateChild & { healthDataConsent: boolean }) =>
+      api.post<Child>("/children", data),
     onSuccess: () => queryClient.invalidateQueries({ queryKey: childrenKeys.all }),
     onError: () => toast.error(i18n.t("toastErrors.addChild")),
   });

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -223,7 +223,10 @@
     "errorRegister": "Registration error",
     "errorNetwork": "Couldn't connect. Check your internet connection and try again.",
     "backToHome": "Home",
-    "forgotPassword": "Forgot password?"
+    "forgotPassword": "Forgot password?",
+    "consentLabel": "I accept the <terms>terms of use</terms> and the <privacy>privacy policy</privacy>.",
+    "errorConsentRequired": "You must accept the terms of use and the privacy policy to continue.",
+    "oauthConsentNotice": "By continuing with Google or a passkey, you accept our <terms>terms of use</terms> and our <privacy>privacy policy</privacy>."
   },
   "forgotPassword": {
     "title": "Forgot password",
@@ -1562,7 +1565,8 @@
     "deleteBody": "This action is irreversible. All data for <1>{{name}}</1> will be permanently deleted: symptoms, journal, crisis list, behaviors, and Barkley rewards.",
     "typeNameToConfirm": "Type <1>{{name}}</1> to confirm",
     "cancel": "Cancel",
-    "deleting": "Deleting..."
+    "deleting": "Deleting...",
+    "healthConsentLabel": "I hold parental authority over this child and I consent to Tokō processing their health data for tracking (GDPR, art. 9). I can withdraw this consent at any time."
   },
   "childAccess": {
     "sectionTitle": "Co-parents and shared access",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -223,7 +223,10 @@
     "errorRegister": "Erreur lors de l'inscription",
     "errorNetwork": "Connexion impossible. Vérifie ta connexion internet et réessaie.",
     "backToHome": "Accueil",
-    "forgotPassword": "Nouveau mot de passe ?"
+    "forgotPassword": "Nouveau mot de passe ?",
+    "consentLabel": "J'accepte les <terms>conditions d'utilisation</terms> et la <privacy>politique de confidentialité</privacy>.",
+    "errorConsentRequired": "Vous devez accepter les conditions d'utilisation et la politique de confidentialité pour continuer.",
+    "oauthConsentNotice": "En continuant avec Google ou une clé d'accès, vous acceptez nos <terms>conditions d'utilisation</terms> et notre <privacy>politique de confidentialité</privacy>."
   },
   "forgotPassword": {
     "title": "Choisir un nouveau mot de passe",
@@ -1986,7 +1989,8 @@
     "deleteBody": "Cette action est irréversible. Toutes les données de <1>{{name}}</1> seront définitivement supprimées : symptômes, journal, liste de crise, comportements et récompenses Barkley.",
     "typeNameToConfirm": "Tapez <1>{{name}}</1> pour confirmer",
     "cancel": "Annuler",
-    "deleting": "Suppression..."
+    "deleting": "Suppression...",
+    "healthConsentLabel": "Je détiens l'autorité parentale sur cet enfant et j'autorise Tokō à traiter ses données de santé pour le suivi (RGPD, art. 9). Je peux retirer ce consentement à tout moment."
   },
   "childAccess": {
     "sectionTitle": "Co-parents et accès partagé",

--- a/apps/web/src/routes/LoginPage.tsx
+++ b/apps/web/src/routes/LoginPage.tsx
@@ -2,6 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { useTranslation } from "react-i18next";
 import { ArrowLeft } from "lucide-react";
 import { BrandLogo } from "@/components/shared/brand-logo";
+import { LegalConsentText } from "@/components/shared/legal-consent-text";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Separator } from "@/components/ui/separator";
 import { useSeoHead } from "@/hooks/use-seo-head";
@@ -45,6 +46,10 @@ export function LoginPage() {
         <GoogleSignInButton />
 
         <PasskeySignInButton />
+
+        <p className="text-center text-xs leading-relaxed text-muted-foreground">
+          <LegalConsentText i18nKey="login.oauthConsentNotice" />
+        </p>
 
         <div className="flex items-center gap-3">
           <Separator className="flex-1" />

--- a/apps/web/src/routes/register-form.tsx
+++ b/apps/web/src/routes/register-form.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import { LegalConsentText } from "@/components/shared/legal-consent-text";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { signUp } from "@/lib/auth-client";
 import { trackEvent } from "@/lib/analytics";
@@ -11,11 +13,13 @@ type RegisterState = {
   name: string;
   email: string;
   password: string;
+  consent: boolean;
   error: string;
   loading: boolean;
 };
 type RegisterAction =
   | { type: "setField"; field: "name" | "email" | "password"; value: string }
+  | { type: "setConsent"; value: boolean }
   | { type: "setError"; error: string }
   | { type: "setLoading"; loading: boolean };
 
@@ -23,6 +27,8 @@ function registerReducer(state: RegisterState, action: RegisterAction): Register
   switch (action.type) {
     case "setField":
       return { ...state, [action.field]: action.value };
+    case "setConsent":
+      return { ...state, consent: action.value };
     case "setError":
       return { ...state, error: action.error };
     case "setLoading":
@@ -36,6 +42,7 @@ const REGISTER_INITIAL: RegisterState = {
   name: "",
   email: "",
   password: "",
+  consent: false,
   error: "",
   loading: false,
 };
@@ -43,10 +50,14 @@ const REGISTER_INITIAL: RegisterState = {
 export function RegisterForm() {
   const { t } = useTranslation();
   const [state, dispatch] = useReducer(registerReducer, REGISTER_INITIAL);
-  const { name, email, password, error, loading } = state;
+  const { name, email, password, consent, error, loading } = state;
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!consent) {
+      dispatch({ type: "setError", error: t("login.errorConsentRequired") });
+      return;
+    }
     dispatch({ type: "setError", error: "" });
     dispatch({ type: "setLoading", loading: true });
 
@@ -111,6 +122,20 @@ export function RegisterForm() {
               required
             />
           </div>
+          <div className="flex items-start gap-2">
+            <Checkbox
+              id="register-consent"
+              checked={consent}
+              onCheckedChange={(v) => dispatch({ type: "setConsent", value: v === true })}
+              className="mt-0.5"
+            />
+            <Label
+              htmlFor="register-consent"
+              className="text-xs font-normal leading-relaxed text-muted-foreground"
+            >
+              <LegalConsentText i18nKey="login.consentLabel" />
+            </Label>
+          </div>
           {error && (
             <p
               role="alert"
@@ -123,7 +148,7 @@ export function RegisterForm() {
           <Button
             type="submit"
             className="w-full shadow-sm shadow-primary/20"
-            disabled={loading}
+            disabled={loading || !consent}
           >
             {loading
               ? t("login.submittingRegister")

--- a/packages/db/src/schema/consents.ts
+++ b/packages/db/src/schema/consents.ts
@@ -26,6 +26,10 @@ export const consents = pgTable(
         // data as a co-parent. Written inside the same tx as the
         // child_access insert on accept.
         "co_parent_health_processing",
+        // Owner's Art. 9(2)(a) RGPD consent to process their own child's
+        // health data, plus the matching parental-authority attestation.
+        // Both are written inside the same tx as the child insert.
+        "owner_health_processing",
       ],
     }).notNull(),
     // Free-form version identifier, e.g. "2026-04-23" or "v2.1". Opaque

--- a/packages/validators/src/__tests__/schemas.test.ts
+++ b/packages/validators/src/__tests__/schemas.test.ts
@@ -4,6 +4,8 @@ import {
   createSymptomSchema,
   createJournalEntrySchema,
   createEventSchema,
+  consentTypeSchema,
+  grantConsentSchema,
 } from "../index";
 
 describe("createChildSchema", () => {
@@ -178,5 +180,35 @@ describe("createEventSchema", () => {
       sessionId: "s_abc123",
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe("consent schemas", () => {
+  it("accepts the owner health-processing consent type", () => {
+    expect(consentTypeSchema.safeParse("owner_health_processing").success).toBe(
+      true
+    );
+  });
+
+  it("still accepts terms and privacy types", () => {
+    expect(consentTypeSchema.safeParse("terms").success).toBe(true);
+    expect(consentTypeSchema.safeParse("privacy").success).toBe(true);
+  });
+
+  it("rejects an unknown consent type", () => {
+    expect(consentTypeSchema.safeParse("marketing").success).toBe(false);
+  });
+
+  it("grantConsentSchema requires a non-empty version", () => {
+    expect(
+      grantConsentSchema.safeParse({ type: "owner_health_processing", version: "" })
+        .success
+    ).toBe(false);
+    expect(
+      grantConsentSchema.safeParse({
+        type: "owner_health_processing",
+        version: "2026-07-13",
+      }).success
+    ).toBe(true);
   });
 });

--- a/packages/validators/src/consent.ts
+++ b/packages/validators/src/consent.ts
@@ -7,6 +7,9 @@ export const consentTypeSchema = z.enum([
   "research",
   "parental_authority_attestation",
   "co_parent_health_processing",
+  // Owner's Art. 9(2)(a) RGPD consent to process their own child's health
+  // data, captured when they create the child profile.
+  "owner_health_processing",
 ]);
 
 export const grantConsentSchema = z.object({


### PR DESCRIPTION
## Contexte

Implémente le chantier **consentement (P0)** du plan `docs/rgpd-compliance.md` — le principal manque légal identifié par l'audit : aucun consentement CGU/confidentialité à l'inscription, et aucun consentement RGPD art. 9 capturé pour le parent propriétaire (seul le parcours co-parent le faisait).

## Changements

**Inscription**
- Case à cocher **obligatoire** (CGU + politique de confidentialité) sur le formulaire d'inscription email, avec liens vers `/mentions-legales` et `/confidentialite`. Le bouton reste désactivé tant que la case n'est pas cochée.
- Mention de consentement sous les boutons Google / clé d'accès (l'OAuth crée aussi un compte).
- Hook Better Auth `user.create.after` qui enregistre les consentements `terms` + `privacy` pour **chaque** nouveau compte (email et Google).

**Création d'un profil enfant**
- Case à cocher **obligatoire** : autorité parentale + consentement explicite au traitement des données de santé (RGPD art. 9).
- L'API refuse la création sans ce consentement (422) et enregistre `parental_authority_attestation` + `owner_health_processing` dans la **même transaction** que l'enfant.

**Socle**
- Nouveau type de consentement `owner_health_processing` (colonne `text`, **aucune migration SQL nécessaire**).
- Module partagé `consent-versions.ts` pour versionner les documents de consentement.
- Composant partagé `LegalConsentText` pour la phrase de consentement liée, réutilisé par le formulaire d'inscription et la page d'authentification.

**Tests**
- Tests de validation pour le nouveau type de consentement (`consentTypeSchema`, `grantConsentSchema`).

## Revue

Diff passé en revue (code-review high effort) puis corrigé : churn i18n éliminé (édition ciblée au lieu d'une resérialisation complète des locales), duplication du bloc de consentement extraite en composant partagé, `aria-describedby` trompeur retiré. Deux constats mineurs conservés tels quels par choix de conception (hook fail-closed ; ordre des vérifications côté API).

## Vérification

- `pnpm typecheck` : ✅ (4 packages)
- `pnpm test` : ✅ (validators, db, web, api — tout passe, +4 tests de consentement)
- Aucun appelant cassé : seul `child-form` consomme `useCreateChild` ; le mobile ne fait que du GET ; les tests E2E ne soumettent pas les formulaires concernés.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8)_