### PR TITLE
feat: quick journal note on the dashboard (one-screen daily entry)

### DIFF
--- a/apps/web/src/components/dashboard/journal-quick-note.tsx
+++ b/apps/web/src/components/dashboard/journal-quick-note.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { toast } from "sonner";
+import { NotebookPen, Check, ArrowRight } from "lucide-react";
+import { Link } from "@tanstack/react-router";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { useCreateJournalEntry } from "@/hooks/use-journal";
+import { tagConfig } from "@/components/journal/journal-card-data";
+import { todayISO } from "@/lib/date";
+import { cn } from "@/lib/utils";
+import type { JournalTag } from "@focusflow/validators";
+
+// Quick daily journal note, on the dashboard so the whole daily entry
+// (mood + medication + a note) lives on one screen — product-strategy Phase 2
+// "fuse the daily entry". The full /journal screen stays for history/editing.
+const QUICK_TAGS: JournalTag[] = ["victory", "crisis", "school", "sleep"];
+
+export function JournalQuickNote({ childId }: { childId: string }) {
+  const { t } = useTranslation();
+  const createEntry = useCreateJournalEntry();
+  const [text, setText] = useState("");
+  const [tags, setTags] = useState<JournalTag[]>([]);
+  const [justSaved, setJustSaved] = useState(false);
+
+  const toggleTag = (tag: JournalTag) =>
+    setTags((prev) =>
+      prev.includes(tag) ? prev.filter((x) => x !== tag) : [...prev, tag]
+    );
+
+  const handleSave = () => {
+    if (!text.trim() || createEntry.isPending) return;
+    createEntry.mutate(
+      { childId, date: todayISO(), text: text.trim(), tags },
+      {
+        onSuccess: () => {
+          setText("");
+          setTags([]);
+          setJustSaved(true);
+          toast.success(t("journalQuickNote.saved"));
+          setTimeout(() => setJustSaved(false), 2500);
+        },
+        onError: () => toast.error(t("journalQuickNote.error")),
+      }
+    );
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <NotebookPen className="size-4" />
+          {t("journalQuickNote.title")}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder={t("journalQuickNote.placeholder")}
+          rows={3}
+          aria-label={t("journalQuickNote.title")}
+          className="resize-none"
+        />
+        <div className="flex flex-wrap gap-2">
+          {QUICK_TAGS.map((tag) => {
+            const active = tags.includes(tag);
+            return (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => toggleTag(tag)}
+                aria-pressed={active}
+                className={cn(
+                  "rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                  active
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-border text-muted-foreground hover:bg-muted"
+                )}
+              >
+                {t(tagConfig[tag].labelKey)}
+              </button>
+            );
+          })}
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <Button
+            onClick={handleSave}
+            disabled={!text.trim() || createEntry.isPending}
+            className="gap-2"
+          >
+            {justSaved ? (
+              <Check className="size-4" data-icon="inline-start" />
+            ) : null}
+            {justSaved
+              ? t("journalQuickNote.savedShort")
+              : t("journalQuickNote.save")}
+          </Button>
+          <Link
+            to="/journal"
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {t("journalQuickNote.openJournal")}
+            <ArrowRight className="size-3" />
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -1896,6 +1896,15 @@
     "average": "Average of {{minutes}} min/day over {{days}} tracked days",
     "empty": "Start logging your evenings to watch the calm build up."
   },
+  "journalQuickNote":   {
+    "title": "Today's note",
+    "placeholder": "A word about the day? (optional)",
+    "save": "Save note",
+    "savedShort": "Saved",
+    "saved": "Note added to the journal.",
+    "error": "Couldn't save the note. Please try again.",
+    "openJournal": "Open journal"
+  },
   "eveningCheck": {
     "title": "How was tonight?",
     "vibe_hard": "Rough",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -2320,6 +2320,15 @@
     "average": "Moyenne de {{minutes}} min/jour sur {{days}} j notés",
     "empty": "Commencez à noter vos soirées pour voir le calme s'accumuler."
   },
+  "journalQuickNote":   {
+    "title": "Note du jour",
+    "placeholder": "Un mot sur la journée ? (facultatif)",
+    "save": "Enregistrer la note",
+    "savedShort": "Enregistré",
+    "saved": "Note ajoutée au journal.",
+    "error": "Impossible d'enregistrer la note. Réessayez.",
+    "openJournal": "Ouvrir le journal"
+  },
   "eveningCheck": {
     "title": "La soirée de ce soir ?",
     "vibe_hard": "Difficile",

--- a/apps/web/src/routes/_authenticated/dashboard/dashboard-page.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard/dashboard-page.tsx
@@ -40,6 +40,7 @@ import { CorrelationInsight } from "@/components/dashboard/correlation-insight";
 import { CalmMinutesCard } from "@/components/dashboard/calm-minutes-card";
 import { EveningCheck } from "@/components/dashboard/evening-check";
 import { MedicationQuickLog } from "@/components/dashboard/medication-quick-log";
+import { JournalQuickNote } from "@/components/dashboard/journal-quick-note";
 import { BarkleyProgressCard } from "@/components/dashboard/barkley-progress-card";
 import { ResourceHintCard } from "@/components/dashboard/resource-hint-card";
 import { AddChildForm } from "@/components/shared/add-child-form";
@@ -195,6 +196,7 @@ export default function DashboardPage() {
           </div>
           {activeChildId && <MedicationQuickLog childId={activeChildId} />}
         </div>
+        {activeChildId && <JournalQuickNote childId={activeChildId} />}
       </motion.section>
 
       {/* ── Zone C: Comprendre ────────────────────────────── */}


### PR DESCRIPTION
## Contexte

Phase 2 du recentrage produit (#335 / suivi #343) : « fusionner la saisie quotidienne en un écran ».

Le tableau de bord héberge déjà l'humeur du jour, le suivi médicament et le check du soir. La seule saisie quotidienne qui obligeait encore à quitter la page était **la note de journal**.

## Changements

- **`JournalQuickNote`** dans la zone « Suivi rapide » du dashboard : une note courte + étiquettes rapides (victoire / crise / école / sommeil) qui crée l'entrée de journal du jour via le hook existant, avec un lien vers `/journal` pour l'historique.
- L'écran `/journal` complet est **inchangé** (historique, édition).

## Vérification

- `pnpm typecheck` ✅ · `pnpm test` ✅
- Additif et à faible risque (réutilise `useCreateJournalEntry`, composants `Card`/`Textarea`/`Button` existants).
- Le dashboard est exercé par la CI E2E (`auth.setup` + `dashboard.spec`) : un crash du rendu serait détecté.

## Suite (tracé dans #343)

Reste de la Phase 2 : rappels push quotidiens (le job `daily-reminders` existe déjà), amélioration du rapport PDF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8)_