### PR TITLE
feat(web): brancher l'analytics self-hosted Umami

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -49,10 +49,10 @@ const app = new Hono();
 // Security headers — explicit CSP so a later Stripe.js integration won't
 // be silently blocked, and so the policy is visible in code review.
 //
-// ANALYTICS_ORIGIN: origin (scheme + host) of the self-hosted GoatCounter
-// instance. When set, it is whitelisted in script-src (loads count.js),
-// img-src (the tracking pixel beacon), and connect-src (the count.js
-// runtime may probe its own origin). Empty/unset = analytics disabled,
+// ANALYTICS_ORIGIN: origin (scheme + host) of the self-hosted Umami
+// instance. When set, it is whitelisted in script-src (loads stats.js),
+// img-src (the tracking pixel beacon), and connect-src (stats.js POSTs
+// events back to its own origin). Empty/unset = analytics disabled,
 // CSP stays maximally strict.
 const analyticsOrigin = process.env.ANALYTICS_ORIGIN?.trim() || "";
 

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -91,6 +91,9 @@
       }
     </script>
 
+
+    <!-- Umami — analytics self-hosted, sans cookie ni donnée personnelle -->
+    <script defer src="https://umami.battistella.ovh/stats.js" data-website-id="88764f1d-0c4d-42ea-b42c-a829a3e8e689"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Pourquoi

Aucun des produits n'était instrumenté : impossible de savoir quel canal d'acquisition amène du trafic, donc impossible de piloter le marketing autrement qu'à l'aveugle. C'est le préalable au reste du plan.

## Ce que ça fait

- `apps/web/index.html` : charge `stats.js` depuis l'instance Umami self-hosted (`umami.battistella.ovh`), en `defer`.
- `apps/api/src/app.ts` : **aucun changement de comportement** — le hook CSP `ANALYTICS_ORIGIN` existait déjà et whiteliste `script-src` / `img-src` / `connect-src`. Seul son commentaire est corrigé (il décrivait encore GoatCounter).

## RGPD

Umami est sans cookie et ne stocke aucune donnée personnelle ni identifiant persistant → pas de bandeau de consentement à ajouter.

## Notes de déploiement

`ANALYTICS_ORIGIN=https://umami.battistella.ovh` est **déjà positionné** dans `/opt/docker/toko/.env` et le conteneur a été redémarré : le CSP en prod autorise déjà l'origine. Ce PR n'ajoute que la balise côté client.

Le script est servi sous `stats.js` (et non `script.js`) car `TRACKER_SCRIPT_NAME=script.js,stats.js` côté serveur — le nom par défaut est bloqué par les listes de filtres des bloqueurs de pub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)