### PR TITLE
feat: navigation à 5 entrées — hub « Suivi » (Phase 1)

### DIFF
--- a/apps/web/src/components/shared/onboarding-tour.tsx
+++ b/apps/web/src/components/shared/onboarding-tour.tsx
@@ -53,8 +53,8 @@ type Step = {
 const STEPS: Step[] = [
   { key: "welcome", icon: Sparkles },
   { key: "dashboard", icon: BarChart3, anchor: "/dashboard", placement: "right" },
-  { key: "tracking", icon: Activity, anchor: "/symptoms", placement: "right" },
-  { key: "routines", icon: ListChecks, anchor: "/routines", placement: "right" },
+  { key: "tracking", icon: Activity, anchor: "/suivi", placement: "right" },
+  { key: "routines", icon: ListChecks, anchor: "/suivi", placement: "right" },
   { key: "care", icon: HandHeart, anchor: "sos", placement: "left" },
   { key: "plans", icon: Wallet },
   { key: "discover", icon: BookOpen },

--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -14,41 +14,52 @@ import {
   ShieldCheck,
   Users,
   Settings,
+  NotebookPen,
+  FileText,
 } from "lucide-react";
 
+export type NavTarget =
+  | "/dashboard"
+  | "/suivi"
+  | "/journal"
+  | "/symptoms"
+  | "/rewards"
+  | "/routines"
+  | "/crisis-list"
+  | "/medications"
+  | "/barkley"
+  | "/timer"
+  | "/report"
+  | "/insights"
+  | "/connaissances"
+  | "/admin-analytics"
+  | "/admin-users"
+  | "/admin-settings"
+  | "/account";
+
 export type NavItem = {
-  to: "/dashboard" | "/journal" | "/symptoms" | "/rewards" | "/routines" | "/crisis-list" | "/medications" | "/barkley" | "/timer" | "/admin-analytics" | "/admin-users" | "/admin-settings" | "/connaissances" | "/account" | "/insights";
+  to: NavTarget;
   labelKey: string;
   shortLabelKey?: string;
   icon: React.ComponentType<{ className?: string }>;
   /** Surfaced in the mobile bottom tab bar (max 4). */
   primary?: boolean;
   /** Section grouping in the desktop sidebar. */
-  group: "knowledge" | "tracking" | "care" | "account" | "admin";
+  group: "main" | "admin";
   /** Restricts the item to users with `isAdmin === true`. */
   requiresAdmin?: boolean;
 };
 
+// Primary navigation — kept to 5 parent entries (Phase 1 goal, docs/product-
+// strategy.md §6): Aujourd'hui, Suivi, Barkley, Rapport, Compte. Every daily
+// tracking screen lives one tap away inside the /suivi hub, so the sidebar
+// stays low-cognitive-load without hiding anything.
 export const navItems: readonly NavItem[] = [
-  // Ressources — apprentissage et outils de référence
-  { to: "/connaissances", labelKey: "nav.knowledgeBase", icon: Library, group: "knowledge" },
-  { to: "/barkley", labelKey: "nav.barkley", shortLabelKey: "nav.barkleyShort", icon: ClipboardList, group: "knowledge" },
-
-  // Suivi — vue d'ensemble, saisies quotidiennes, puis revue des tendances
-  { to: "/dashboard", labelKey: "nav.dashboard", shortLabelKey: "nav.home", icon: BarChart3, primary: true, group: "tracking" },
-  { to: "/journal", labelKey: "nav.journal", icon: BookOpen, primary: true, group: "tracking" },
-  { to: "/symptoms", labelKey: "nav.symptoms", icon: Activity, primary: true, group: "tracking" },
-  { to: "/routines", labelKey: "nav.routines", shortLabelKey: "nav.routinesShort", icon: ListChecks, primary: true, group: "tracking" },
-  { to: "/rewards", labelKey: "nav.rewards", shortLabelKey: "nav.rewardsShort", icon: Trophy, group: "tracking" },
-  { to: "/insights", labelKey: "nav.insights", icon: TrendingUp, group: "tracking" },
-
-  // Soins — urgence d'abord, puis routines médicales
-  { to: "/crisis-list", labelKey: "nav.crisisList", shortLabelKey: "nav.crisis", icon: HandHeart, group: "care" },
-  { to: "/medications", labelKey: "nav.medications", icon: Pill, group: "care" },
-  { to: "/timer", labelKey: "nav.timer", icon: Timer, group: "care" },
-
-  // Compte — paramètres
-  { to: "/account", labelKey: "nav.account", icon: UserCog, group: "account" },
+  { to: "/dashboard", labelKey: "nav.today", shortLabelKey: "nav.home", icon: BarChart3, primary: true, group: "main" },
+  { to: "/suivi", labelKey: "nav.tracking", shortLabelKey: "nav.trackingShort", icon: NotebookPen, primary: true, group: "main" },
+  { to: "/barkley", labelKey: "nav.barkley", shortLabelKey: "nav.barkleyShort", icon: ClipboardList, primary: true, group: "main" },
+  { to: "/report", labelKey: "nav.report", icon: FileText, group: "main" },
+  { to: "/account", labelKey: "nav.account", icon: UserCog, primary: true, group: "main" },
 
   // Admin — réservé aux utilisateurs avec isAdmin === true
   { to: "/admin-users", labelKey: "nav.adminUsers", icon: Users, group: "admin", requiresAdmin: true },
@@ -57,11 +68,38 @@ export const navItems: readonly NavItem[] = [
 ] as const;
 
 export const navGroups: { key: NavItem["group"]; labelKey: string }[] = [
-  { key: "knowledge", labelKey: "nav.groupKnowledge" },
-  { key: "tracking", labelKey: "nav.groupTracking" },
-  { key: "care", labelKey: "nav.groupCare" },
-  { key: "account", labelKey: "nav.groupAccount" },
+  { key: "main", labelKey: "nav.groupMain" },
   { key: "admin", labelKey: "nav.groupAdmin" },
 ];
 
 export const primaryNavItems = navItems.filter((i) => i.primary);
+
+// Secondary screens, reachable from the /suivi hub (not the sidebar). Grouped
+// for the hub layout; each keeps its own route + URL unchanged.
+export type HubGroup = "daily" | "tools" | "resources";
+
+export type HubItem = {
+  to: NavTarget;
+  labelKey: string;
+  descriptionKey: string;
+  icon: React.ComponentType<{ className?: string }>;
+  hubGroup: HubGroup;
+};
+
+export const hubNavItems: readonly HubItem[] = [
+  { to: "/journal", labelKey: "nav.journal", descriptionKey: "suiviHub.desc.journal", icon: BookOpen, hubGroup: "daily" },
+  { to: "/symptoms", labelKey: "nav.symptoms", descriptionKey: "suiviHub.desc.symptoms", icon: Activity, hubGroup: "daily" },
+  { to: "/medications", labelKey: "nav.medications", descriptionKey: "suiviHub.desc.medications", icon: Pill, hubGroup: "daily" },
+  { to: "/routines", labelKey: "nav.routines", descriptionKey: "suiviHub.desc.routines", icon: ListChecks, hubGroup: "daily" },
+  { to: "/rewards", labelKey: "nav.rewards", descriptionKey: "suiviHub.desc.rewards", icon: Trophy, hubGroup: "tools" },
+  { to: "/timer", labelKey: "nav.timer", descriptionKey: "suiviHub.desc.timer", icon: Timer, hubGroup: "tools" },
+  { to: "/insights", labelKey: "nav.insights", descriptionKey: "suiviHub.desc.insights", icon: TrendingUp, hubGroup: "tools" },
+  { to: "/crisis-list", labelKey: "nav.crisisList", descriptionKey: "suiviHub.desc.crisisList", icon: HandHeart, hubGroup: "resources" },
+  { to: "/connaissances", labelKey: "nav.knowledgeBase", descriptionKey: "suiviHub.desc.knowledgeBase", icon: Library, hubGroup: "resources" },
+] as const;
+
+export const hubGroups: { key: HubGroup; labelKey: string }[] = [
+  { key: "daily", labelKey: "suiviHub.groups.daily" },
+  { key: "tools", labelKey: "suiviHub.groups.tools" },
+  { key: "resources", labelKey: "suiviHub.groups.resources" },
+];

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -302,6 +302,11 @@
   },
   "nav": {
     "dashboard": "Dashboard",
+    "today": "Today",
+    "tracking": "Tracking",
+    "trackingShort": "Tracking",
+    "report": "Report",
+    "groupMain": "Menu",
     "rewards": "Rewards",
     "crisisList": "Crisis list",
     "symptoms": "Symptoms",
@@ -341,6 +346,26 @@
     "groupAccount": "Account",
     "groupAdmin": "Admin",
     "breadcrumbHome": "Home"
+  },
+  "suiviHub": {
+    "title": "Tracking",
+    "subtitle": "All your daily entries and tools, in one place.",
+    "groups": {
+      "daily": "Every day",
+      "tools": "Motivation & tools",
+      "resources": "When you need it"
+    },
+    "desc": {
+      "journal": "Note your child's day",
+      "symptoms": "Track symptoms over time",
+      "medications": "Treatments, doses and effects",
+      "routines": "Morning and evening routines",
+      "rewards": "Reward board and stars",
+      "timer": "Companion timer for transitions",
+      "insights": "Tracking trends and analysis",
+      "crisisList": "Your crisis plan, ready to use",
+      "knowledgeBase": "Guides to understand and support"
+    }
   },
   "contact": {
     "title": "Contact",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -302,6 +302,11 @@
   },
   "nav": {
     "dashboard": "Tableau de bord",
+    "today": "Aujourd'hui",
+    "tracking": "Suivi",
+    "trackingShort": "Suivi",
+    "report": "Rapport",
+    "groupMain": "Menu",
     "insights": "Analyses",
     "rewards": "Récompenses",
     "crisisList": "Liste de crise",
@@ -342,6 +347,26 @@
     "groupAccount": "Compte",
     "groupAdmin": "Administration",
     "breadcrumbHome": "Accueil"
+  },
+  "suiviHub": {
+    "title": "Suivi",
+    "subtitle": "Toutes vos saisies et vos outils du quotidien, au même endroit.",
+    "groups": {
+      "daily": "Au quotidien",
+      "tools": "Motivation & outils",
+      "resources": "En cas de besoin"
+    },
+    "desc": {
+      "journal": "Noter la journée de votre enfant",
+      "symptoms": "Suivre les symptômes au fil du temps",
+      "medications": "Traitements, prises et effets",
+      "routines": "Routines du matin et du soir",
+      "rewards": "Tableau de récompenses et étoiles",
+      "timer": "Minuteur-compagnon pour les transitions",
+      "insights": "Tendances et analyses de suivi",
+      "crisisList": "Votre plan anti-crise, prêt à l'emploi",
+      "knowledgeBase": "Guides pour comprendre et accompagner"
+    }
   },
   "contact": {
     "title": "Contact",

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -28,6 +28,7 @@ import { Route as RessourcesSlugRouteImport } from './routes/ressources/$slug'
 import { Route as InviteTokenRouteImport } from './routes/invite/$token'
 import { Route as AuthenticatedTimerIndexRouteImport } from './routes/_authenticated/timer/index'
 import { Route as AuthenticatedSymptomsIndexRouteImport } from './routes/_authenticated/symptoms/index'
+import { Route as AuthenticatedSuiviIndexRouteImport } from './routes/_authenticated/suivi/index'
 import { Route as AuthenticatedRoutinesIndexRouteImport } from './routes/_authenticated/routines/index'
 import { Route as AuthenticatedRewardsIndexRouteImport } from './routes/_authenticated/rewards/index'
 import { Route as AuthenticatedReportIndexRouteImport } from './routes/_authenticated/report/index'
@@ -140,6 +141,11 @@ const AuthenticatedSymptomsIndexRoute =
     path: '/symptoms/',
     getParentRoute: () => AuthenticatedRoute,
   } as any)
+const AuthenticatedSuiviIndexRoute = AuthenticatedSuiviIndexRouteImport.update({
+  id: '/suivi/',
+  path: '/suivi/',
+  getParentRoute: () => AuthenticatedRoute,
+} as any)
 const AuthenticatedRoutinesIndexRoute =
   AuthenticatedRoutinesIndexRouteImport.update({
     id: '/routines/',
@@ -273,6 +279,7 @@ export interface FileRoutesByFullPath {
   '/report/': typeof AuthenticatedReportIndexRoute
   '/rewards/': typeof AuthenticatedRewardsIndexRoute
   '/routines/': typeof AuthenticatedRoutinesIndexRoute
+  '/suivi/': typeof AuthenticatedSuiviIndexRoute
   '/symptoms/': typeof AuthenticatedSymptomsIndexRoute
   '/timer/': typeof AuthenticatedTimerIndexRoute
   '/barkley/formation/$stepNumber': typeof AuthenticatedBarkleyFormationStepNumberRoute
@@ -309,6 +316,7 @@ export interface FileRoutesByTo {
   '/report': typeof AuthenticatedReportIndexRoute
   '/rewards': typeof AuthenticatedRewardsIndexRoute
   '/routines': typeof AuthenticatedRoutinesIndexRoute
+  '/suivi': typeof AuthenticatedSuiviIndexRoute
   '/symptoms': typeof AuthenticatedSymptomsIndexRoute
   '/timer': typeof AuthenticatedTimerIndexRoute
   '/barkley/formation/$stepNumber': typeof AuthenticatedBarkleyFormationStepNumberRoute
@@ -347,6 +355,7 @@ export interface FileRoutesById {
   '/_authenticated/report/': typeof AuthenticatedReportIndexRoute
   '/_authenticated/rewards/': typeof AuthenticatedRewardsIndexRoute
   '/_authenticated/routines/': typeof AuthenticatedRoutinesIndexRoute
+  '/_authenticated/suivi/': typeof AuthenticatedSuiviIndexRoute
   '/_authenticated/symptoms/': typeof AuthenticatedSymptomsIndexRoute
   '/_authenticated/timer/': typeof AuthenticatedTimerIndexRoute
   '/_authenticated/barkley/formation/$stepNumber': typeof AuthenticatedBarkleyFormationStepNumberRoute
@@ -385,6 +394,7 @@ export interface FileRouteTypes {
     | '/report/'
     | '/rewards/'
     | '/routines/'
+    | '/suivi/'
     | '/symptoms/'
     | '/timer/'
     | '/barkley/formation/$stepNumber'
@@ -421,6 +431,7 @@ export interface FileRouteTypes {
     | '/report'
     | '/rewards'
     | '/routines'
+    | '/suivi'
     | '/symptoms'
     | '/timer'
     | '/barkley/formation/$stepNumber'
@@ -458,6 +469,7 @@ export interface FileRouteTypes {
     | '/_authenticated/report/'
     | '/_authenticated/rewards/'
     | '/_authenticated/routines/'
+    | '/_authenticated/suivi/'
     | '/_authenticated/symptoms/'
     | '/_authenticated/timer/'
     | '/_authenticated/barkley/formation/$stepNumber'
@@ -618,6 +630,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedSymptomsIndexRouteImport
       parentRoute: typeof AuthenticatedRoute
     }
+    '/_authenticated/suivi/': {
+      id: '/_authenticated/suivi/'
+      path: '/suivi'
+      fullPath: '/suivi/'
+      preLoaderRoute: typeof AuthenticatedSuiviIndexRouteImport
+      parentRoute: typeof AuthenticatedRoute
+    }
     '/_authenticated/routines/': {
       id: '/_authenticated/routines/'
       path: '/routines'
@@ -749,6 +768,7 @@ interface AuthenticatedRouteChildren {
   AuthenticatedReportIndexRoute: typeof AuthenticatedReportIndexRoute
   AuthenticatedRewardsIndexRoute: typeof AuthenticatedRewardsIndexRoute
   AuthenticatedRoutinesIndexRoute: typeof AuthenticatedRoutinesIndexRoute
+  AuthenticatedSuiviIndexRoute: typeof AuthenticatedSuiviIndexRoute
   AuthenticatedSymptomsIndexRoute: typeof AuthenticatedSymptomsIndexRoute
   AuthenticatedTimerIndexRoute: typeof AuthenticatedTimerIndexRoute
   AuthenticatedBarkleyFormationStepNumberRoute: typeof AuthenticatedBarkleyFormationStepNumberRoute
@@ -770,6 +790,7 @@ const AuthenticatedRouteChildren: AuthenticatedRouteChildren = {
   AuthenticatedReportIndexRoute: AuthenticatedReportIndexRoute,
   AuthenticatedRewardsIndexRoute: AuthenticatedRewardsIndexRoute,
   AuthenticatedRoutinesIndexRoute: AuthenticatedRoutinesIndexRoute,
+  AuthenticatedSuiviIndexRoute: AuthenticatedSuiviIndexRoute,
   AuthenticatedSymptomsIndexRoute: AuthenticatedSymptomsIndexRoute,
   AuthenticatedTimerIndexRoute: AuthenticatedTimerIndexRoute,
   AuthenticatedBarkleyFormationStepNumberRoute:

--- a/apps/web/src/routes/AuthenticatedLayout.tsx
+++ b/apps/web/src/routes/AuthenticatedLayout.tsx
@@ -12,7 +12,7 @@ import { OnboardingTour } from "@/components/shared/onboarding-tour";
 import { KoeWidget } from "@/components/koe-widget";
 import { useIdleLock } from "@/hooks/use-idle-lock";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { navItems } from "@/config/nav";
+import { navItems, hubNavItems } from "@/config/nav";
 import { cn } from "@/lib/utils";
 import { trackSessionStart } from "@/lib/analytics";
 
@@ -40,7 +40,9 @@ function AuthenticatedShell() {
   }, []);
 
   // Announce the active page to screen readers when the route changes.
-  const activeNavItem = navItems.find(
+  // Search hub items too: the daily-tracking screens moved under /suivi but
+  // still need their page announced to screen readers on navigation.
+  const activeNavItem = [...navItems, ...hubNavItems].find(
     (i) => pathname === i.to || pathname.startsWith(`${i.to}/`)
   );
   const activePageLabel = activeNavItem ? t(activeNavItem.labelKey) : "";

--- a/apps/web/src/routes/_authenticated/suivi/index.tsx
+++ b/apps/web/src/routes/_authenticated/suivi/index.tsx
@@ -1,0 +1,61 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { useTranslation } from "react-i18next";
+import { ChevronRight } from "lucide-react";
+import { PageHeader } from "@/components/layout/page-header";
+import { Card, CardContent } from "@/components/ui/card";
+import { hubGroups, hubNavItems } from "@/config/nav";
+
+export const Route = createFileRoute("/_authenticated/suivi/")({
+  component: SuiviHubPage,
+  staticData: {
+    crumb: "nav.tracking",
+  },
+});
+
+// The "Suivi" hub: one calm entry point to every daily-tracking screen, so the
+// sidebar stays at 5 parent entries (Phase 1 simplification) without burying
+// anything. Grouped, explicit labels, one tap to each tool.
+function SuiviHubPage() {
+  const { t } = useTranslation();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t("suiviHub.title")}
+        description={t("suiviHub.subtitle")}
+      />
+
+      {hubGroups.map((group) => {
+        const items = hubNavItems.filter((i) => i.hubGroup === group.key);
+        if (items.length === 0) return null;
+        return (
+          <section key={group.key} className="space-y-3">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              {t(group.labelKey)}
+            </h2>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {items.map((item) => (
+                <Link key={item.to} to={item.to} className="group block">
+                  <Card className="transition-colors hover:border-primary/40 hover:bg-primary/5">
+                    <CardContent className="flex items-center gap-4 p-4">
+                      <div className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-muted text-foreground/70 group-hover:bg-primary/10 group-hover:text-primary">
+                        <item.icon className="size-5" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="font-medium">{t(item.labelKey)}</p>
+                        <p className="mt-0.5 text-sm text-muted-foreground">
+                          {t(item.descriptionKey)}
+                        </p>
+                      </div>
+                      <ChevronRight className="size-4 shrink-0 text-muted-foreground group-hover:text-primary" />
+                    </CardContent>
+                  </Card>
+                </Link>
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Contexte

Termine l'objectif **Phase 1 · navigation à 4–5 entrées** (`docs/product-strategy.md` §6). La barre latérale passe de ~12 à **5 entrées** : **Aujourd'hui** (dashboard) · **Suivi** · **Barkley** · **Rapport** · **Compte**.

## Changements

- **Nouvelle route `/suivi`** : un hub calme qui regroupe **tous** les écrans de suivi quotidien (journal, symptômes, médicaments, routines, récompenses, minuteur, analyses, liste de crise, connaissances) sous forme de cartes libellées et groupées. **Rien n'est supprimé** — chaque écran garde son URL, désormais à un tap depuis Suivi.
- `config/nav.ts` : 5 entrées primaires + `hubNavItems`/`hubGroups` ; groupes réduits à `main` + `admin` ; barre d'onglets mobile → 4 primaires (Aujourd'hui/Suivi/Barkley/Compte).
- **Couplages gérés** : ancres de la visite guidée (`/symptoms`,`/routines` → `/suivi`) ; libellé a11y de page (`AuthenticatedLayout`) cherche désormais nav + hub.
- i18n fr/en.

Aucune route supprimée, aucune donnée touchée.

## Vérification

- `pnpm typecheck` ✅ · tests web ✅ · copy-lint (B7) ✅ · `routeTree.gen.ts` régénéré (route `/suivi`).
- ⚠️ **Capture non réalisée** : l'app authentifiée nécessite Postgres, indisponible dans cet environnement (pas de Docker). **PR laissée en draft pour votre revue visuelle** — c'est un changement de mise en page qui mérite votre œil. La CI E2E (auth démo) rend la barre latérale sur `/dashboard` et détecterait un crash de rendu.

## Note

Le libellé du groupe latéral unique est « Menu ». La route `/report` (Rapport médical) devient une entrée de nav de premier niveau. Les anciens libellés de groupe (Ressources/Soins…) sont désormais inertes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8)_