### PR TITLE
feat: recenter landing on the medical-report mono-CTA

### DIFF
--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -35,6 +35,7 @@
     "nav": {
       "features": "Features",
       "resources": "Resources",
+      "formation": "Training",
       "pricing": "Pricing",
       "login": "Sign in",
       "getStarted": "Try for free",
@@ -69,6 +70,12 @@
         "author": "Elise, mother of Sacha (10)"
       }
     },
+    "formation":     {
+      "badge": "Inspired by the Barkley method · recommended by France's HAS",
+      "title": "Tokō Training — parenting skills, at your pace",
+      "description": "The 10 steps of the parent-training program inspired by Dr Barkley's method, with lessons and quizzes — right inside the app, for families affected by ADHD.",
+      "cta": "Discover the training"
+    },
     "resourcesTeaser": {
       "title": "Understand and support your child",
       "description": "Clear guides on everyday parenting — routines, sleep, emotions — with an ADHD section for families who need it. Drawn from public scientific publications, they don't replace a healthcare professional's advice.",
@@ -85,10 +92,10 @@
       "note": "Just one email at launch. No spam, unsubscribe anytime."
     },
     "hero": {
-      "title1": "Fewer meltdowns,",
-      "title2": "more time together.",
-      "description": "Tokō helps parents of children with ADHD bring calm back to daily life. Spot what soothes your child, reduce meltdowns, and free up quality time — to rebuild the bond and feel at home in family life again.",
-      "ctaPrimary": "Try Tokō for free",
+      "title1": "Show up to your next appointment",
+      "title2": "with a clear report.",
+      "description": "Note your child's day in 30 seconds. Tokō turns it into a tracking report your doctor can actually use: trends, treatment, side effects, and the questions to ask.",
+      "ctaPrimary": "Prepare my next appointment",
       "ctaSecondary": "See how it works",
       "noCard": "No credit card. 2 minutes to get started."
     },
@@ -195,9 +202,9 @@
       }
     },
     "finalCta": {
-      "title": "2 minutes tonight. A calmer day tomorrow.",
-      "description": "Create your free account and write your first note tonight.",
-      "cta": "Create my free account"
+      "title": "Your next appointment is coming up.",
+      "description": "Start noting tonight — every day counts toward a complete report on the day.",
+      "cta": "Prepare my next appointment"
     },
     "footer": {
       "tagline": "Tokō — Fewer meltdowns, more time together",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -35,16 +35,17 @@
     "nav": {
       "features": "Fonctionnalités",
       "resources": "Ressources",
+      "formation": "Formation",
       "pricing": "Tarifs",
       "login": "Connexion",
       "getStarted": "Essayer gratuitement",
       "menu": "Menu"
     },
     "hero": {
-      "title1": "Moins de crises,",
-      "title2": "plus de moments en famille.",
-      "description": "Tokō aide les parents d'enfants TDAH à apaiser le quotidien. Identifiez ce qui calme votre enfant, espacez les crises et libérez du temps de qualité — pour restaurer le lien et retrouver une vie de famille plus sereine.",
-      "ctaPrimary": "Essayer Tokō gratuitement",
+      "title1": "Arrivez à votre prochain rendez-vous",
+      "title2": "avec un rapport clair.",
+      "description": "Notez la journée de votre enfant en 30 secondes. Tokō en fait un rapport de suivi que votre médecin peut vraiment utiliser : tendances, traitement, effets secondaires, et les questions à poser.",
+      "ctaPrimary": "Préparer mon prochain rendez-vous",
       "ctaSecondary": "Voir comment ça marche",
       "noCard": "Sans carte bancaire. 2 minutes pour démarrer."
     },
@@ -76,6 +77,12 @@
         "quote": "Le programme Barkley étape par étape m'a donné une structure. J'ai arrêté de naviguer à vue.",
         "author": "Elise, maman de Sacha (10 ans)"
       }
+    },
+    "formation":     {
+      "badge": "Inspirée de la méthode Barkley · recommandée par la HAS",
+      "title": "Tokō Formation — les habiletés parentales, à votre rythme",
+      "description": "Les 10 étapes du programme d'entraînement aux habiletés parentales inspiré de la méthode du Dr Barkley, avec contenu pédagogique et quiz — directement dans l'app, pour les familles concernées par le TDAH.",
+      "cta": "Découvrir la formation"
     },
     "resourcesTeaser": {
       "title": "Comprendre et accompagner votre enfant",
@@ -195,9 +202,9 @@
       }
     },
     "finalCta": {
-      "title": "2 minutes ce soir. Une journée plus calme demain.",
-      "description": "Créez votre compte gratuit et notez votre première observation dès ce soir.",
-      "cta": "Créer mon compte gratuit"
+      "title": "Votre prochain rendez-vous approche.",
+      "description": "Commencez à noter ce soir : chaque jour compte pour un rapport complet le jour J.",
+      "cta": "Préparer mon prochain rendez-vous"
     },
     "footer": {
       "tagline": "Tokō — Moins de crises, plus de moments en famille",

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -8,6 +8,7 @@ import {
   TrustBar,
   ResourcesTeaser,
   FeaturesSection,
+  FormationBanner,
   TestimonialsSection,
   AndroidWaitlistSection,
   FinalCtaSection,
@@ -40,6 +41,7 @@ function LandingPage() {
       <TrustBar />
       <ResourcesTeaser />
       <FeaturesSection />
+      <FormationBanner />
       <TestimonialsSection />
       <PricingSection />
       <AndroidWaitlistSection />

--- a/apps/web/src/routes/landing-sections.tsx
+++ b/apps/web/src/routes/landing-sections.tsx
@@ -13,6 +13,7 @@ import {
   Menu,
   Smartphone,
   Check,
+  GraduationCap,
 } from "lucide-react";
 import { BrandLogo } from "@/components/shared/brand-logo";
 import { Button } from "@/components/ui/button";
@@ -67,6 +68,12 @@ export function Nav() {
             className="text-muted-foreground transition-colors hover:text-foreground"
           >
             {t("landing.nav.features")}
+          </a>
+          <a
+            href="#formation"
+            className="text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {t("landing.nav.formation")}
           </a>
           <Link
             to="/ressources"
@@ -133,6 +140,16 @@ function MobileNavSheet() {
                 className="rounded-md px-3 py-2 text-foreground hover:bg-muted"
               >
                 {t("landing.nav.features")}
+              </a>
+            }
+          />
+          <SheetClose
+            render={
+              <a
+                href="#formation"
+                className="rounded-md px-3 py-2 text-foreground hover:bg-muted"
+              >
+                {t("landing.nav.formation")}
               </a>
             }
           />
@@ -376,6 +393,42 @@ export function FeaturesSection() {
         <p className="mx-auto mt-10 max-w-3xl text-center text-sm leading-relaxed text-muted-foreground">
           {t("landing.features.andMore")}
         </p>
+      </div>
+    </section>
+  );
+}
+
+export function FormationBanner() {
+  const { t } = useTranslation();
+  return (
+    <section
+      id="formation"
+      className="scroll-mt-20 border-t border-border/60 py-16"
+    >
+      <div className="mx-auto max-w-5xl px-4">
+        <div className="flex flex-col items-start gap-6 rounded-2xl border border-accent-200/60 bg-accent-100/30 p-6 sm:flex-row sm:items-center sm:justify-between sm:p-8">
+          <div className="max-w-2xl">
+            <Badge
+              variant="outline"
+              className="mb-3 border-accent-300/60 bg-accent-100/40 text-accent-700"
+            >
+              {t("landing.formation.badge")}
+            </Badge>
+            <h2 className="font-heading flex items-center gap-2 text-xl font-semibold tracking-tight sm:text-2xl">
+              <GraduationCap className="size-5 shrink-0 text-accent-700" />
+              {t("landing.formation.title")}
+            </h2>
+            <p className="mt-3 leading-relaxed text-muted-foreground">
+              {t("landing.formation.description")}
+            </p>
+          </div>
+          <Link to="/login" className="w-full shrink-0 sm:w-auto">
+            <Button variant="outline" size="lg" className="w-full gap-2 sm:w-auto">
+              {t("landing.formation.cta")}
+              <ArrowRight className="size-4" />
+            </Button>
+          </Link>
+        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
## Contexte

Phase 1 (volet landing) du recentrage produit (#335 / suivi #343). Recentre la landing sur **un seul message** : le rapport médical.

## Changements

- **Hero mono-CTA** : « Moins de crises, plus de moments en famille » → « **Arrivez à votre prochain rendez-vous avec un rapport clair** », description axée rapport (tendances, traitement, effets secondaires, questions à poser), CTA « **Préparer mon prochain rendez-vous** ». Final CTA aligné.
- **Offre Formation (§4.2)** : entrée de nav « Formation » (ancre) + `FormationBanner` — un bandeau présentant le programme Barkley comme offre distincte (badge « inspirée de la méthode Barkley · recommandée par la HAS »). Le CTA pointe vers l'inscription pour l'instant ; la landing `/formation` dédiée + produit Stripe one-shot restent le suivi tracé dans #343.

Copy uniquement + une nouvelle section ; **aucune suppression** de feature/DB.

## Vérification

- `pnpm typecheck` ✅ · `pnpm test` ✅
- **Rendu réel vérifié** (dev server + Chromium) : hero et bandeau Formation s'affichent correctement (captures partagées dans la conversation).
- E2E landing non impacté : le test hero vérifie la présence d'un `h1` (pas le texte exact) ; features/pricing headings inchangés.

## Suite (tracé dans #343)

Landing `/formation` dédiée + produit Stripe one-shot ; simplification des features (Phase 1) ; fusion de la saisie quotidienne (Phase 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8)_