### PR TITLE
fix: espace vide de la carte tarifs + ligne Barkley cohérente avec l'offre

### DIFF
--- a/apps/web/src/components/landing/pricing-section.tsx
+++ b/apps/web/src/components/landing/pricing-section.tsx
@@ -29,7 +29,14 @@ const comparisonRows = [
   { key: "symptoms", free: true, family: true },
   { key: "medications", free: true, family: true },
   { key: "rewards", free: true, family: true },
-  { key: "barkley", free: true, family: true },
+  // Barkley teaching content is a paid offer (Tokō Formation, §4.2): sold as a
+  // one-shot or bundled with Famille — not free. The reward board / practice
+  // layer stays free (the "rewards" row above).
+  {
+    key: "barkley",
+    freeValueKey: "barkleyFree" as const,
+    familyValueKey: "barkleyFamily" as const,
+  },
   { key: "news", free: true, family: true },
   { key: "weekTrends", free: true, family: true },
   { key: "rgpdExport", free: true, family: true },
@@ -61,7 +68,7 @@ export function PricingSection() {
                 {t("landing.pricing.free.description")}
               </CardDescription>
             </CardHeader>
-            <CardContent className="space-y-5">
+            <CardContent className="flex flex-1 flex-col space-y-5">
               <div className="flex items-baseline gap-1">
                 <span className="font-heading text-4xl font-semibold">0€</span>
                 <span className="text-muted-foreground">
@@ -81,6 +88,11 @@ export function PricingSection() {
                   </li>
                 ))}
               </ul>
+              {/* Fills the height the taller Famille card would otherwise leave
+                  empty, with a calm, honest nudge toward the paid plan. */}
+              <div className="mt-auto rounded-xl border border-primary/15 bg-primary/5 p-4 text-sm leading-relaxed text-muted-foreground">
+                {t("landing.pricing.free.upgradeHint")}
+              </div>
             </CardContent>
             <CardFooter>
               <Link

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -204,6 +204,8 @@
         "medications": "Medication tracking",
         "rewards": "Rewards board",
         "barkley": "Full Barkley program",
+        "barkleyFree": "Training €89",
+        "barkleyFamily": "Included",
         "news": "News & resources",
         "weekTrends": "Weekly trends",
         "rgpdExport": "GDPR data export"
@@ -216,7 +218,8 @@
         "feature1": "ADHD logbook (7 and 30 days)",
         "feature2": "Journal, symptoms, medication, calm-down list",
         "feature3": "GDPR data export",
-        "cta": "Prepare my next appointment"
+        "cta": "Prepare my next appointment",
+        "upgradeHint": "Need the PDF report, tracking for several children or full history? Move to Famille whenever you like."
       },
       "family": {
         "name": "Family",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -204,6 +204,8 @@
         "medications": "Suivi médicaments",
         "rewards": "Tableau de récompenses",
         "barkley": "Programme Barkley complet",
+        "barkleyFree": "Formation 89 €",
+        "barkleyFamily": "Inclus",
         "news": "Actualités & ressources",
         "weekTrends": "Tendances semaine",
         "rgpdExport": "Export RGPD de vos données"
@@ -216,7 +218,8 @@
         "feature1": "Carnet de consultation TDAH (7 et 30 jours)",
         "feature2": "Journal, symptômes, médicaments, anti-crise",
         "feature3": "Export RGPD de vos données",
-        "cta": "Préparer ma prochaine consultation"
+        "cta": "Préparer ma prochaine consultation",
+        "upgradeHint": "Besoin du rapport PDF, du suivi de plusieurs enfants ou de l'historique complet ? Passez à Famille quand vous voulez."
       },
       "family": {
         "name": "Famille",


### PR DESCRIPTION
## Contexte

Deux corrections sur `PricingSection` (`/tarifs`), issues d'une revue visuelle.

## 1. Espace vide sous la carte « Gratuit »

La carte Gratuit laissait un grand vide (la carte Famille est bien plus haute). Elle **remplit désormais la hauteur** (`CardContent flex-1`) avec un **encart d'incitation calme** ancré au-dessus d'un CTA aligné en bas — équilibrée avec Famille.

## 2. Ligne « Programme Barkley » incohérente avec le modèle d'offres

Le comparatif affichait **« Programme Barkley complet » en ✓ gratuit** pour le plan Gratuit — ce qui **contredit la décision §4.2** : Barkley (Tokō Formation) est une **offre payante**. La ligne affiche maintenant **« Formation 89 € » (Gratuit) / « Inclus » (Famille)**, cohérent avec les trois offres et le paywall de #348.

La couche pratique / tableau de récompenses reste **gratuite** (ligne distincte, inchangée).

## Vérification

- `pnpm typecheck` ✅ · copy-lint (B7) ✅ · JSON locales valides ✅
- **Rendu réel vérifié** (dev server + Chromium `/tarifs`) — captures partagées dans la conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8

---
_Generated by [Claude Code](https://claude.ai/code/session_01KR7VJaziMEPd87U1R717v8)_