### PR TITLE
feat: « une marque, trois offres » sur la page tarifs

### DIFF
--- a/apps/web/src/components/landing/three-offers-section.tsx
+++ b/apps/web/src/components/landing/three-offers-section.tsx
@@ -1,0 +1,132 @@
+import { Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { BookOpen, GraduationCap, HeartHandshake, ArrowRight } from "lucide-react";
+import { trackEvent } from "@/lib/analytics";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+
+// "Une marque, trois offres" (§4.2). One verb per card, one price, one action —
+// the funnel made legible for a tired parent in five seconds:
+// Comprendre (articles, gratuit) → Apprendre (Formation, achat unique) →
+// Appliquer (Famille, abonnement). Deliberately NOT the full feature grid;
+// that lives below in the Gratuit/Famille PricingSection.
+const OFFERS = [
+  {
+    key: "understand",
+    icon: BookOpen,
+    to: "/ressources" as const,
+    plan: "articles",
+    highlight: false,
+  },
+  {
+    key: "learn",
+    icon: GraduationCap,
+    to: "/formation" as const,
+    plan: "formation",
+    highlight: true,
+  },
+  {
+    key: "apply",
+    icon: HeartHandshake,
+    to: "/login" as const,
+    plan: "famille",
+    highlight: false,
+  },
+] as const;
+
+export function ThreeOffersSection() {
+  const { t } = useTranslation();
+
+  return (
+    <section className="border-b border-border/60 py-16 lg:py-20">
+      <div className="mx-auto max-w-5xl px-4">
+        <div className="text-center">
+          <h2 className="font-heading text-2xl font-semibold tracking-tight lg:text-3xl">
+            {t("landing.threeOffers.title")}
+          </h2>
+          <p className="mx-auto mt-3 max-w-xl text-muted-foreground">
+            {t("landing.threeOffers.subtitle")}
+          </p>
+        </div>
+
+        <div className="mt-10 grid items-stretch gap-6 md:grid-cols-3">
+          {OFFERS.map(({ key, icon: Icon, to, plan, highlight }) => (
+            <Card
+              key={key}
+              className={
+                highlight
+                  ? "flex flex-col border-primary/30 shadow-lg shadow-primary/10"
+                  : "flex flex-col border-border/60"
+              }
+            >
+              <CardContent className="flex flex-1 flex-col gap-4 p-6">
+                <div className="flex items-center justify-between">
+                  <div
+                    className={
+                      highlight
+                        ? "flex size-11 items-center justify-center rounded-xl bg-primary/10 text-primary"
+                        : "flex size-11 items-center justify-center rounded-xl bg-muted text-foreground/70"
+                    }
+                  >
+                    <Icon className="size-5" />
+                  </div>
+                  {t(`landing.threeOffers.${key}.badge`, { defaultValue: "" }) ? (
+                    <Badge variant={highlight ? "default" : "outline"} className="shadow-sm">
+                      {t(`landing.threeOffers.${key}.badge`)}
+                    </Badge>
+                  ) : null}
+                </div>
+
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-primary">
+                    {t(`landing.threeOffers.${key}.verb`)}
+                  </p>
+                  <h3 className="font-heading mt-1 text-lg font-semibold">
+                    {t(`landing.threeOffers.${key}.name`)}
+                  </h3>
+                </div>
+
+                <div className="flex items-baseline gap-1.5">
+                  <span className="font-heading text-3xl font-semibold">
+                    {t(`landing.threeOffers.${key}.price`)}
+                  </span>
+                  <span className="text-sm text-muted-foreground">
+                    {t(`landing.threeOffers.${key}.priceNote`)}
+                  </span>
+                </div>
+
+                <p className="text-sm leading-relaxed text-muted-foreground">
+                  {t(`landing.threeOffers.${key}.description`)}
+                </p>
+
+                <div className="mt-auto pt-2">
+                  <Link
+                    to={to}
+                    className="block w-full"
+                    onClick={() =>
+                      trackEvent("pricing_cta_clicked", { plan })
+                    }
+                  >
+                    <Button
+                      variant={highlight ? "default" : "outline"}
+                      size="lg"
+                      className="w-full gap-2"
+                    >
+                      {t(`landing.threeOffers.${key}.cta`)}
+                      <ArrowRight className="size-4" />
+                    </Button>
+                  </Link>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+
+        <p className="mx-auto mt-8 max-w-2xl text-center text-xs leading-relaxed text-muted-foreground">
+          {t("landing.threeOffers.footnote")}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -76,6 +76,38 @@
       "description": "The 10 steps of the parent-training program inspired by Dr Barkley's method, with lessons and quizzes — right inside the app, for families affected by ADHD.",
       "cta": "Discover the training"
     },
+    "threeOffers":     {
+      "title": "One brand, three ways forward",
+      "subtitle": "Each step has its offer. Start where you are.",
+      "understand": {
+        "verb": "Understand",
+        "name": "Articles & resources",
+        "price": "Free",
+        "priceNote": "openly available",
+        "description": "Clear guides to understand ADHD and lighten the everyday.",
+        "cta": "Read the guides",
+        "badge": ""
+      },
+      "learn": {
+        "verb": "Learn",
+        "name": "Tokō Training",
+        "price": "€89",
+        "priceNote": "one-time · lifetime",
+        "description": "The Barkley program in 10 steps, at your pace. Yours forever.",
+        "cta": "Discover the training",
+        "badge": "One-time"
+      },
+      "apply": {
+        "verb": "Apply",
+        "name": "Tokō Famille",
+        "price": "€39",
+        "priceNote": "per year · training included",
+        "description": "The tracking, history and report to bring to your appointments.",
+        "cta": "Try 14 days",
+        "badge": "Recommended"
+      },
+      "footnote": "Articles stay free for everyone. The training is a one-time purchase, yours for life. The Famille subscription includes the training."
+    },
     "resourcesTeaser": {
       "title": "Understand and support your child",
       "description": "Clear guides on everyday parenting — routines, sleep, emotions — with an ADHD section for families who need it. Drawn from public scientific publications, they don't replace a healthcare professional's advice.",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -84,6 +84,38 @@
       "description": "Les 10 étapes du programme d'entraînement aux habiletés parentales inspiré de la méthode du Dr Barkley, avec contenu pédagogique et quiz — directement dans l'app, pour les familles concernées par le TDAH.",
       "cta": "Découvrir la formation"
     },
+    "threeOffers":     {
+      "title": "Une marque, trois façons d'avancer",
+      "subtitle": "Chaque étape a son offre. Commencez là où vous êtes.",
+      "understand": {
+        "verb": "Comprendre",
+        "name": "Articles & ressources",
+        "price": "Gratuit",
+        "priceNote": "en accès libre",
+        "description": "Des guides clairs pour comprendre le TDAH et alléger le quotidien.",
+        "cta": "Lire les guides",
+        "badge": ""
+      },
+      "learn": {
+        "verb": "Apprendre",
+        "name": "Tokō Formation",
+        "price": "89 €",
+        "priceNote": "paiement unique · à vie",
+        "description": "Le programme Barkley en 10 étapes, à votre rythme. À vous pour toujours.",
+        "cta": "Découvrir la formation",
+        "badge": "Achat unique"
+      },
+      "apply": {
+        "verb": "Appliquer",
+        "name": "Tokō Famille",
+        "price": "39 €",
+        "priceNote": "par an · formation incluse",
+        "description": "Le suivi, l'historique et le rapport à présenter à vos rendez-vous.",
+        "cta": "Essayer 14 jours",
+        "badge": "Recommandé"
+      },
+      "footnote": "Les articles restent gratuits pour tout le monde. La formation s'achète une fois et reste à vie. L'abonnement Famille inclut la formation."
+    },
     "resourcesTeaser": {
       "title": "Comprendre et accompagner votre enfant",
       "description": "Des guides clairs sur la parentalité au quotidien — routines, sommeil, émotions — avec un volet TDAH pour les familles concernées. Rédigés à partir de publications scientifiques publiques, ils ne remplacent pas l'avis d'un professionnel de santé.",

--- a/apps/web/src/routes/TarifsPage.tsx
+++ b/apps/web/src/routes/TarifsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { Badge } from "@/components/ui/badge";
 import { useSeoHead } from "@/hooks/use-seo-head";
 import { PricingSection } from "@/components/landing/pricing-section";
+import { ThreeOffersSection } from "@/components/landing/three-offers-section";
 import { trackEventOnce } from "@/lib/analytics";
 import { TopNav } from "./tarifs-top-nav";
 import { Footer } from "./tarifs-footer";
@@ -126,6 +127,10 @@ export function TarifsPage() {
           </p>
         </div>
       </section>
+
+      {/* Une marque, trois offres — the funnel made legible before the
+          detailed Gratuit/Famille comparison. */}
+      <ThreeOffersSection />
 
       <PricingSection />
 


### PR DESCRIPTION
## Contexte

Suite de la monétisation Formation (#348). Donne à la stratégie **§4.2 « Une marque, trois offres »** (#335 / suivi #343) une présentation claire sur `/tarifs`.

## Changements

- **`ThreeOffersSection`** ajoutée sur la page tarifs, **au-dessus** du comparatif Gratuit/Famille détaillé. Trois cartes, **un verbe + un prix + une action** chacune (lecture 5 secondes, principe TDAH) :
  - **Comprendre** — Articles & ressources · *gratuit* → `/ressources`
  - **Apprendre** — Tokō Formation · *89 €, achat unique, à vie* → `/formation` *(carte mise en avant, badge « Achat unique »)*
  - **Appliquer** — Tokō Famille · *39 €/an, formation incluse* → essai 14 j *(badge « Recommandé »)*
- **Note de bas de section** qui énonce le modèle sans ambiguïté : articles gratuits pour tous · formation achetée une fois et à vie · Famille inclut la formation.
- i18n **fr/en**, analytics `pricing_cta_clicked` sur chaque CTA.

Additif — aucune suppression, aucun changement de billing. Le comparatif Gratuit/Famille existant est inchangé (il reste le détail sous la vue d'ensemble).

## Vérification

- `pnpm typecheck` ✅ · `pnpm lint:copy` (rule B7) ✅ · JSON locales valides ✅
- **Rendu réel vérifié** (dev server + Chromium) en **français et anglais** — captures partagées dans la conversation. La section i18n bascule correctement ; le hero/FAQ de la page (chaînes en dur, pré-existant) restent en français.

## Suite (#343)

Upsell Formation→Famille (1re année remisée — nécessite un coupon Stripe + décision sur la remise) ; instrumentation du taux de conversion Formation→Famille. Provisionnement du prix Stripe `toko_formation_oneshot` (hors dépôt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8)_