### PR TITLE
feat: dedicated /formation landing page (Barkley offer)

### DIFF
--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -386,6 +386,50 @@
       }
     }
   },
+  "formationPage":   {
+    "badge": "Inspired by the Barkley method · recommended by France's HAS",
+    "hero": {
+      "title": "Workshops have months-long waitlists. Start tonight.",
+      "description": "The parent-training program, in 10 steps, at your own pace. Built for parents of children affected by ADHD.",
+      "cta": "Start the training",
+      "note": "Included in Tokō · no card to get started"
+    },
+    "curriculum": {
+      "title": "10 steps, like the workshops",
+      "subtitle": "A progressive path, with lessons and a quiz at each step."
+    },
+    "steps": {
+      "understand": {
+        "range": "1–3",
+        "title": "Understand",
+        "body": "ADHD, positive attention, and setting a clear, predictable framework."
+      },
+      "act": {
+        "range": "4–7",
+        "title": "Act",
+        "body": "Effective instructions, a reward system, handling difficult behaviors and meltdowns."
+      },
+      "anchor": {
+        "range": "8–10",
+        "title": "Anchor",
+        "body": "School, public places, and sustaining what you've built over time."
+      }
+    },
+    "practice": {
+      "title": "The training teaches. The app makes the practice real.",
+      "body": "What no video course does: target behaviors, stars, and daily tracking activate right inside Tokō, step by step.",
+      "points": {
+        "log": "Daily tracking of target behaviors",
+        "rewards": "Reward board with the stars earned",
+        "track": "Visible progress, step after step"
+      }
+    },
+    "finalCta": {
+      "title": "Ready to start?",
+      "cta": "Create my account"
+    },
+    "disclaimer": "A parent-training program inspired by Dr Barkley's method. Tokō is not a medical device and does not replace support from a healthcare professional."
+  },
   "legal": {
     "title": "Legal notice",
     "editor": "Site publisher",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -390,6 +390,50 @@
       }
     }
   },
+  "formationPage":   {
+    "badge": "Inspirée de la méthode Barkley · recommandée par la HAS",
+    "hero": {
+      "title": "Les ateliers ont des mois d'attente. Commencez ce soir.",
+      "description": "Le programme d'entraînement aux habiletés parentales, en 10 étapes, à votre rythme. Pensé pour les parents d'enfants concernés par le TDAH.",
+      "cta": "Commencer la formation",
+      "note": "Incluse dans Tokō · sans carte bancaire pour démarrer"
+    },
+    "curriculum": {
+      "title": "10 étapes, comme les ateliers",
+      "subtitle": "Un parcours progressif, avec contenu pédagogique et quiz à chaque étape."
+    },
+    "steps": {
+      "understand": {
+        "range": "1–3",
+        "title": "Comprendre",
+        "body": "Le TDAH, l'attention positive, poser un cadre clair et prévisible."
+      },
+      "act": {
+        "range": "4–7",
+        "title": "Agir",
+        "body": "Consignes efficaces, système de récompenses, gestion des comportements difficiles et des crises."
+      },
+      "anchor": {
+        "range": "8–10",
+        "title": "Ancrer",
+        "body": "L'école, les lieux publics, et maintenir les acquis dans la durée."
+      }
+    },
+    "practice": {
+      "title": "La formation enseigne. L'app fait vivre la pratique.",
+      "body": "Ce qu'aucun cours vidéo ne fait : les comportements cibles, les étoiles et les suivis quotidiens s'activent directement dans Tokō, au fil des étapes.",
+      "points": {
+        "log": "Suivi quotidien des comportements cibles",
+        "rewards": "Tableau de récompenses avec les étoiles gagnées",
+        "track": "Progression visible étape après étape"
+      }
+    },
+    "finalCta": {
+      "title": "Prêt·e à commencer ?",
+      "cta": "Créer mon compte"
+    },
+    "disclaimer": "Programme d'entraînement aux habiletés parentales inspiré de la méthode du Dr Barkley. Tokō n'est pas un dispositif médical et ne remplace pas un accompagnement par un professionnel de santé."
+  },
   "legal": {
     "title": "Mentions légales",
     "editor": "Éditeur du site",

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as TarifsRouteImport } from './routes/tarifs'
 import { Route as ResetPasswordRouteImport } from './routes/reset-password'
 import { Route as MentionsLegalesRouteImport } from './routes/mentions-legales'
 import { Route as LoginRouteImport } from './routes/login'
+import { Route as FormationRouteImport } from './routes/formation'
 import { Route as ForgotPasswordRouteImport } from './routes/forgot-password'
 import { Route as DevelopersRouteImport } from './routes/developers'
 import { Route as ContactRouteImport } from './routes/contact'
@@ -70,6 +71,11 @@ const MentionsLegalesRoute = MentionsLegalesRouteImport.update({
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
   path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const FormationRoute = FormationRouteImport.update({
+  id: '/formation',
+  path: '/formation',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ForgotPasswordRoute = ForgotPasswordRouteImport.update({
@@ -299,6 +305,7 @@ export interface FileRoutesByFullPath {
   '/contact': typeof ContactRoute
   '/developers': typeof DevelopersRoute
   '/forgot-password': typeof ForgotPasswordRoute
+  '/formation': typeof FormationRoute
   '/login': typeof LoginRoute
   '/mentions-legales': typeof MentionsLegalesRoute
   '/reset-password': typeof ResetPasswordRoute
@@ -342,6 +349,7 @@ export interface FileRoutesByTo {
   '/contact': typeof ContactRoute
   '/developers': typeof DevelopersRoute
   '/forgot-password': typeof ForgotPasswordRoute
+  '/formation': typeof FormationRoute
   '/login': typeof LoginRoute
   '/mentions-legales': typeof MentionsLegalesRoute
   '/reset-password': typeof ResetPasswordRoute
@@ -387,6 +395,7 @@ export interface FileRoutesById {
   '/contact': typeof ContactRoute
   '/developers': typeof DevelopersRoute
   '/forgot-password': typeof ForgotPasswordRoute
+  '/formation': typeof FormationRoute
   '/login': typeof LoginRoute
   '/mentions-legales': typeof MentionsLegalesRoute
   '/reset-password': typeof ResetPasswordRoute
@@ -432,6 +441,7 @@ export interface FileRouteTypes {
     | '/contact'
     | '/developers'
     | '/forgot-password'
+    | '/formation'
     | '/login'
     | '/mentions-legales'
     | '/reset-password'
@@ -475,6 +485,7 @@ export interface FileRouteTypes {
     | '/contact'
     | '/developers'
     | '/forgot-password'
+    | '/formation'
     | '/login'
     | '/mentions-legales'
     | '/reset-password'
@@ -519,6 +530,7 @@ export interface FileRouteTypes {
     | '/contact'
     | '/developers'
     | '/forgot-password'
+    | '/formation'
     | '/login'
     | '/mentions-legales'
     | '/reset-password'
@@ -564,6 +576,7 @@ export interface RootRouteChildren {
   ContactRoute: typeof ContactRoute
   DevelopersRoute: typeof DevelopersRoute
   ForgotPasswordRoute: typeof ForgotPasswordRoute
+  FormationRoute: typeof FormationRoute
   LoginRoute: typeof LoginRoute
   MentionsLegalesRoute: typeof MentionsLegalesRoute
   ResetPasswordRoute: typeof ResetPasswordRoute
@@ -602,6 +615,13 @@ declare module '@tanstack/react-router' {
       path: '/login'
       fullPath: '/login'
       preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/formation': {
+      id: '/formation'
+      path: '/formation'
+      fullPath: '/formation'
+      preLoaderRoute: typeof FormationRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/forgot-password': {
@@ -945,6 +965,7 @@ const rootRouteChildren: RootRouteChildren = {
   ContactRoute: ContactRoute,
   DevelopersRoute: DevelopersRoute,
   ForgotPasswordRoute: ForgotPasswordRoute,
+  FormationRoute: FormationRoute,
   LoginRoute: LoginRoute,
   MentionsLegalesRoute: MentionsLegalesRoute,
   ResetPasswordRoute: ResetPasswordRoute,

--- a/apps/web/src/routes/FormationPage.tsx
+++ b/apps/web/src/routes/FormationPage.tsx
@@ -1,0 +1,145 @@
+import { Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { ArrowLeft, ArrowRight, GraduationCap, Check } from "lucide-react";
+import { BrandLogo } from "@/components/shared/brand-logo";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useSeoHead } from "@/hooks/use-seo-head";
+
+// The three curriculum blocks. Each maps to cgu-style i18n keys under
+// `formationPage.steps.<key>`.
+const STEP_GROUPS = ["understand", "act", "anchor"] as const;
+
+export function FormationPage() {
+  const { t } = useTranslation();
+  useSeoHead({
+    title: "Programme Barkley en ligne — Tokō Formation",
+    description:
+      "Le programme d'entraînement aux habiletés parentales inspiré de la méthode Barkley, en 10 étapes, à votre rythme. Pour les parents d'enfants TDAH.",
+    canonical: "https://toko.battistella.ovh/formation",
+  });
+
+  return (
+    <div className="min-h-dvh bg-background">
+      {/* Minimal top bar */}
+      <header className="border-b border-border/60">
+        <div className="mx-auto flex h-16 max-w-5xl items-center justify-between px-4">
+          <Link to="/" className="flex items-center gap-2">
+            <BrandLogo className="size-8 rounded-lg" />
+            <span className="font-heading text-xl font-semibold tracking-tight">
+              Tokō
+            </span>
+          </Link>
+          <Link
+            to="/"
+            className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="size-4" />
+            {t("common.back")}
+          </Link>
+        </div>
+      </header>
+
+      {/* Hero */}
+      <section className="relative overflow-hidden border-b border-border/60">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-20%,oklch(0.85_0.09_75_/_0.15),transparent)]" />
+        <div className="relative mx-auto max-w-3xl px-4 py-16 text-center sm:py-20">
+          <Badge
+            variant="outline"
+            className="mb-4 border-accent-300/60 bg-accent-100/40 text-accent-700"
+          >
+            {t("formationPage.badge")}
+          </Badge>
+          <h1 className="font-heading mx-auto max-w-2xl text-3xl font-semibold leading-tight tracking-tight sm:text-4xl">
+            {t("formationPage.hero.title")}
+          </h1>
+          <p className="mx-auto mt-5 max-w-xl text-lg leading-relaxed text-muted-foreground">
+            {t("formationPage.hero.description")}
+          </p>
+          <div className="mt-8">
+            <Link to="/login">
+              <Button size="lg" className="gap-2 px-8 text-base shadow-md shadow-primary/20">
+                {t("formationPage.hero.cta")}
+                <ArrowRight className="size-4" />
+              </Button>
+            </Link>
+            <p className="mt-3 text-sm text-muted-foreground/80">
+              {t("formationPage.hero.note")}
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* Curriculum */}
+      <section className="border-b border-border/60 py-16">
+        <div className="mx-auto max-w-5xl px-4">
+          <h2 className="font-heading text-center text-2xl font-semibold tracking-tight">
+            {t("formationPage.curriculum.title")}
+          </h2>
+          <p className="mx-auto mt-3 max-w-xl text-center text-muted-foreground">
+            {t("formationPage.curriculum.subtitle")}
+          </p>
+          <div className="mt-10 grid gap-6 md:grid-cols-3">
+            {STEP_GROUPS.map((key) => (
+              <div
+                key={key}
+                className="rounded-2xl border border-border/60 bg-card/60 p-6"
+              >
+                <div className="mb-3 flex size-10 items-center justify-center rounded-xl bg-accent-100 font-heading text-sm font-semibold text-accent-700">
+                  {t(`formationPage.steps.${key}.range`)}
+                </div>
+                <h3 className="font-heading text-lg font-semibold">
+                  {t(`formationPage.steps.${key}.title`)}
+                </h3>
+                <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                  {t(`formationPage.steps.${key}.body`)}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* The app makes the practice real — the differentiator */}
+      <section className="border-b border-border/60 bg-muted/30 py-16">
+        <div className="mx-auto flex max-w-4xl flex-col gap-4 px-4 text-center">
+          <GraduationCap className="mx-auto size-8 text-accent-700" />
+          <h2 className="font-heading text-2xl font-semibold tracking-tight">
+            {t("formationPage.practice.title")}
+          </h2>
+          <p className="mx-auto max-w-2xl leading-relaxed text-muted-foreground">
+            {t("formationPage.practice.body")}
+          </p>
+          <ul className="mx-auto mt-2 flex max-w-xl flex-col gap-2 text-left">
+            {["log", "rewards", "track"].map((k) => (
+              <li key={k} className="flex items-start gap-2 text-sm text-foreground/90">
+                <Check className="mt-0.5 size-4 shrink-0 text-primary" />
+                {t(`formationPage.practice.points.${k}`)}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+
+      {/* CTA + legal */}
+      <section className="py-16">
+        <div className="mx-auto max-w-2xl px-4 text-center">
+          <h2 className="font-heading text-2xl font-semibold tracking-tight">
+            {t("formationPage.finalCta.title")}
+          </h2>
+          <div className="mt-6">
+            <Link to="/login">
+              <Button size="lg" className="gap-2 px-8 text-base shadow-md shadow-primary/20">
+                {t("formationPage.finalCta.cta")}
+                <ArrowRight className="size-4" />
+              </Button>
+            </Link>
+          </div>
+          <p className="mx-auto mt-8 max-w-xl text-xs leading-relaxed text-muted-foreground">
+            {t("formationPage.disclaimer")}
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/routes/formation.tsx
+++ b/apps/web/src/routes/formation.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { FormationPage } from "./FormationPage";
+
+export const Route = createFileRoute("/formation")({
+  component: FormationPage,
+});

--- a/apps/web/src/routes/landing-sections.tsx
+++ b/apps/web/src/routes/landing-sections.tsx
@@ -422,7 +422,7 @@ export function FormationBanner() {
               {t("landing.formation.description")}
             </p>
           </div>
-          <Link to="/login" className="w-full shrink-0 sm:w-auto">
+          <Link to="/formation" className="w-full shrink-0 sm:w-auto">
             <Button variant="outline" size="lg" className="w-full gap-2 sm:w-auto">
               {t("landing.formation.cta")}
               <ArrowRight className="size-4" />


### PR DESCRIPTION
## Contexte

Poursuit la présentation « une marque, trois offres » (§4.2, suivi #343) : une landing dédiée `/formation` pour le programme Barkley.

## Changements

- **Page `/formation`** : landing SEO (« programme Barkley en ligne ») — hero « Les ateliers ont des mois d'attente. Commencez ce soir. », les **10 étapes en 3 blocs** (Comprendre 1–3 / Agir 4–7 / Ancrer 8–10), le différenciateur « la formation enseigne, l'app fait vivre la pratique », CTA d'inscription, et le garde-fou légal « inspiré de la méthode Barkley · pas un dispositif médical ».
- Le bandeau Formation de la landing pointe désormais **vers `/formation`** (au lieu d'un placeholder vers `/login`).

## Vérification

- `pnpm typecheck` ✅ · `pnpm test` ✅
- **Rendu réel vérifié** (dev server + Chromium) — capture partagée dans la conversation.
- Route file-based ajoutée + `routeTree.gen.ts` régénéré. Aucun E2E ne référence `/formation`.

## Suite (tracé dans #343)

Produit Stripe one-shot (achat unique 79–149 €, `mode: payment`) + déverrouillage du contenu à l'achat — changement billing/webhook qui mérite sa propre PR et une config Stripe réelle. Le CTA pointe pour l'instant vers l'inscription (le programme Barkley est déjà accessible dans l'app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8)_