### PR TITLE
fix(mobile): autoriser les captures d'écran sur Android

### DIFF
--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -7,7 +7,6 @@ import {
 } from "@react-navigation/native";
 import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
-import { usePreventScreenCapture } from "expo-screen-capture";
 import { StatusBar } from "expo-status-bar";
 import {
   ActivityIndicator,
@@ -376,11 +375,6 @@ function ThemedNavigation() {
 }
 
 export default function App() {
-  // Block screenshots and hide the app from the recents/app-switcher preview:
-  // the screens show a child's health data, which must not leak into the OS
-  // thumbnail cache or casual screenshots (FLAG_SECURE under the hood).
-  usePreventScreenCapture();
-
   // Load brand fonts in the background — do NOT gate rendering on them.
   useFonts({
     SourceSerif4_600SemiBold,

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -56,8 +56,11 @@ médicaments) — données sensibles au sens du RGPD. Durcissement en place :
 - **Permissions réduites** : `android.blockedPermissions` retire
   `SYSTEM_ALERT_WINDOW`, `READ/WRITE_EXTERNAL_STORAGE` ajoutées par des libs.
 - **Pas de trafic en clair** : `android.usesCleartextTraffic: false`.
-- **Pas de fuite à l'écran** : `usePreventScreenCapture()` (App.tsx) bloque les
-  captures et masque l'aperçu dans le multitâche (FLAG_SECURE).
+- **Captures d'écran autorisées** : `FLAG_SECURE` n'est **pas** posé. Le parent
+  peut faire une capture (partage avec un soignant, visuels du Play Store) et
+  l'aperçu multitâche affiche l'écran réel. Compromis assumé : sur Android les
+  deux comportements sont indissociables, bloquer l'aperçu bloque aussi les
+  captures.
 - **OTA désactivé** : `updates.enabled: false` — aucune surface de code distant.
 - **Session** : cookie en `expo-secure-store`, transport HTTPS uniquement, aucun
   secret ni log de données sensibles dans `src/`.

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -37,7 +37,6 @@
     "expo-linking": "~8.0.12",
     "expo-network": "~8.0.8",
     "expo-notifications": "~0.32.0",
-    "expo-screen-capture": "~8.0.9",
     "expo-secure-store": "~15.0.0",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.0",

--- a/apps/mobile/pnpm-lock.yaml
+++ b/apps/mobile/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       expo-notifications:
         specifier: ~0.32.0
         version: 0.32.17(expo@54.0.36(@babel/core@7.29.7)(react-native@0.81.4(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react-native@0.81.4(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-screen-capture:
-        specifier: ~8.0.9
-        version: 8.0.9(expo@54.0.36(@babel/core@7.29.7)(react-native@0.81.4(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react@19.1.0)
       expo-secure-store:
         specifier: ~15.0.0
         version: 15.0.8(expo@54.0.36(@babel/core@7.29.7)(react-native@0.81.4(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))
@@ -1827,12 +1824,6 @@ packages:
       expo: '*'
       react: '*'
       react-native: '*'
-
-  expo-screen-capture@8.0.9:
-    resolution: {integrity: sha512-Xu3ZHlqxO2rEa/R5BOSyTBIJzgVA4sxzMf9jz03dSg5X/I9qwD984cSH9dABJY8NYLQmxKYUTN8jTbA9jzgcTw==}
-    peerDependencies:
-      expo: '*'
-      react: '*'
 
   expo-secure-store@15.0.8:
     resolution: {integrity: sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==}
@@ -5420,11 +5411,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
       - typescript
-
-  expo-screen-capture@8.0.9(expo@54.0.36(@babel/core@7.29.7)(react-native@0.81.4(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3))(react@19.1.0):
-    dependencies:
-      expo: 54.0.36(@babel/core@7.29.7)(react-native@0.81.4(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      react: 19.1.0
 
   expo-secure-store@15.0.8(expo@54.0.36(@babel/core@7.29.7)(react-native@0.81.4(@babel/core@7.29.7)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)):
     dependencies:


### PR DESCRIPTION
## Problème

Impossible de faire une capture d'écran dans l'app Android.

Ce n'était pas un bug : `App.tsx` appelait `usePreventScreenCapture()` au niveau racine, ce qui pose `FLAG_SECURE` sur toute l'application. Le durcissement était volontaire et documenté (« Pas de fuite à l'écran » dans `apps/mobile/README.md`), motivé par le fait que les écrans affichent des données de santé d'enfants.

Sur Android, les deux comportements de `FLAG_SECURE` sont indissociables : masquer l'aperçu dans le multitâche bloque forcément aussi les captures. Conséquences concrètes :

- le parent ne pouvait pas partager une capture avec un soignant ;
- les 2 à 8 captures d'écran téléphone exigées pour la fiche Play Store (`docs/play-store-listing.md`) ne pouvaient pas être produites depuis un appareil.

## Changements

- `apps/mobile/App.tsx` : retire l'appel `usePreventScreenCapture()` et son import.
- `apps/mobile/package.json` + `apps/mobile/pnpm-lock.yaml` : retire la dépendance `expo-screen-capture`, devenue inutilisée (lockfile régénéré avec `--ignore-workspace`, `apps/mobile` étant hors du graphe pnpm racine). Aucun autre paquet n'est touché.
- `apps/mobile/README.md` : la section Sécurité annonçait une protection qui n'existe plus. Elle décrit maintenant le compromis réellement en place plutôt que de laisser une garantie fausse.

Aucune entrée `expo-screen-capture` dans les `plugins` de `app.json` : rien à nettoyer côté config native.

## Compromis assumé

L'aperçu de l'app dans le sélecteur d'applications récentes affiche désormais l'écran réel, données de santé comprises. C'est le prix à payer pour rendre les captures possibles — les deux ne sont pas séparables sur Android.

Les autres protections de la section Sécurité restent intactes : cache chiffré au repos, `allowBackup: false`, permissions bloquées, pas de trafic en clair, OTA désactivé.

## Vérification

`pnpm typecheck` dans `apps/mobile` : 33 erreurs, contre 34 sur la base avant changement (la 34ᵉ était l'import devenu obsolète). Les 33 restantes sont préexistantes et sans rapport — résolution de `zod` depuis le workspace racine non installé, et des `implicit any` dans `JournalScreen.tsx` / `SymptomsScreen.tsx`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XdRYFgVMs5ftMuf3hzqLh9)_