### PR TITLE
chore: operationalize backups + legal-review handoff

### DIFF
--- a/deploy/backup-verify.sh
+++ b/deploy/backup-verify.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# backup-verify.sh — Verify a Tokō backup by restoring it into a throwaway
+# database and running a sanity check. A backup that has never been restored is
+# not a backup (RGPD art. 32 — availability/resilience of health data).
+#
+# Restores into a temporary database, checks that a core table has rows, then
+# drops the temporary database. The production database is never touched.
+#
+# Required environment:
+#   BACKUP_ENCRYPTION_KEY   passphrase used by backup.sh
+# Optional environment:
+#   TOKO_BACKUP_DIR         where backups live (default /opt/toko/backups)
+#   TOKO_PG_CONTAINER       postgres container (default toko-postgres)
+#   DB_USER                 superuser able to CREATE/DROP DATABASE (default toko)
+#   BACKUP_FILE             specific backup to verify (default: newest)
+#   VERIFY_DB_NAME          throwaway database name (default toko_verify)
+#
+# Usage:
+#   BACKUP_ENCRYPTION_KEY=... ./deploy/backup-verify.sh
+#   BACKUP_ENCRYPTION_KEY=... BACKUP_FILE=/path/to/toko-….sql.enc ./deploy/backup-verify.sh
+
+set -eu
+
+BACKUP_DIR="${TOKO_BACKUP_DIR:-/opt/toko/backups}"
+PG_CONTAINER="${TOKO_PG_CONTAINER:-toko-postgres}"
+DB_USER="${DB_USER:-toko}"
+VERIFY_DB_NAME="${VERIFY_DB_NAME:-toko_verify}"
+
+if [ -z "${BACKUP_ENCRYPTION_KEY:-}" ]; then
+  echo "[verify] ERROR: BACKUP_ENCRYPTION_KEY is required" >&2
+  exit 1
+fi
+
+for cmd in docker openssl; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "[verify] ERROR: $cmd not found" >&2; exit 1; }
+done
+
+# Pick the backup to verify — an explicit file, or the newest one.
+BACKUP_FILE="${BACKUP_FILE:-}"
+if [ -z "$BACKUP_FILE" ]; then
+  BACKUP_FILE="$(ls -1t "$BACKUP_DIR"/toko-*.sql.enc 2>/dev/null | head -n 1 || true)"
+fi
+if [ -z "$BACKUP_FILE" ] || [ ! -f "$BACKUP_FILE" ]; then
+  echo "[verify] ERROR: no backup file found in $BACKUP_DIR" >&2
+  exit 1
+fi
+echo "[verify] verifying $BACKUP_FILE"
+
+# Always drop the throwaway database, even on failure.
+cleanup() {
+  docker exec "$PG_CONTAINER" psql -U "$DB_USER" -d postgres \
+    -c "DROP DATABASE IF EXISTS \"$VERIFY_DB_NAME\";" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+cleanup
+docker exec "$PG_CONTAINER" psql -U "$DB_USER" -d postgres \
+  -c "CREATE DATABASE \"$VERIFY_DB_NAME\";" >/dev/null
+
+# Decrypt and pipe straight into psql — the plaintext dump never hits disk.
+openssl enc -d -aes-256-cbc -pbkdf2 -pass env:BACKUP_ENCRYPTION_KEY -in "$BACKUP_FILE" \
+  | docker exec -i "$PG_CONTAINER" psql -U "$DB_USER" -d "$VERIFY_DB_NAME" -v ON_ERROR_STOP=1 -q >/dev/null
+
+# Sanity check: the restored schema has tables, and a core table is queryable.
+TABLE_COUNT="$(docker exec "$PG_CONTAINER" psql -U "$DB_USER" -d "$VERIFY_DB_NAME" -tAc \
+  "SELECT count(*) FROM information_schema.tables WHERE table_schema = 'public';")"
+USER_COUNT="$(docker exec "$PG_CONTAINER" psql -U "$DB_USER" -d "$VERIFY_DB_NAME" -tAc \
+  "SELECT count(*) FROM \"user\";" 2>/dev/null || echo "ERR")"
+
+if [ "$TABLE_COUNT" -lt 1 ] 2>/dev/null || [ "$USER_COUNT" = "ERR" ]; then
+  echo "[verify] FAILED: restore produced $TABLE_COUNT tables, user table readable: $USER_COUNT" >&2
+  exit 1
+fi
+
+echo "[verify] OK — restored $TABLE_COUNT tables, \"user\" rows: $USER_COUNT"

--- a/deploy/systemd/toko-backup.service
+++ b/deploy/systemd/toko-backup.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Tokō encrypted database backup
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+# Adjust paths to your deployment. BACKUP_ENCRYPTION_KEY must be a root-only
+# file OUTSIDE the repo and different from DB_ENCRYPTION_KEY.
+WorkingDirectory=/opt/toko
+EnvironmentFile=/opt/toko/secrets/backup.env
+ExecStart=/opt/toko/deploy/backup.sh
+# Weekly, verify the newest backup actually restores.
+ExecStartPost=/bin/sh -c 'test "$(date +%%u)" = "7" && /opt/toko/deploy/backup-verify.sh || true'

--- a/deploy/systemd/toko-backup.timer
+++ b/deploy/systemd/toko-backup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run the Tokō database backup daily
+
+[Timer]
+# Daily at 02:30, with a randomized delay so it doesn't collide with other jobs.
+OnCalendar=*-*-* 02:30:00
+RandomizedDelaySec=300
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -21,16 +21,39 @@ Variables :
 | `DB_USER` / `DB_NAME` | identifiants base | `toko` / `toko` |
 | `BACKUP_RETENTION_DAYS` | rétention | `30` |
 
-## Planification (cron hôte)
+## Planification (systemd, recommandé)
 
-Sauvegarde quotidienne à 02:30, journalisée :
+Les unités versionnées `deploy/systemd/toko-backup.service` et
+`toko-backup.timer` planifient la sauvegarde quotidienne (02:30) et lancent une
+**vérification de restauration hebdomadaire** automatiquement. Installation :
+
+```sh
+sudo cp deploy/systemd/toko-backup.* /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now toko-backup.timer
+systemctl list-timers toko-backup.timer   # vérifier la prochaine échéance
+```
+
+Le service lit ses variables depuis `EnvironmentFile=/opt/toko/secrets/backup.env`,
+qui doit au minimum contenir `BACKUP_ENCRYPTION_KEY=…` (fichier hors du dépôt, en
+lecture seule root `chmod 600`, et **différent** de `DB_ENCRYPTION_KEY`).
+
+### Alternative : cron hôte
 
 ```cron
 30 2 * * * BACKUP_ENCRYPTION_KEY=$(cat /opt/toko/secrets/backup.key) /opt/toko/deploy/backup.sh >> /var/log/toko-backup.log 2>&1
 ```
 
-Le fichier `backup.key` doit être hors du dépôt, en lecture seule root
-(`chmod 600`), et **différent** de `DB_ENCRYPTION_KEY`.
+## Vérification de restauration
+
+`deploy/backup-verify.sh` restaure la sauvegarde la plus récente (ou celle passée
+via `BACKUP_FILE`) dans une base jetable, vérifie qu'elle contient des tables et
+que la table `user` est lisible, puis supprime la base de test. La base de
+production n'est **jamais** touchée.
+
+```sh
+BACKUP_ENCRYPTION_KEY=$(cat /opt/toko/secrets/backup.key) ./deploy/backup-verify.sh
+```
 
 ## Restauration
 

--- a/docs/legal-review-checklist.md
+++ b/docs/legal-review-checklist.md
@@ -1,0 +1,59 @@
+# Checklist de revue juridique — avant lancement public
+
+Les textes juridiques et l'AIPD ont été rédigés à partir de l'application telle
+que construite (faits vérifiables), mais **doivent être validés par un
+professionnel du droit** avant l'ouverture au public. Ce document liste
+précisément ce qui reste à trancher, pour un aller-retour efficace.
+
+## 1. Identité et coordonnées (à renseigner)
+
+Les pages actuelles disent « édité à titre personnel » sans identité complète.
+Le professionnel doit confirmer les mentions obligatoires (LCEN / RGPD) :
+
+- [ ] Nom / raison sociale de l'éditeur (responsable de traitement)
+- [ ] Adresse postale de contact
+- [ ] Email de contact pour l'exercice des droits (aujourd'hui : page de contact)
+- [ ] Le cas échéant : SIRET, directeur de la publication, DPO
+- [ ] Coordonnées précises de l'hébergeur (actuellement « UE / OVH » générique)
+
+Fichiers : `apps/web/src/lib/i18n/locales/fr.json` → clés `legal.*`.
+
+## 2. CGU (`/cgu`, clés `cgu.*`)
+
+Contenu de base fourni ; à faire valider :
+
+- [ ] Clauses de responsabilité et de garantie (limites conformes au droit conso.)
+- [ ] Conditions d'abonnement, rétractation (14 j) et remboursement
+- [ ] Clause de résiliation / suspension de compte
+- [ ] Droit applicable et juridiction compétente (actuellement : droit français)
+- [ ] Cohérence avec le statut « non-dispositif médical »
+
+## 3. Politique de confidentialité (`/confidentialite`, clés `privacy.*`)
+
+- [ ] Durées de conservation par catégorie (cf. registre art. 30, §13 de
+      `rgpd-compliance.md`) — confirmer les valeurs (events 13 mois, audit 3 ans,
+      compte : effacement ≤ 30 j)
+- [ ] Liste des sous-traitants exhaustive et exacte (Stripe, Resend, Google)
+- [ ] Formulation du consentement art. 9 (données de santé de l'enfant)
+- [ ] Base légale de la mesure d'audience (intérêt légitime / exemption CNIL)
+
+## 4. AIPD (`docs/aipd.md`)
+
+- [ ] Compléter avec les retours de la bêta fermée (Phase 3 du plan produit)
+- [ ] Valider l'analyse des risques et la proportionnalité
+- [ ] Décider si une **consultation préalable de la CNIL** est nécessaire
+- [ ] Trancher les risques résiduels documentés (chiffrement des textes libres,
+      scoping des clés) — décisions actuelles dans `rgpd-compliance.md §9/§11`
+
+## 5. Consentement enfant / autorité parentale
+
+- [ ] Confirmer que l'attestation d'autorité parentale + consentement art. 9
+      capturés à l'inscription et à la création d'enfant suffisent juridiquement
+- [ ] Vérifier le traitement du cas des parents séparés / co-parent
+
+## 6. Points déjà couverts (pour information)
+
+Consentement versionné et horodaté, export/suppression RGPD natifs, chiffrement
+au repos des données les plus sensibles, sous-traitants UE uniquement, aucun
+transfert hors UE, aucun tracker tiers, désinscription one-click, registre des
+traitements (art. 30). Détail et références de code dans `docs/rgpd-compliance.md`.

--- a/docs/rgpd-compliance.md
+++ b/docs/rgpd-compliance.md
@@ -201,8 +201,11 @@ reste est en clair (colonne) et repose sur la sécurité du volume Docker.
   besoin de recherche côté chiffré émerge (index chiffré / recherche
   déterministe).
 - [x] **P0 — Backups** : `deploy/backup.sh` (pg_dump chiffré AES-256, rétention,
-  purge) + procédure de restauration et planification cron documentées dans
-  `docs/backups.md`. Le dump en clair ne touche jamais le disque ; stockage UE.
+  purge), `deploy/backup-verify.sh` (test de restauration dans une base jetable)
+  et unités systemd versionnées (`deploy/systemd/`, sauvegarde quotidienne +
+  vérification hebdomadaire). Procédure complète dans `docs/backups.md`. Le dump
+  en clair ne touche jamais le disque ; stockage UE. **Reste à l'opérateur :**
+  installer les unités systemd et fournir `BACKUP_ENCRYPTION_KEY`.
 - [x] **P1 — Rediriger le tarif solidaire** vers une boîte dédiée
   (`support@toko.app`) au lieu de la boîte ProtonMail personnelle
   (`SOLIDARITY_NOTIFY_EMAIL`), et mentionner ce traitement dans la politique.
@@ -226,6 +229,11 @@ reste est en clair (colonne) et repose sur la sécurité du volume Docker.
 - [x] **P2 — AIPD (analyse d'impact)** : version préliminaire rédigée dans
   `docs/aipd.md` (description, nécessité/proportionnalité, risques et mesures,
   risques résiduels). À finaliser/valider avant le lancement public.
+
+> **Revue juridique :** la liste précise de ce qu'un professionnel du droit doit
+> valider (identité éditeur, clauses CGU, durées, AIPD, consentement enfant) est
+> centralisée dans `docs/legal-review-checklist.md` — pour un aller-retour
+> efficace avant le lancement public.
 
 ## 11. Accès programmatique (clés API, MCP, CLI)
 


### PR DESCRIPTION
## Contexte

Suite de la conformité RGPD (#340) : les deux dernières étapes étaient « externes au code » (opérateur + juriste). Ce PR les rend actionnables au maximum depuis le dépôt.

## Changements

**Sauvegardes — opérationnalisation (P0)**
- `deploy/backup-verify.sh` : restaure la sauvegarde la plus récente dans une base **jetable**, vérifie qu'elle contient des tables et que `user` est lisible, puis supprime la base de test. La base de production n'est jamais touchée → « tester la restauration » devient une seule commande.
- `deploy/systemd/toko-backup.{service,timer}` : planification **versionnée** (sauvegarde quotidienne 02:30 + vérification de restauration hebdomadaire), à la place d'une ligne cron écrite à la main.
- `docs/backups.md` : étapes d'installation systemd + section vérification.

**Revue juridique — handoff**
- `docs/legal-review-checklist.md` : liste concrète de ce qu'un professionnel du droit doit valider avant le lancement public (identité éditeur, clauses CGU, durées de rétention, AIPD, consentement enfant / autorité parentale), avec les décisions déjà prises pour référence.

**Doc**
- `docs/rgpd-compliance.md` référence le nouveau tooling et la checklist ; précise ce qui reste à l'opérateur (installer les unités systemd + fournir `BACKUP_ENCRYPTION_KEY`).

## Vérification

Docs + scripts shell uniquement (aucun impact build/typecheck/tests). Scripts validés par `sh -n`. Le dump en clair ne touche jamais le disque ; stockage/traitement UE.

## Reste hors dépôt (par nature)

Installer les unités systemd et le secret sur l'hôte de production ; faire valider les textes juridiques et l'AIPD par un professionnel (checklist fournie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8)_