### PR TITLE
feat: Phase 2 core — report trend column, PDF glyph fixes, evening-reminder opt-in

### DIFF
--- a/apps/api/src/__tests__/report-render.test.ts
+++ b/apps/api/src/__tests__/report-render.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+    buildReportPdf,
+    buildReportHtml,
+    type ReportData,
+} from "../routes/report";
+
+// A 20-day fixture where each dimension moves in a known direction, so we can
+// assert the trend column renders the right valence without a database.
+function fixture(): ReportData {
+    const dates = Array.from(
+        { length: 20 },
+        (_, i) => `2026-03-${String(i + 1).padStart(2, "0")}`,
+    );
+    const lin = (a: number, b: number, i: number) =>
+        Math.round(a + (b - a) * (i / 19));
+    return {
+        child: { name: "Lucas", gender: "male", ageRange: "6-8" },
+        sinceDate: dates[0]!,
+        untilDate: dates[19]!,
+        symptoms: dates.map((date, i) => ({
+            date,
+            mood: lin(4, 8, i), // improving
+            focus: lin(8, 4, i), // worsening
+            agitation: lin(7, 3, i), // improving (lower is better)
+            impulse: lin(3, 7, i), // worsening (higher is worse)
+            sleep: 5, // stable
+        })),
+        journal: [{ date: dates[5]!, text: "Plus concentré en classe.", tags: ["school"] }],
+        barkleySteps: [{ stepNumber: 1, completedAt: new Date("2026-03-05") }],
+        crisisItems: [{ label: "Respirer 5 fois", emoji: "🫧", position: 0 }],
+        medications: [
+            {
+                name: "Méthylphénidate",
+                dose: "18 mg",
+                schedule: "morning",
+                startDate: dates[0]!,
+                endDate: null,
+                notes: "Bonne tolérance",
+                active: true,
+                adherence: { taken: 18, total: 20 },
+            },
+        ],
+        carePathway: [
+            { stepId: "gp_consultation", status: "done", notes: null, completedAt: new Date("2026-03-03") },
+        ],
+        questions: "Faut-il ajuster la dose du soir ?",
+        parentName: "Damien",
+    };
+}
+
+describe("report rendering with the trend column", () => {
+    it("builds a non-empty PDF without throwing", async () => {
+        const pdf = await buildReportPdf(fixture());
+        expect(pdf.length).toBeGreaterThan(1000);
+        // PDF magic header
+        expect(pdf.subarray(0, 4).toString()).toBe("%PDF");
+    });
+
+    it("renders the trend column and valence in the HTML report", () => {
+        const html = buildReportHtml(fixture());
+        expect(html).toContain("Tendance");
+        expect(html).toContain("Amélioration"); // mood up / agitation down
+        expect(html).toContain("Aggravation"); // focus down / impulse up
+        expect(html).toContain("Stable"); // sleep flat
+    });
+});

--- a/apps/api/src/__tests__/report-trend.test.ts
+++ b/apps/api/src/__tests__/report-trend.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import {
+    dimensionTrend,
+    trendDisplay,
+} from "../lib/report-trend";
+
+// Build date-sorted-ish readings; dimensionTrend sorts internally.
+function series(dim: string, values: number[]) {
+    return values.map((v, i) => ({
+        date: `2026-01-${String(i + 1).padStart(2, "0")}`,
+        [dim]: v,
+    }));
+}
+
+describe("dimensionTrend", () => {
+    it("returns null when there are too few readings to split", () => {
+        expect(dimensionTrend(series("mood", [5, 6, 7]), "mood")).toBeNull();
+    });
+
+    it("flags a rising higher-is-better dimension as an improvement", () => {
+        // mood: first half ~4, second half ~7 → up → better
+        const t = dimensionTrend(series("mood", [4, 4, 7, 7]), "mood");
+        expect(t?.better).toBe(true);
+        expect(t?.delta).toBeGreaterThan(0);
+    });
+
+    it("flags a falling higher-is-better dimension as a worsening", () => {
+        const t = dimensionTrend(series("focus", [8, 8, 4, 4]), "focus");
+        expect(t?.better).toBe(false);
+    });
+
+    it("flags a FALLING lower-is-better dimension as an improvement", () => {
+        // agitation going down is good
+        const t = dimensionTrend(series("agitation", [8, 8, 4, 4]), "agitation");
+        expect(t?.better).toBe(true);
+        expect(t?.delta).toBeLessThan(0);
+    });
+
+    it("flags a RISING lower-is-better dimension as a worsening", () => {
+        const t = dimensionTrend(series("impulse", [3, 3, 7, 7]), "impulse");
+        expect(t?.better).toBe(false);
+    });
+
+    it("reports a negligible change as stable (better = null)", () => {
+        const t = dimensionTrend(series("sleep", [5, 5, 5, 5]), "sleep");
+        expect(t?.better).toBeNull();
+    });
+
+    it("ignores zero/absent readings when splitting", () => {
+        const t = dimensionTrend(series("mood", [0, 4, 4, 7, 7]), "mood");
+        expect(t?.better).toBe(true);
+    });
+});
+
+describe("trendDisplay", () => {
+    it("renders a dash for no trend", () => {
+        expect(trendDisplay(null).label).toBe("—");
+    });
+    it("colors an improvement green and a worsening red", () => {
+        expect(trendDisplay({ delta: 1.2, better: true }).color).toBe("#059669");
+        expect(trendDisplay({ delta: -1.2, better: false }).color).toBe("#dc2626");
+    });
+    it("shows the signed delta", () => {
+        expect(trendDisplay({ delta: 0.8, better: true }).label).toContain("+0.8");
+        expect(trendDisplay({ delta: -0.6, better: true }).label).toContain("-0.6");
+    });
+});

--- a/apps/api/src/lib/report-trend.ts
+++ b/apps/api/src/lib/report-trend.ts
@@ -1,0 +1,50 @@
+// Symptom-trend logic for the medical report, extracted so the clinical
+// valence (is a change an improvement or a worsening?) is unit-testable
+// without a database or a PDF/HTML renderer.
+
+export type SymptomDim = "mood" | "focus" | "agitation" | "impulse" | "sleep";
+
+// Dimensions where a higher score is clinically better (mood/focus/sleep);
+// the others (agitation/impulse) are better when lower.
+export const HIGHER_IS_BETTER: ReadonlySet<SymptomDim> = new Set([
+    "mood",
+    "focus",
+    "sleep",
+]);
+
+export type DimensionTrend = { delta: number; better: boolean | null };
+
+type SymptomPoint = { date: string | Date } & Partial<Record<SymptomDim, number | null>>;
+
+// Compares the average of the second half of the (date-sorted) readings to the
+// first half. `better` is null when the change is negligible or there aren't
+// enough readings to split meaningfully.
+export function dimensionTrend(
+    symptoms: ReadonlyArray<SymptomPoint>,
+    key: SymptomDim,
+): DimensionTrend | null {
+    const points = symptoms
+        .filter((s) => typeof s[key] === "number" && (s[key] as number) > 0)
+        .slice()
+        .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0))
+        .map((s) => s[key] as number);
+    if (points.length < 4) return null;
+    const mid = Math.floor(points.length / 2);
+    const mean = (arr: number[]) => arr.reduce((a, b) => a + b, 0) / arr.length;
+    const delta = mean(points.slice(mid)) - mean(points.slice(0, mid));
+    if (Math.abs(delta) < 0.3) return { delta, better: null };
+    const rising = delta > 0;
+    return { delta, better: HIGHER_IS_BETTER.has(key) ? rising : !rising };
+}
+
+// Label + hex color for a trend cell, shared by the PDF and HTML reports.
+export function trendDisplay(trend: DimensionTrend | null): {
+    label: string;
+    color: string;
+} {
+    if (!trend) return { label: "—", color: "#9ca3af" };
+    const signed = `${trend.delta >= 0 ? "+" : "-"}${Math.abs(trend.delta).toFixed(1)}`;
+    if (trend.better === null) return { label: `Stable (${signed})`, color: "#6b7280" };
+    if (trend.better) return { label: `Amélioration (${signed})`, color: "#059669" };
+    return { label: `Aggravation (${signed})`, color: "#dc2626" };
+}

--- a/apps/api/src/routes/report.ts
+++ b/apps/api/src/routes/report.ts
@@ -18,6 +18,7 @@ import { rateLimiter } from "../middleware/rate-limiter";
 import { AppError } from "../middleware/error-handler";
 import { assertChildAccess, getChildOwnerId } from "../lib/child-access";
 import { getPremiumAccess } from "../lib/premium";
+import { dimensionTrend, trendDisplay } from "../lib/report-trend";
 import { sendEmail } from "../lib/email";
 import {
   getUserTimezone,
@@ -354,7 +355,7 @@ async function loadReportData(input: LoadReportDataInput): Promise<ReportData> {
 
 // ─── Report data shape ────────────────────────────────────
 
-interface ReportData {
+export interface ReportData {
     child: { name: string; gender: string | null; ageRange: string | null };
     sinceDate: string;
     untilDate: string;
@@ -448,18 +449,20 @@ function formatDateFr(d: string | Date): string {
 
 // ─── HTML builder ─────────────────────────────────────────
 
-function buildReportHtml(data: ReportData): string {
+export function buildReportHtml(data: ReportData): string {
     const dims = ["mood", "focus", "agitation", "impulse", "sleep"] as const;
 
-    // Symptom averages
+    // Symptom averages + trend (2nd half vs 1st half of the period)
     const symptomRows = dims
         .map((key) => {
             const values = data.symptoms
                 .map((s) => s[key])
                 .filter((v) => typeof v === "number" && v > 0);
+            const trend = trendDisplay(dimensionTrend(data.symptoms, key));
             return `<tr>
         <td style="padding:6px 12px;border-bottom:1px solid #eee;font-weight:500">${SYMPTOM_LABELS[key]}</td>
         <td style="padding:6px 12px;border-bottom:1px solid #eee;text-align:center">${avg(values)}</td>
+        <td style="padding:6px 12px;border-bottom:1px solid #eee;text-align:center;color:${trend.color};font-size:13px">${trend.label}</td>
         <td style="padding:6px 12px;border-bottom:1px solid #eee;text-align:center">${values.length}</td>
       </tr>`;
         })
@@ -490,7 +493,7 @@ function buildReportHtml(data: ReportData): string {
            <div style="height:100%;width:${(completedSteps.length / 10) * 100}%;background:#6366f1;border-radius:4px"></div>
          </div>
          <ul style="margin-top:8px;padding-left:0;list-style:none">
-           ${completedSteps.map((s) => `<li style="padding:2px 0;font-size:13px">✓ Étape ${s.stepNumber}${s.completedAt ? ` — ${formatDateFr(s.completedAt)}` : ""}</li>`).join("")}
+           ${completedSteps.map((s) => `<li style="padding:2px 0;font-size:13px">• Étape ${s.stepNumber}${s.completedAt ? ` — ${formatDateFr(s.completedAt)}` : ""}</li>`).join("")}
          </ul>`
             : "";
 
@@ -511,7 +514,7 @@ function buildReportHtml(data: ReportData): string {
 
     const renderMed = (m: ReportData["medications"][number]) => {
         const period = m.endDate
-            ? `${formatDateFr(m.startDate)} → ${formatDateFr(m.endDate)}`
+            ? `${formatDateFr(m.startDate)} — ${formatDateFr(m.endDate)}`
             : `Depuis le ${formatDateFr(m.startDate)}`;
         const adherence = m.adherence && m.adherence.total > 0
             ? `<span style="margin-left:8px;font-size:12px;color:#059669">Observance ${Math.round((m.adherence.taken / m.adherence.total) * 100)}% (${m.adherence.taken}/${m.adherence.total})</span>`
@@ -590,11 +593,13 @@ function buildReportHtml(data: ReportData): string {
       <tr style="background:#f9fafb">
         <th style="padding:6px 12px;text-align:left;font-size:12px;color:#6b7280">Dimension</th>
         <th style="padding:6px 12px;text-align:center;font-size:12px;color:#6b7280">Moyenne</th>
+        <th style="padding:6px 12px;text-align:center;font-size:12px;color:#6b7280">Tendance</th>
         <th style="padding:6px 12px;text-align:center;font-size:12px;color:#6b7280">Relevés</th>
       </tr>
     </thead>
     <tbody>${symptomRows}</tbody>
   </table>
+  <p style="font-size:11px;color:#9ca3af;margin:6px 0 0">Tendance : évolution de la 2ᵉ moitié de la période par rapport à la 1ʳᵉ (vert = amélioration, rouge = aggravation).</p>
 
   ${medicationsSection}
   ${carePathwaySection}
@@ -622,7 +627,7 @@ const PDF_TEXT = "#1f2937";
 const PDF_MUTED = "#6b7280";
 const PDF_BORDER = "#e5e7eb";
 
-function buildReportPdf(data: ReportData): Promise<Buffer> {
+export function buildReportPdf(data: ReportData): Promise<Buffer> {
     return new Promise((resolve, reject) => {
         const doc = new PDFDocument({
             size: "A4",
@@ -705,7 +710,7 @@ function renderHeader(doc: PDFDoc, data: ReportData): void {
         .fontSize(10)
         .fillColor(PDF_MUTED)
         .text(
-            `Période : ${formatDateFr(data.sinceDate)} → ${formatDateFr(data.untilDate)} · Généré le ${formatDateFr(new Date().toISOString())}`,
+            `Période : ${formatDateFr(data.sinceDate)} — ${formatDateFr(data.untilDate)} · Généré le ${formatDateFr(new Date().toISOString())}`,
         );
     if (meta.length > 0) {
         doc.text(meta.join(" · "));
@@ -822,9 +827,10 @@ function renderSymptomTable(doc: PDFDoc, data: ReportData): void {
     const dims = ["mood", "focus", "agitation", "impulse", "sleep"] as const;
     const x = PDF_PAGE_MARGIN;
     const w = pageWidth(doc);
-    const colDimW = w * 0.55;
-    const colAvgW = w * 0.225;
-    const colCountW = w * 0.225;
+    const colDimW = w * 0.32;
+    const colAvgW = w * 0.16;
+    const colTrendW = w * 0.34;
+    const colCountW = w * 0.18;
     const rowH = 22;
 
     let y = doc.y;
@@ -843,7 +849,11 @@ function renderSymptomTable(doc: PDFDoc, data: ReportData): void {
         width: colAvgW,
         align: "center",
     });
-    doc.text("Relevés", x + colDimW + colAvgW, y + 7, {
+    doc.text("Tendance", x + colDimW + colAvgW, y + 7, {
+        width: colTrendW,
+        align: "center",
+    });
+    doc.text("Relevés", x + colDimW + colAvgW + colTrendW, y + 7, {
         width: colCountW,
         align: "center",
     });
@@ -853,6 +863,7 @@ function renderSymptomTable(doc: PDFDoc, data: ReportData): void {
         const values = data.symptoms
             .map((s) => s[key])
             .filter((v) => typeof v === "number" && v > 0);
+        const trend = trendDisplay(dimensionTrend(data.symptoms, key));
         doc
             .strokeColor(PDF_BORDER)
             .lineWidth(0.5)
@@ -871,10 +882,20 @@ function renderSymptomTable(doc: PDFDoc, data: ReportData): void {
             width: colAvgW,
             align: "center",
         });
-        doc.text(String(values.length), x + colDimW + colAvgW, y + 7, {
-            width: colCountW,
-            align: "center",
-        });
+        doc
+            .fillColor(trend.color)
+            .fontSize(9)
+            .text(trend.label, x + colDimW + colAvgW, y + 7.5, {
+                width: colTrendW,
+                align: "center",
+            });
+        doc
+            .fillColor(PDF_TEXT)
+            .fontSize(10)
+            .text(String(values.length), x + colDimW + colAvgW + colTrendW, y + 7, {
+                width: colCountW,
+                align: "center",
+            });
         y += rowH;
     });
 
@@ -887,6 +908,18 @@ function renderSymptomTable(doc: PDFDoc, data: ReportData): void {
 
     doc.y = y;
     doc.x = x;
+    doc.moveDown(0.3);
+    doc
+        .font("Helvetica-Oblique")
+        .fontSize(7.5)
+        .fillColor(PDF_MUTED)
+        .text(
+            "Tendance : évolution de la 2e moitié de la période par rapport à la 1re (vert = amélioration, rouge = aggravation).",
+            x,
+            doc.y,
+            { width: w },
+        );
+    doc.fillColor(PDF_TEXT);
     doc.moveDown(0.5);
 }
 
@@ -911,7 +944,7 @@ function renderMedications(doc: PDFDoc, data: ReportData): void {
 
         meds.forEach((m) => {
             const period = m.endDate
-                ? `${formatDateFr(m.startDate)} → ${formatDateFr(m.endDate)}`
+                ? `${formatDateFr(m.startDate)} — ${formatDateFr(m.endDate)}`
                 : `Depuis le ${formatDateFr(m.startDate)}`;
             const adherence =
                 m.adherence && m.adherence.total > 0
@@ -1069,7 +1102,7 @@ function renderBarkley(doc: PDFDoc, data: ReportData): void {
             .fontSize(10)
             .fillColor(PDF_TEXT)
             .text(
-                `✓ Étape ${s.stepNumber}${s.completedAt ? ` — ${formatDateFr(s.completedAt)}` : ""}`,
+                `• Étape ${s.stepNumber}${s.completedAt ? ` — ${formatDateFr(s.completedAt)}` : ""}`,
             );
     });
     doc.moveDown(0.3);
@@ -1115,7 +1148,7 @@ function renderFooterOnEachPage(doc: PDFDoc, data: ReportData): void {
             .fontSize(8)
             .fillColor(PDF_MUTED)
             .text(
-                `Tokō · toko.app — Rapport généré pour ${data.parentName} · Page ${i - range.start + 1}/${range.count}`,
+                `Toko · toko.app — Rapport généré pour ${data.parentName} · Page ${i - range.start + 1}/${range.count}`,
                 PDF_PAGE_MARGIN,
                 y + 6,
                 { width: w, align: "center" },

--- a/apps/web/src/components/dashboard/evening-reminder-prompt.tsx
+++ b/apps/web/src/components/dashboard/evening-reminder-prompt.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Bell, X } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { usePreferences, useUpdatePreferences } from "@/hooks/use-preferences";
+
+// Reminders default to OFF (opt-in, RGPD). This dashboard prompt re-offers the
+// evening reminder — the retention loop the product depends on — where the
+// parent actually is, once, and only while it's disabled. Dismissible for the
+// session; it disappears for good as soon as it's enabled.
+export function EveningReminderPrompt() {
+  const { t } = useTranslation();
+  const { data: prefs } = usePreferences();
+  const update = useUpdatePreferences();
+  const [dismissed, setDismissed] = useState(false);
+
+  // Only show when we know reminders are off. Hidden while loading, once
+  // enabled, or after a manual dismiss.
+  if (dismissed || !prefs || prefs.eveningReminderOptIn) return null;
+
+  return (
+    <Card className="border-primary/30 bg-primary/5">
+      <CardContent className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <Bell className="size-4" />
+          </div>
+          <div>
+            <p className="font-medium">{t("eveningReminderPrompt.title")}</p>
+            <p className="mt-0.5 text-sm text-muted-foreground">
+              {t("eveningReminderPrompt.body")}
+            </p>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2 self-end sm:self-auto">
+          <Button
+            onClick={() => update.mutate({ eveningReminderOptIn: true })}
+            disabled={update.isPending}
+          >
+            {update.isPending
+              ? t("eveningReminderPrompt.enabling")
+              : t("eveningReminderPrompt.enable")}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={t("eveningReminderPrompt.dismiss")}
+            onClick={() => setDismissed(true)}
+          >
+            <X className="size-4" />
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -1905,6 +1905,13 @@
     "error": "Couldn't save the note. Please try again.",
     "openJournal": "Open journal"
   },
+  "eveningReminderPrompt":   {
+    "title": "Don't forget in the evening",
+    "body": "A 2-minute reminder each evening to note your child's day.",
+    "enable": "Turn on evening reminder",
+    "enabling": "Turning on…",
+    "dismiss": "Dismiss"
+  },
   "eveningCheck": {
     "title": "How was tonight?",
     "vibe_hard": "Rough",

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -1906,7 +1906,7 @@
     "openJournal": "Open journal"
   },
   "eveningReminderPrompt":   {
-    "title": "Don't forget in the evening",
+    "title": "Your 2-minute evening ritual",
     "body": "A 2-minute reminder each evening to note your child's day.",
     "enable": "Turn on evening reminder",
     "enabling": "Turning on…",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -2329,6 +2329,13 @@
     "error": "Impossible d'enregistrer la note. Réessayez.",
     "openJournal": "Ouvrir le journal"
   },
+  "eveningReminderPrompt":   {
+    "title": "Ne rien oublier le soir",
+    "body": "Un rappel de 2 minutes chaque soir pour noter la journée de votre enfant.",
+    "enable": "Activer le rappel du soir",
+    "enabling": "Activation…",
+    "dismiss": "Masquer"
+  },
   "eveningCheck": {
     "title": "La soirée de ce soir ?",
     "vibe_hard": "Difficile",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -2330,7 +2330,7 @@
     "openJournal": "Ouvrir le journal"
   },
   "eveningReminderPrompt":   {
-    "title": "Ne rien oublier le soir",
+    "title": "Votre rituel du soir en 2 minutes",
     "body": "Un rappel de 2 minutes chaque soir pour noter la journée de votre enfant.",
     "enable": "Activer le rappel du soir",
     "enabling": "Activation…",

--- a/apps/web/src/routes/_authenticated/dashboard/dashboard-page.tsx
+++ b/apps/web/src/routes/_authenticated/dashboard/dashboard-page.tsx
@@ -41,6 +41,7 @@ import { CalmMinutesCard } from "@/components/dashboard/calm-minutes-card";
 import { EveningCheck } from "@/components/dashboard/evening-check";
 import { MedicationQuickLog } from "@/components/dashboard/medication-quick-log";
 import { JournalQuickNote } from "@/components/dashboard/journal-quick-note";
+import { EveningReminderPrompt } from "@/components/dashboard/evening-reminder-prompt";
 import { BarkleyProgressCard } from "@/components/dashboard/barkley-progress-card";
 import { ResourceHintCard } from "@/components/dashboard/resource-hint-card";
 import { AddChildForm } from "@/components/shared/add-child-form";
@@ -190,6 +191,7 @@ export default function DashboardPage() {
         aria-label={t("dashboard.trackingSection")}
         className="space-y-6"
       >
+        <EveningReminderPrompt />
         <div className="grid gap-6 lg:grid-cols-2">
           <div ref={moodLoggerRef} id="mood-logger" className="scroll-mt-20">
             <MoodLogger />


### PR DESCRIPTION
## Contexte

Lot **Phase 2 — renforcer le cœur** du recentrage (#335 / suivi #343). Deux améliorations liées, sur la branche désignée.

## 1. Rapport médical — colonne « Tendance » + glyphes

Le rapport promet « les tendances » mais ne montrait que des moyennes.

- **Colonne « Tendance »** (PDF **et** HTML) : compare la 2ᵉ moitié de la période à la 1ʳᵉ et affiche une **valence clinique** — Amélioration / Aggravation / Stable, colorée, avec le delta signé. Polarité dimension-aware (agitation/impulsivité en baisse = amélioration). Logique extraite dans `lib/report-trend.ts` et **testée unitairement**.
- **Correction de glyphes cassés du PDF** (absents de l'encodage Helvetica) : `→` (→ tiret cadratin), `✓` Barkley (→ puce), macron `Tokō` (→ `Toko`).
- **Test de rendu** : PDF valide + valence correcte en HTML. Rendus réels vérifiés (captures partagées).

## 2. Rappel du soir — opt-in sur le dashboard

Les rappels sont par défaut **désactivés** (opt-in, RGPD), mais le rappel du soir est la boucle de rétention du produit. Un encart **dismissable** sur le dashboard le re-propose en un clic, uniquement tant qu'il est désactivé ; il disparaît une fois activé. Additif, réutilise le hook de préférences.

## Vérification

- `pnpm typecheck` ✅ · `pnpm test` ✅ (tests de tendance + rendu)
- Le dashboard est exercé par la CI E2E.

## Suite (#343)

Monétisation Formation (Stripe one-shot, PR dédiée) ; puis, si confirmé, simplification des features (Phase 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8