### PR TITLE
docs: document FORMATION_UPSELL_COUPON_ID in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,11 @@ VITE_STRIPE_PUBLISHABLE_KEY=pk_test_...
 #    resolved at runtime — no env var to copy.
 # 3. Run 'pnpm stripe:listen' in a separate terminal, copy the whsec_... value
 STRIPE_WEBHOOK_SECRET=whsec_...
+# 4. Optional — coupon applied to the first Famille year for Formation one-shot
+#    buyers (50% off year 1 upsell). Create a coupon (percent_off=50,
+#    duration=once) and paste its id here. Unset ⇒ the upsell shows but the
+#    annual checkout stays full price (graceful).
+FORMATION_UPSELL_COUPON_ID=
 
 # ─── Email (Resend — optional) ────────────────────────
 # Sign up at https://resend.com and create an API key.


### PR DESCRIPTION
## Contexte

Suite de l'upsell Formation→Famille (#351). Documente la variable d'environnement optionnelle `FORMATION_UPSELL_COUPON_ID` dans `.env.example`.

## Provisionnement Stripe réalisé (compte live `pro.battistella.ovh`)

- **Prix Formation** : déjà présent — `price_1TtiuEK…`, live, actif, `lookup_key: toko_formation_oneshot`, one-time, **89 € EUR**. Résolu au runtime par lookup-key (aucune env requise). ✅
- **Coupon upsell** : créé — `ZfBIIys2`, live, valide, **percent_off 50 · duration once**. À renseigner dans `FORMATION_UPSELL_COUPON_ID` côté prod.

## Changement

`.env.example` : ajoute `FORMATION_UPSELL_COUPON_ID` avec commentaire (dégradation gracieuse si non renseignée).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8)_