### PR TITLE
fix: conformité mobile-first sur toutes les fonctionnalités (audit #360)

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -6,6 +6,8 @@
     <title>Tokō — App TDAH enfant pour parents épuisés | Routines, suivi, plan de crise</title>
     <meta name="description" content="Tokō aide les parents TDAH à gérer le quotidien de leurs enfants TDAH. Routines simplifiées, suivi des symptômes, plan de crise, récompenses. Sans charge mentale." />
     <link rel="canonical" href="https://toko.battistella.ovh/" />
+    <meta name="theme-color" content="#358891" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#091123" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#358891" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />

--- a/apps/web/src/components/barkley/behavior-tracking.tsx
+++ b/apps/web/src/components/barkley/behavior-tracking.tsx
@@ -563,7 +563,7 @@ function SortableBehaviorCard({
                 type="button"
                 {...attributes}
                 {...listeners}
-                className="cursor-grab touch-none rounded p-0.5 text-muted-foreground/40 hover:text-muted-foreground transition-colors active:cursor-grabbing shrink-0"
+                className="flex size-11 -my-2 -ml-2 cursor-grab touch-none items-center justify-center rounded text-muted-foreground/40 hover:text-muted-foreground transition-colors active:cursor-grabbing shrink-0"
               >
                 <GripVertical className="size-4" />
               </button>
@@ -578,7 +578,7 @@ function SortableBehaviorCard({
               name={behavior.name}
               onDelete={onDelete}
               pending={deletePending}
-              className="text-muted-foreground/40 hover:text-destructive transition-colors p-1 rounded shrink-0"
+              className="flex size-11 -my-2 -mr-2 items-center justify-center rounded text-muted-foreground/40 hover:text-destructive transition-colors shrink-0"
             />
           </div>
           <div className="flex justify-between gap-1">

--- a/apps/web/src/components/barkley/behavior-week-header.tsx
+++ b/apps/web/src/components/barkley/behavior-week-header.tsx
@@ -36,14 +36,14 @@ export function BehaviorWeekHeader({
           variant="ghost"
           size="icon"
           onClick={onPrevWeek}
-          className="size-7"
+          className="md:size-7"
         >
           <ChevronLeft className="size-4" />
         </Button>
         <button
           type="button"
           onClick={onGoToThisWeek}
-          className="text-sm font-medium text-muted-foreground hover:text-foreground transition-colors"
+          className="inline-flex min-h-11 items-center px-1 text-sm font-medium text-muted-foreground hover:text-foreground md:min-h-0 transition-colors"
           title={thisWeekLabel}
         >
           {weekLabel}
@@ -52,7 +52,7 @@ export function BehaviorWeekHeader({
           variant="ghost"
           size="icon"
           onClick={onNextWeek}
-          className="size-7"
+          className="md:size-7"
         >
           <ChevronRight className="size-4" />
         </Button>
@@ -60,7 +60,7 @@ export function BehaviorWeekHeader({
           <button
             type="button"
             onClick={onGoToThisWeek}
-            className="ml-1 text-xs text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2"
+            className="ml-1 inline-flex min-h-11 items-center px-1 text-xs text-muted-foreground hover:text-foreground md:min-h-0 transition-colors underline underline-offset-2"
           >
             {thisWeekLabel}
           </button>

--- a/apps/web/src/components/catalog-picker.tsx
+++ b/apps/web/src/components/catalog-picker.tsx
@@ -72,7 +72,7 @@ export function CatalogPicker({
       <p className="sticky top-0 z-10 bg-popover/95 py-1 text-xs font-medium text-muted-foreground backdrop-blur-sm">
         {label}
       </p>
-      <div className="grid grid-cols-7 gap-1 sm:grid-cols-8">
+      <div className="grid grid-cols-6 gap-1 sm:grid-cols-8">
         {emojis.map((emoji) => (
           <EmojiButton
             key={`${keyPrefix}-${emoji}`}
@@ -139,7 +139,7 @@ export function CatalogPicker({
               {t("emojiPicker.noResults")}
             </p>
           ) : (
-            <div className="grid grid-cols-7 gap-1 sm:grid-cols-8">
+            <div className="grid grid-cols-6 gap-1 sm:grid-cols-8">
               {filteredEmojis.map((emoji) => (
                 <EmojiButton
                   key={`search-${emoji}`}
@@ -151,7 +151,7 @@ export function CatalogPicker({
             </div>
           )
         ) : currentCategory ? (
-          <div className="grid grid-cols-7 gap-1 sm:grid-cols-8">
+          <div className="grid grid-cols-6 gap-1 sm:grid-cols-8">
             {currentCategory.emojis.map((emoji) => (
               <EmojiButton
                 key={`cat-${emoji}`}

--- a/apps/web/src/components/co-parent/co-parent-section.tsx
+++ b/apps/web/src/components/co-parent/co-parent-section.tsx
@@ -310,7 +310,7 @@ function MemberRow({
                   aria-label={t("childAccess.revokeAria", {
                     name: row.userName ?? row.userEmail,
                   })}
-                  className="size-8 text-muted-foreground hover:text-destructive"
+                  className="text-muted-foreground hover:text-destructive"
                 >
                   <Trash2 className="size-3.5" />
                 </Button>

--- a/apps/web/src/components/co-parent/family-members-list.tsx
+++ b/apps/web/src/components/co-parent/family-members-list.tsx
@@ -96,7 +96,7 @@ function FamilyMemberRow({ row }: RowProps) {
             <Button
               type="button"
               variant="ghost"
-              size="sm"
+              size="icon"
               disabled={revoke.isPending}
               className="shrink-0 text-muted-foreground hover:text-destructive"
               aria-label={t("childAccess.revokeAria", { name: displayName })}

--- a/apps/web/src/components/dashboard/journal-quick-note.tsx
+++ b/apps/web/src/components/dashboard/journal-quick-note.tsx
@@ -73,7 +73,7 @@ export function JournalQuickNote({ childId }: { childId: string }) {
                 onClick={() => toggleTag(tag)}
                 aria-pressed={active}
                 className={cn(
-                  "rounded-full border px-3 py-1 text-xs font-medium transition-colors",
+                  "inline-flex min-h-10 items-center rounded-full border px-3 py-1 text-xs font-medium md:min-h-0 transition-colors",
                   active
                     ? "border-primary bg-primary text-primary-foreground"
                     : "border-border text-muted-foreground hover:bg-muted"

--- a/apps/web/src/components/dashboard/medication-quick-log.tsx
+++ b/apps/web/src/components/dashboard/medication-quick-log.tsx
@@ -56,8 +56,7 @@ export function MedicationQuickLog({ childId }: { childId: string }) {
               <Button
                 type="button"
                 variant={med.todayTaken === true ? "default" : "outline"}
-                size="sm"
-                className="size-8 p-0"
+                size="icon"
                 aria-label={t("medications.takeValidated")}
                 onClick={() => handleLog(med.id, true)}
                 disabled={logMedication.isPending}
@@ -67,8 +66,7 @@ export function MedicationQuickLog({ childId }: { childId: string }) {
               <Button
                 type="button"
                 variant={med.todayTaken === false ? "default" : "outline"}
-                size="sm"
-                className="size-8 p-0"
+                size="icon"
                 aria-label={t("medications.takeMissed")}
                 onClick={() => handleLog(med.id, false)}
                 disabled={logMedication.isPending}

--- a/apps/web/src/components/dashboard/resource-hint-card.tsx
+++ b/apps/web/src/components/dashboard/resource-hint-card.tsx
@@ -61,7 +61,7 @@ export function ResourceHintCard({ childId }: { childId: string }) {
           type="button"
           onClick={handleDismiss}
           aria-label={t("resourceHint.dismiss")}
-          className="rounded p-1 text-muted-foreground/60 hover:text-foreground transition-colors"
+          className="flex size-11 -my-3 -mr-2 shrink-0 items-center justify-center rounded text-muted-foreground/60 hover:text-foreground md:size-8 md:-my-1.5 md:-mr-1 transition-colors"
         >
           <X className="size-3.5" />
         </button>

--- a/apps/web/src/components/dashboard/weekly-chart.tsx
+++ b/apps/web/src/components/dashboard/weekly-chart.tsx
@@ -73,9 +73,9 @@ export function WeeklyChart({
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between gap-2">
-        <CardTitle className="text-base">{title}</CardTitle>
-        <div className="flex gap-1">
+      <CardHeader className="flex flex-row flex-wrap items-center justify-between gap-2">
+        <CardTitle className="min-w-0 text-base">{title}</CardTitle>
+        <div className="flex shrink-0 gap-1">
           {PERIODS.map((p) => {
             const isLocked = lockedSet.has(p.key);
             return (

--- a/apps/web/src/components/emoji-button.tsx
+++ b/apps/web/src/components/emoji-button.tsx
@@ -19,7 +19,7 @@ export function EmojiButton({
       onClick={() => onSelect(emoji)}
       aria-label={ariaLabelFor(emoji)}
       aria-pressed={selected}
-      className={`flex size-11 items-center justify-center rounded-md text-xl transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+      className={`flex h-11 w-full min-w-9 items-center justify-center rounded-md text-xl transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
         selected ? "bg-accent ring-2 ring-primary" : ""
       }`}
     >

--- a/apps/web/src/components/emoji-grid.tsx
+++ b/apps/web/src/components/emoji-grid.tsx
@@ -3,8 +3,8 @@ import { EmojiButton } from "./emoji-button";
 const GRID_COLS: Record<number, string> = {
   5: "grid-cols-5",
   6: "grid-cols-6",
-  7: "grid-cols-7",
-  8: "grid-cols-8",
+  7: "grid-cols-6 sm:grid-cols-7",
+  8: "grid-cols-6 sm:grid-cols-8",
 };
 
 export function EmojiGrid({
@@ -19,7 +19,7 @@ export function EmojiGrid({
   columns: number;
 }) {
   return (
-    <div className={`grid gap-1 ${GRID_COLS[columns] ?? "grid-cols-8"}`}>
+    <div className={`grid gap-1 ${GRID_COLS[columns] ?? "grid-cols-6 sm:grid-cols-8"}`}>
       {emojis.map((emoji) => (
         <EmojiButton
           key={emoji}

--- a/apps/web/src/components/journal/journal-card.tsx
+++ b/apps/web/src/components/journal/journal-card.tsx
@@ -46,7 +46,8 @@ export function JournalCard({
                   render={
                     <Button
                       variant="ghost"
-                      size="icon-sm"
+                      size="icon"
+                      className="md:size-8"
                       aria-label={t("journal.actionsLabel")}
                     >
                       <MoreVertical className="size-4" />

--- a/apps/web/src/components/journal/journal-form.tsx
+++ b/apps/web/src/components/journal/journal-form.tsx
@@ -159,7 +159,7 @@ export function JournalForm({
             <Badge
               key={tag}
               variant={selectedTags.includes(tag) ? "default" : "outline"}
-              className="cursor-pointer"
+              className="min-h-10 cursor-pointer px-3 md:min-h-0 md:px-2"
               onClick={() => toggleTag(tag)}
             >
               {t(config.labelKey)}

--- a/apps/web/src/components/mode-toggle.tsx
+++ b/apps/web/src/components/mode-toggle.tsx
@@ -35,9 +35,9 @@ export function ModeToggle({ className }: { className?: string }) {
         render={
           <Button
             variant="ghost"
-            size="icon-sm"
+            size="icon"
             aria-label={t("theme.toggle")}
-            className={cn("relative", className)}
+            className={cn("relative md:size-7", className)}
           />
         }
       >

--- a/apps/web/src/components/shared/floating-tip-button.tsx
+++ b/apps/web/src/components/shared/floating-tip-button.tsx
@@ -94,7 +94,7 @@ export function FloatingTipButton() {
               type="button"
               onClick={() => setOffset((o) => o + 1)}
               aria-label={t("featureTip.next")}
-              className="flex h-7 items-center gap-1 rounded px-2 text-xs text-info-foreground/80 hover:text-info-foreground focus-visible:text-info-foreground focus-visible:outline-2 focus-visible:outline-ring"
+              className="flex h-9 items-center gap-1 rounded px-2 text-xs text-info-foreground/80 hover:text-info-foreground focus-visible:text-info-foreground focus-visible:outline-2 focus-visible:outline-ring md:h-7"
             >
               <span>{t("featureTip.next")}</span>
               <ChevronRight className="size-3.5" />
@@ -107,7 +107,7 @@ export function FloatingTipButton() {
               setOffset(0);
             }}
             aria-label={t("featureTip.dismiss")}
-            className="flex size-7 items-center justify-center rounded text-info-foreground/70 hover:text-info-foreground focus-visible:text-info-foreground focus-visible:outline-2 focus-visible:outline-ring"
+            className="flex size-9 items-center justify-center rounded text-info-foreground/70 hover:text-info-foreground focus-visible:text-info-foreground focus-visible:outline-2 focus-visible:outline-ring md:size-7"
           >
             <X className="size-3.5" />
           </button>

--- a/apps/web/src/components/symptoms/symptom-card.tsx
+++ b/apps/web/src/components/symptoms/symptom-card.tsx
@@ -106,7 +106,7 @@ export function SymptomCard({
               type="button"
               onClick={() => onEdit(symptom)}
               aria-label={t("common.edit")}
-              className="flex size-9 items-center justify-center rounded text-muted-foreground/50 hover:text-foreground transition-colors"
+              className="flex size-11 items-center justify-center rounded text-muted-foreground/70 hover:text-foreground md:size-9 transition-colors"
             >
               <Pencil className="size-4" />
             </button>
@@ -117,7 +117,7 @@ export function SymptomCard({
                     type="button"
                     disabled={deleteSymptom.isPending}
                     aria-label={t("common.delete")}
-                    className="flex size-9 items-center justify-center rounded text-muted-foreground/30 hover:text-destructive transition-colors"
+                    className="flex size-11 items-center justify-center rounded text-muted-foreground/70 hover:text-destructive md:size-9 transition-colors"
                   >
                     <Trash2 className="size-4" />
                   </button>

--- a/apps/web/src/components/timer/timer-controls.tsx
+++ b/apps/web/src/components/timer/timer-controls.tsx
@@ -29,7 +29,7 @@ export function TimerControls({
   const { t } = useTranslation();
 
   return (
-    <div className="flex items-center gap-3">
+    <div className="flex flex-wrap items-center justify-center gap-3">
       <Button
         size="lg"
         onClick={onPlayPause}

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -57,7 +57,7 @@ function DropdownMenuItem({
     <MenuPrimitive.Item
       data-slot="dropdown-menu-item"
       className={cn(
-        "flex w-full cursor-pointer items-center gap-2 rounded-md p-2 text-sm outline-none select-none data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "flex min-h-10 w-full cursor-pointer items-center gap-2 rounded-md p-2 text-sm outline-none select-none md:min-h-0 data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
         className
       )}
       {...props}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -29,7 +29,7 @@ import { PanelLeftIcon } from "lucide-react"
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
 const SIDEBAR_WIDTH = "18rem"
-const SIDEBAR_WIDTH_MOBILE = "18rem"
+const SIDEBAR_WIDTH_MOBILE = "min(18rem, 85vw)"
 const SIDEBAR_WIDTH_ICON = "3rem"
 const SIDEBAR_KEYBOARD_SHORTCUT = "b"
 

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -11,6 +11,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
     <Sonner
       theme={theme as ToasterProps["theme"]}
       position="top-center"
+      mobileOffset={{ top: "calc(3.5rem + env(safe-area-inset-top) + 0.5rem)" }}
       className="toaster group"
       icons={{
         success: (

--- a/apps/web/src/routes/_authenticated/crisis-list/crisis-list-page.tsx
+++ b/apps/web/src/routes/_authenticated/crisis-list/crisis-list-page.tsx
@@ -351,7 +351,7 @@ function SortableCrisisItemCard({
       <CardContent className="flex items-center gap-2 py-2 pl-2 pr-3 sm:gap-3 sm:pl-3 sm:pr-4">
         <button
           type="button"
-          className="flex h-10 w-8 shrink-0 cursor-grab touch-none items-center justify-center rounded text-muted-foreground/40 hover:text-muted-foreground active:cursor-grabbing"
+          className="flex h-11 w-10 shrink-0 cursor-grab touch-none items-center justify-center rounded text-muted-foreground/40 hover:text-muted-foreground active:cursor-grabbing"
           aria-label={t("crisis.reorder")}
           {...attributes}
           {...listeners}
@@ -375,7 +375,7 @@ function SortableCrisisItemCard({
                 type="button"
                 disabled={deleteItem.isPending}
                 aria-label={t("crisis.delete")}
-                className="flex size-10 items-center justify-center rounded text-muted-foreground/40 hover:text-destructive transition-colors"
+                className="flex size-11 items-center justify-center rounded text-muted-foreground/40 hover:text-destructive transition-colors"
               >
                 <Trash2 className="size-4" />
               </button>

--- a/apps/web/src/routes/_authenticated/journal/index.tsx
+++ b/apps/web/src/routes/_authenticated/journal/index.tsx
@@ -167,7 +167,7 @@ export function JournalPage() {
               <Badge
                 key={tag}
                 variant={filterTags.includes(tag) ? "default" : "outline"}
-                className="cursor-pointer"
+                className="min-h-10 cursor-pointer px-3 md:min-h-0 md:px-2"
                 onClick={() => toggleTagFilter(tag)}
               >
                 {t(config.labelKey)}

--- a/apps/web/src/routes/_authenticated/report/index.tsx
+++ b/apps/web/src/routes/_authenticated/report/index.tsx
@@ -159,8 +159,8 @@ function ReportPage() {
   return (
     <div className="mx-auto max-w-3xl">
       <div className="report-controls mb-6 flex flex-col gap-4">
-        <div className="flex items-center justify-between">
-          <div>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="min-w-0">
             <Button
               variant="ghost"
               size="sm"

--- a/apps/web/src/routes/_authenticated/report/report-controls.tsx
+++ b/apps/web/src/routes/_authenticated/report/report-controls.tsx
@@ -102,7 +102,7 @@ export function ReportControls({
         <div
           role="tablist"
           aria-label="Sélection de la période du rapport"
-          className="inline-flex rounded-lg border border-border/60 bg-background p-0.5 shadow-sm"
+          className="flex flex-wrap rounded-lg border border-border/60 bg-background p-0.5 shadow-sm"
         >
           {PERIOD_OPTIONS_LOCAL.map((opt) => {
             const locked = !isActive && opt.value === "quarter";
@@ -121,7 +121,7 @@ export function ReportControls({
                   setPeriod(opt.value);
                 }}
                 className={
-                  "rounded-md px-3 py-1.5 text-sm font-medium transition-colors inline-flex items-center gap-1.5 " +
+                  "rounded-md px-3 py-2.5 md:py-1.5 text-sm font-medium transition-colors inline-flex items-center gap-1.5 " +
                   (period === opt.value
                     ? "bg-primary text-primary-foreground shadow-sm"
                     : "text-muted-foreground hover:text-foreground")
@@ -145,7 +145,7 @@ export function ReportControls({
               setPeriod("custom");
             }}
             className={
-              "rounded-md px-3 py-1.5 text-sm font-medium transition-colors inline-flex items-center gap-1.5 " +
+              "rounded-md px-3 py-2.5 md:py-1.5 text-sm font-medium transition-colors inline-flex items-center gap-1.5 " +
               (period === "custom"
                 ? "bg-primary text-primary-foreground shadow-sm"
                 : "text-muted-foreground hover:text-foreground")

--- a/apps/web/src/routes/_authenticated/rewards/reward-card.tsx
+++ b/apps/web/src/routes/_authenticated/rewards/reward-card.tsx
@@ -54,7 +54,7 @@ export function RewardCard({
       }
     >
       <CardContent className="p-4">
-        <div className="flex items-center gap-4">
+        <div className="flex flex-wrap items-center gap-4">
           {/* Large emoji — friendly for kids */}
           <span
             className="text-3xl sm:text-4xl shrink-0 leading-none"
@@ -64,7 +64,7 @@ export function RewardCard({
           </span>
 
           {/* Center content */}
-          <div className="flex-1 min-w-0">
+          <div className="flex-1 min-w-32">
             <h3 className="font-semibold truncate">{reward.name}</h3>
 
             {/* Cost line */}
@@ -99,7 +99,7 @@ export function RewardCard({
           </div>
 
           {/* Right side: claim button OR parent actions */}
-          <div className="shrink-0 flex items-center gap-1">
+          <div className="ml-auto flex shrink-0 items-center justify-end gap-1">
             {isUnlockable && (
               <Button
                 size="sm"

--- a/apps/web/src/routes/_authenticated/routines/routines-page.tsx
+++ b/apps/web/src/routes/_authenticated/routines/routines-page.tsx
@@ -376,7 +376,7 @@ export default function RoutinesPage() {
                 size="icon"
                 onClick={dismissPatience}
                 aria-label={t("routines.templates.patienceDismiss")}
-                className="size-8 shrink-0"
+                className="shrink-0"
               >
                 <X className="size-4" />
               </Button>

--- a/apps/web/src/routes/developers-code-block.tsx
+++ b/apps/web/src/routes/developers-code-block.tsx
@@ -12,8 +12,8 @@ export function CodeBlock({ code }: { code: string }) {
       <Button
         type="button"
         variant="outline"
-        size="xs"
-        className="absolute right-2 top-2"
+        size="sm"
+        className="absolute right-2 top-2 md:h-6 md:px-2"
         onClick={() => {
           void navigator.clipboard.writeText(code);
           setCopied(true);


### PR DESCRIPTION
Closes #360

## Contexte

Audit mobile-first complet (viewports 320–414 px, iOS Safari + Android Chrome) sur **toutes les fonctionnalités**. Les fondations issues du précédent audit (#77) sont saines : boutons 44 px mobile-first, dialogs en bottom-sheet `90dvh`, inputs 16 px sans zoom iOS, safe-areas, tables avec wrapper `overflow-x-auto`. Les 26 violations relevées sont presque toutes des **surcharges locales qui court-circuitent ces fondations** — le correctif consiste principalement à les supprimer. Détail complet des constats dans #360.

## Changements

### Débordements de layout (cassés sur mobile)
- **Carnet — sélecteur de période** (`report-controls.tsx`) : le contrôle segmenté « 7 jours / 30 jours / 90 jours / Personnalisé » (~355–375 px insécable) débordait sous ~390 px → `flex flex-wrap` + cibles `py-2.5` sur mobile
- **Sélecteur d'emoji** (`emoji-button.tsx`, `emoji-grid.tsx`, `catalog-picker.tsx`) : boutons `size-11` fixes dans des grilles 7/8 colonnes → la grille débordait du Sheet mobile à 320–414 px. Boutons fluides (`h-11 w-full min-w-9`) + 6 colonnes sur mobile
- **Timer** (`timer-controls.tsx`) : jusqu'à 4 boutons `lg` en ligne insécable → `flex-wrap justify-center`
- **Carnet multi-enfants** (`report/index.tsx`) et **graphique hebdo** (`weekly-chart.tsx`) : en-têtes titre + boutons sans `flex-wrap` → le titre n'est plus écrasé
- **Récompenses** (`reward-card.tsx`) : le cluster d'actions (débloquer + éditer + supprimer) passe à la ligne au lieu d'écraser le nom de la récompense (`min-w-32` sur le contenu central)

### Cibles tactiles 44 px (suppression des surcharges)
- Médicaments ✓/✗ du dashboard : 32 px → `size="icon"` (44 px mobile / 32 px desktop)
- Flèches de navigation de semaine Barkley : 28 px → 44 px mobile (`md:size-7` conservé sur desktop)
- Révocation d'accès co-parent (×2), fermeture bannière routines, menu d'actions journal, toggle de thème du header : surcharges `size-8`/`icon-sm`/`size="sm"` retirées au profit de `size="icon"`
- `<button>` bruts agrandis à 44 px mobile : éditer/supprimer carte symptôme (avec contraste de base lisible `/70` au lieu de `/30`–`/50` réservé au hover), supprimer/drag de la carte comportement Barkley et du plan de crise, fermeture de la carte ressource, boutons du popover d'astuce, libellés de semaine Barkley
- Pastilles/badges de tags (note rapide, filtres et formulaire journal) : `min-h-10` mobile
- Bouton copier de la page Développeurs : `xs` (24 px) → `sm`

### Primitives UI et configuration
- `dropdown-menu.tsx` : items `min-h-10` sur mobile (menu compte)
- `sidebar.tsx` : drawer mobile `min(18rem, 85vw)` au lieu de 18 rem fixes (écrans 320 px)
- `sonner.tsx` : `mobileOffset` pour que les toasts s'affichent sous le header sticky
- `index.html` : `theme-color` avec variante `prefers-color-scheme: dark`

## Constats sans changement de code
- **Widget Koe au-dessus de la tab bar** (constat n°3 de l'audit) : déjà mitigé — `app.css:590` masque le lanceur flottant, le widget s'ouvre depuis le menu utilisateur
- Navigation publique mobile (liens cachés sous `sm:` sur tarifs/ressources) : différé, cf. #77 et #360
- `orientation: portrait` du manifest et légende du graphique admin : acceptés, cf. #360

## Vérification
- `pnpm typecheck` ✅ (4 packages)
- `pnpm test` ✅ (132 tests API + suites web)
- `pnpm build` (web + PWA) ✅ — l'échec du « build » API est environnemental (le script démarre le serveur et exige `DATABASE_URL`), antérieur à cette PR
- Aucune chaîne utilisateur ajoutée ou modifiée (classes CSS uniquement) — pas d'impact i18n

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VWTcQSpkv28uNcwgWujcr

---
_Generated by [Claude Code](https://claude.ai/code/session_019VWTcQSpkv28uNcwgWujcr)_