### PR TITLE
feat: analytics de conversion Formation→Famille (admin)

### DIFF
--- a/apps/api/src/routes/admin-analytics.ts
+++ b/apps/api/src/routes/admin-analytics.ts
@@ -91,6 +91,7 @@ adminAnalyticsRoutes.get("/events", async (c) => {
       sosHelpfulTotal: sql<number>`cast(count(*) filter (where ${events.eventName} = 'sos_helpful_rating') as int)`,
       paywallViews: sql<number>`cast(count(*) filter (where ${events.eventName} = 'paywall_viewed') as int)`,
       trialsStarted: sql<number>`cast(count(*) filter (where ${events.eventName} = 'trial_started') as int)`,
+      formationPurchases: sql<number>`cast(count(*) filter (where ${events.eventName} = 'formation_purchased') as int)`,
       activeParents: sql<number>`cast(count(distinct ${events.parentId}) filter (where ${events.parentId} is not null) as int)`,
     })
     .from(events)
@@ -318,6 +319,37 @@ adminAnalyticsRoutes.get("/events", async (c) => {
     left join trial_users on paywall_users.parent_id = trial_users.parent_id
   `);
 
+  // Formation → Famille conversion (all-time). The CMO's day-one metric: of
+  // the parents who bought the one-shot Formation, how many later started a
+  // Famille subscription (sub start at or after their purchase). A low rate
+  // is a product signal, not a pricing one.
+  const [formationFunnel] = await db.execute<{
+    buyers: number;
+    converted: number;
+  }>(sql`
+    with buyers as (
+      select parent_id, min(created_at) as bought_at
+      from events
+      where event_name = 'formation_purchased'
+        and parent_id is not null
+      group by parent_id
+    ),
+    subs as (
+      select parent_id, min(created_at) as subbed_at
+      from events
+      where event_name = 'subscription_started'
+        and parent_id is not null
+      group by parent_id
+    )
+    select
+      cast(count(*) as int) as buyers,
+      cast(count(*) filter (
+        where subs.subbed_at >= buyers.bought_at
+      ) as int) as converted
+    from buyers
+    left join subs on subs.parent_id = buyers.parent_id
+  `);
+
   // Same disengaged-rate query shifted back 7 days — gives the
   // "previous week" baseline so we can derive a week-over-week delta
   // (#191 alert: "+10 % de churn invisible semaine sur semaine").
@@ -516,6 +548,16 @@ adminAnalyticsRoutes.get("/events", async (c) => {
     });
   }
 
+  const formationBuyers = formationFunnel?.buyers ?? 0;
+  const formationConverted = formationFunnel?.converted ?? 0;
+  const formation = {
+    purchases7d: kpi7d?.formationPurchases ?? 0,
+    buyers: formationBuyers,
+    converted: formationConverted,
+    conversionRate:
+      formationBuyers > 0 ? formationConverted / formationBuyers : null,
+  };
+
   return c.json({
     days,
     byDay,
@@ -525,6 +567,7 @@ adminAnalyticsRoutes.get("/events", async (c) => {
     derived7d,
     timeToAha,
     paid30d,
+    formation,
     alerts,
   });
 });

--- a/apps/web/src/hooks/use-admin-analytics.ts
+++ b/apps/web/src/hooks/use-admin-analytics.ts
@@ -40,6 +40,17 @@ export type Paid30d = {
   ltvMonths: number | null;
 };
 
+export type FormationFunnel = {
+  /** Formation one-shot purchases in the last 7 days. */
+  purchases7d: number;
+  /** All-time distinct parents who bought the Formation. */
+  buyers: number;
+  /** Buyers who later started a Famille subscription. */
+  converted: number;
+  /** converted / buyers, or null when there are no buyers yet. */
+  conversionRate: number | null;
+};
+
 export type AnalyticsAlert = {
   level: "warn" | "critical";
   message: string;
@@ -72,6 +83,7 @@ export type AnalyticsEventsResponse = {
   derived7d: DerivedKpis;
   timeToAha: TimeToAha;
   paid30d: Paid30d;
+  formation: FormationFunnel;
   churnSignals: ChurnSignals;
   alerts: AnalyticsAlert[];
 };

--- a/apps/web/src/routes/_authenticated/admin-analytics/AdminAnalyticsPage.tsx
+++ b/apps/web/src/routes/_authenticated/admin-analytics/AdminAnalyticsPage.tsx
@@ -10,6 +10,7 @@ import {
   TimeToAhaSection,
   ChurnSection,
   PaidSection,
+  FormationSection,
   EventVolumesSection,
   DailyChartSection,
 } from "./analytics-sections";
@@ -54,6 +55,7 @@ export function AdminAnalyticsPage() {
       <TimeToAhaSection aha={data.timeToAha} />
       <ChurnSection churn={data.churnSignals} />
       <PaidSection paid={data.paid30d} />
+      <FormationSection formation={data.formation} />
       <EventVolumesSection
         totals7d={totals7d}
         totalsRange={totalsRange}

--- a/apps/web/src/routes/_authenticated/admin-analytics/analytics-sections.tsx
+++ b/apps/web/src/routes/_authenticated/admin-analytics/analytics-sections.tsx
@@ -4,6 +4,7 @@ import type {
   DerivedKpis,
   TimeToAha,
   Paid30d,
+  FormationFunnel,
   ChurnSignals,
   AnalyticsAlert,
 } from "@/hooks/use-admin-analytics";
@@ -326,6 +327,65 @@ export function PaidSection({ paid }: { paid: Paid30d }) {
             </div>
             <div className="mt-1 text-xs text-muted-foreground">
               Approximation 1 / churn
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  );
+}
+
+export function FormationSection({
+  formation,
+}: {
+  formation: FormationFunnel;
+}) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+        Formation
+      </h2>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">
+              Ventes Formation · 7 j
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">
+              {formation.purchases7d}
+            </div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              achats uniques sur 7 jours
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">
+              Formation → Famille
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">
+              {formatPercent(formation.conversionRate)}
+            </div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              {formation.converted} / {formation.buyers} acheteurs abonnés
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium">
+              Acheteurs Formation
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-semibold">{formation.buyers}</div>
+            <div className="mt-1 text-xs text-muted-foreground">
+              parents (cumul) · un taux bas = signal produit, pas prix
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Contexte

Instrumente la **métrique clé du CMO** (panel marketing #348) maintenant que la Formation est **vendue en prod** : combien de parents qui achètent la Formation (one-shot) s'abonnent ensuite à Famille. Recommandation du panel : *un taux faible = problème produit, pas de prix* — d'où l'importance de le mesurer dès le jour 1.

## Changements

**API** (`GET /admin/analytics/events`)
- Compteur **ventes Formation sur 7 j** (`formation_purchased`).
- **Entonnoir de conversion tout-temps** : acheteurs Formation → abonnés Famille (abonnement démarré **à ou après** l'achat), via CTE `buyers` / `subs`.
- Nouveau bloc `formation: { purchases7d, buyers, converted, conversionRate }`.

**Web** (page admin analytics)
- Section **« Formation »** : 3 tuiles — Ventes 7 j · Formation→Famille (taux + `converted / buyers`) · Acheteurs cumulés (avec le rappel « un taux bas = signal produit, pas prix »).

Additif — analytics existantes inchangées.

## Vérification

- `pnpm typecheck` (api + web) ✅ · tests web ✅ · copy-lint (B7) ✅
- Le test d'intégration admin-analytics (Postgres) s'exécute en CI. La requête est additive et valide (colonnes `event_name` / `parent_id` / `created_at`, mêmes que l'entonnoir paywall existant). Sans achat réel : `buyers=0`, `conversionRate=null`.

## Suite (#343)

Restent surtout des décisions/design : nav à 4–5 entrées (fusion « Suivi ») ; drop éventuel des tables préservées ; bêta fermée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8)_