### PR TITLE
docs(marketing): corriger les templates d'outreach et acter les canaux fermés

### DIFF
--- a/docs/marketing/outreach-template.md
+++ b/docs/marketing/outreach-template.md
@@ -1,120 +1,263 @@
 # Outreach Email Templates — Partenariats associations TDAH
 
-**Usage:** templates for reaching out to French-speaking TDAH associations. Warm tone, offer value first, no hard sell, no commercial pitch.
+**Usage:** templates for reaching out to French-speaking TDAH associations and
+practitioners. Warm tone, offer value first, no hard sell, no commercial pitch.
 
 **Red line:** never promise that Tokō improves/treats/diagnoses TDAH. We're a tracking tool.
+
+**Voice:** Tokō is built by one person. Write in the first person singular — an
+association or a practitioner that looks the project up will find a solo
+micro-entreprise, and a "nous" that turns out to be one person costs more
+credibility than it buys.
+
+---
+
+## Facts to keep accurate
+
+These are checked against the shipped app. Update them here when they change, and
+never restate them from memory.
+
+| Claim | Reality |
+|---|---|
+| Domaine | `https://toko.battistella.ovh` (**pas** `toko.app`) |
+| Offre gratuite | 1 enfant, « pour toujours », sans carte bancaire |
+| Offre Famille | 4,99 €/mois ou 39 €/an, essai 14 jours sans CB |
+| Formation Barkley | 89 € une fois |
+| Tarif solidaire | sur demande, **sans justificatif**, réponse sous 48 h |
+| Hébergement | Union européenne (règle métier F1) |
+| Programme Barkley | 10 étapes PEHP + quiz de validation |
+| Traitements | registre **déclaratif** — aucune recommandation, aucun ajustement |
+| App Android | fiche Play Store rédigée, **non soumise** — ne pas l'annoncer |
+
+Inventaire complet : [features.md](../features.md).
+
+---
+
+## Where NOT to post
+
+Learned the hard way, 2026-08-29 — this is not a matter of finding a better angle:
+
+- **Reddit** — la *Responsible Builder Policy* interdit « processing data to derive or
+  infer potentially sensitive characteristics about Reddit users (e.g. **health**) ».
+  Cibler r/TDAH pour identifier des prospects tombe exactement dedans. Une approbation
+  commerciale ne lève pas cette clause. Le collecteur Reddit est désactivé sur le
+  produit `toko` dans Solopilot.
+- **Groupes Facebook TDAH** — la charte HyperSupers interdit « aucun message
+  publicitaire, que ce soit sous forme de texte ou de liens », et les messages sont
+  modérés *avant* publication. Les règles du groupe ajoutent « L'auto-promotion […]
+  n'est pas autorisée ». La charte interdit aussi toute reproduction du contenu hors
+  du forum, donc on ne peut pas non plus en tirer des signaux.
+
+Ce sont des espaces de santé protégés du démarchage. On écrit **aux structures**, pas
+à leurs membres. Y participer en tant que parent, sans outillage et sans lien, reste
+évidemment possible.
 
 ---
 
 ## Template A — HyperSupers TDAH France
 
-**Objet :** Un outil parents pour préparer les consultations TDAH — on aimerait avoir votre avis
+**Objet :** Un outil parents pour préparer les consultations TDAH — j'aimerais avoir votre avis
 
 Bonjour,
 
-Je me permets de vous écrire au nom de Tokō, un petit carnet de bord numérique gratuit que nous avons construit avec des parents d'enfants TDAH francophones.
+Je me permets de vous écrire au sujet de Tokō, un carnet de bord numérique gratuit
+que je développe pour les parents d'enfants TDAH francophones.
 
-L'idée est partie d'un constat très simple : beaucoup de parents arrivent en consultation avec des souvenirs approximatifs des 3 derniers mois, et repartent en ayant l'impression d'avoir mal expliqué. Tokō permet de noter 2 minutes par soir ce qu'on observe (symptômes, crises, victoires) puis de générer une synthèse PDF à apporter au pédopsy.
+L'idée est partie d'un constat simple : beaucoup de parents arrivent en consultation
+avec des souvenirs approximatifs des trois derniers mois, et repartent en ayant
+l'impression d'avoir mal expliqué. Tokō permet de noter deux minutes par soir ce
+qu'on observe — symptômes, crises, victoires — puis de générer une synthèse à
+apporter au pédopsychiatre.
 
-**Nous n'arrivons pas en vendeurs.** On aimerait surtout :
-- Avoir votre retour sur l'outil (conception, posture, langage)
-- Vous partager librement nos contenus éducatifs (base de connaissances sur la dysrégulation, les fonctions exécutives, le sommeil…) si cela peut nourrir vos newsletters ou journées régionales
-- Discuter d'un éventuel article invité croisé
+Je ne vous écris pas en vendeur, et je n'ai rien publié sur vos groupes : j'ai lu
+votre charte de fonctionnement et je sais que ce ne sont pas des espaces de promotion.
 
-Tokō est gratuit pour 1 enfant, sans carte bancaire, sans pub, sans revente de données. L'option Famille (4,99 €/mois, 14 j offerts) finance juste l'hébergement et le temps de dev.
+J'aimerais surtout :
 
-Je serais ravi·e d'échanger 20 minutes en visio si vous avez un créneau dans les prochaines semaines.
+- avoir votre retour sur l'outil — sa conception, sa posture, son langage ;
+- vous partager librement mes contenus éducatifs (dysrégulation émotionnelle,
+  fonctions exécutives, sommeil, co-régulation…) si cela peut nourrir vos
+  newsletters ou vos journées régionales ;
+- discuter d'un éventuel article invité croisé.
+
+Sur le modèle économique, pour être transparent : Tokō est gratuit pour un enfant,
+sans carte bancaire et sans publicité, et les données ne sont pas revendues.
+L'option Famille (4,99 €/mois ou 39 €/an, 14 jours d'essai sans CB) finance
+l'hébergement et le temps de développement. Il existe aussi un tarif solidaire,
+accordé sans justificatif, pour les parents isolés ou en difficulté budgétaire.
+
+L'application ne pose aucun diagnostic, ne recommande aucun traitement et ne
+remplace aucun professionnel de santé — c'est un carnet d'observation, rien de plus.
+L'hébergement est en Union européenne.
+
+Je serais ravi d'échanger vingt minutes en visio si vous avez un créneau dans les
+prochaines semaines.
 
 Bien cordialement,
-[Prénom Nom]
-Tokō — toko.app
+Damien Battistella — battistella@proton.me
+https://toko.battistella.ovh
 
 ---
 
-## Template B — TDAH Belgique (asbl)
+## Template B — Praticien·ne animant le programme Barkley
 
-**Objet :** Tokō, un carnet de bord pour parents TDAH — on aimerait piloter côté Wallonie
+Le meilleur profil de tous : il ou elle enseigne déjà le PEHP que Tokō implémente, et
+ses familles n'ont rien pour tenir le fil entre deux séances. Personnaliser avec le
+nom des ateliers et le département.
+
+**Objet :** Un outil de suivi pour les familles entre deux séances Barkley — votre avis m'intéresse
 
 Bonjour,
 
-Je m'appelle [Prénom] et je co-construis Tokō, un outil de suivi quotidien gratuit pour les familles TDAH francophones. Nous cherchons un pilote côté Belgique pour avoir un retour terrain hors France.
+Je découvre votre page et votre site : vous animez des ateliers de guidance parentale
+issus du programme Barkley. C'est précisément ce qui me pousse à vous écrire plutôt
+qu'à quelqu'un d'autre.
 
-Le concept : 2 minutes par soir pour noter symptômes, crises et journal, et une synthèse PDF pour le pédopsy/pédiatre. Rien de médical, rien de diagnostique — un simple carnet de bord qu'on tient à la place du post-it sur le frigo.
+Je développe Tokō (https://toko.battistella.ovh), un carnet de bord numérique pour les
+parents d'enfants TDAH. Le produit est construit autour du PEHP : les 10 étapes du
+programme avec un quiz de validation à chacune, un tableau de comportements
+hebdomadaires avec cumul d'étoiles et récompenses, des routines fractionnées en étapes,
+et un relevé quotidien sur 7 dimensions.
 
-**Ce qu'on peut vous apporter :**
-- Accès gratuit illimité pour vos adhérents qui voudraient tester
-- Contenus éducatifs libres (6 articles déjà en ligne, d'autres à venir) que vous pouvez reprendre
-- Retour régulier sur les usages observés chez vos membres
+Le constat qui m'y a mené : entre deux séances, les familles n'ont souvent rien pour
+tenir le fil. Elles reviennent avec des souvenirs approximatifs, et une bonne partie de
+la séance sert à reconstituer ce qui s'est passé.
 
-**Ce qu'on cherche :**
-- Vos retours critiques honnêtes
-- Potentiellement un post sur vos réseaux si l'outil vous semble sain
-- Si le courant passe, un webinaire co-animé sur *« Tenir un journal TDAH utile en consultation »*
+Ce que j'aimerais, dans l'ordre :
 
-Un créneau de 20 min vous conviendrait-il dans les prochaines semaines ?
+1. Votre regard de professionnel·le. Vous voyez ces familles chaque semaine et vous
+   connaissez le programme bien mieux que moi. Ce qui est juste, ce qui est maladroit,
+   ce qui trahit le PEHP — j'ai besoin de l'entendre, y compris si c'est sévère.
+
+2. Si l'outil vous semblait sain, un accès gratuit pour les familles de vos ateliers,
+   sans limite de durée et sans contrepartie. Je préfère qu'il serve dans un cadre
+   encadré par quelqu'un qui sait, plutôt que seul dans la nature.
+
+Pour être clair sur ce que Tokō n'est pas : il ne pose aucun diagnostic, ne recommande
+et n'ajuste aucun traitement, et ne remplace aucun professionnel. C'est un carnet
+d'observation. Le suivi des traitements y est purement déclaratif — le parent note ce
+qui a été donné, rien de plus.
+
+Sur le modèle : gratuit pour un enfant sans carte bancaire, offre Famille à 4,99 €/mois
+ou 39 €/an avec 14 jours d'essai, et un tarif solidaire accordé sans justificatif pour
+les familles en difficulté budgétaire. Pas de publicité, pas de revente de données,
+hébergement en Union européenne.
+
+Je serais ravi d'échanger vingt minutes si vous avez un créneau. Et si le sujet ne vous
+intéresse pas, dites-le moi simplement, je n'insisterai pas.
+
+Bien cordialement,
+Damien Battistella — battistella@proton.me
+https://toko.battistella.ovh
+
+---
+
+## Template C — TDAH Belgique (asbl)
+
+**Objet :** Tokō, un carnet de bord pour parents TDAH — je cherche un retour côté Wallonie
+
+Bonjour,
+
+Je m'appelle Damien et je développe Tokō, un outil de suivi quotidien pour les familles
+TDAH francophones. Je cherche un retour terrain hors France.
+
+Le concept : deux minutes par soir pour noter symptômes, crises et journal, et une
+synthèse à apporter au pédopsychiatre ou au pédiatre. Rien de médical, rien de
+diagnostique — un carnet de bord qu'on tient à la place du post-it sur le frigo.
+
+**Ce que je peux vous apporter :**
+- un accès gratuit et illimité pour vos adhérents qui voudraient tester ;
+- mes contenus éducatifs, librement réutilisables ;
+- un retour régulier sur les usages observés chez vos membres.
+
+**Ce que je cherche :**
+- vos retours critiques honnêtes ;
+- éventuellement un mot sur vos réseaux si l'outil vous semble sain ;
+- si le courant passe, un webinaire co-animé sur « Tenir un journal TDAH utile en consultation ».
+
+Un créneau de vingt minutes vous conviendrait-il dans les prochaines semaines ?
 
 Cordialement,
-[Prénom Nom]
-Tokō — toko.app
+Damien Battistella — battistella@proton.me
+https://toko.battistella.ovh
 
 ---
 
-## Template C — PANDA Québec
+## Template D — PANDA Québec
 
-**Objet :** Tokō — outil parents TDAH francophone, on aimerait échanger
+**Objet :** Tokō — outil parents TDAH francophone, j'aimerais échanger
 
 Bonjour,
 
-Je me permets de vous contacter depuis la France. Je fais partie de l'équipe qui construit Tokō, un carnet de bord gratuit pour parents d'enfants TDAH, en français, accessible depuis le Québec comme depuis l'Europe.
+Je vous écris depuis la France. Je développe Tokō, un carnet de bord pour parents
+d'enfants TDAH, en français, accessible depuis le Québec comme depuis l'Europe.
 
-Nous admirons beaucoup la structuration du réseau PANDA autour du soutien parental — et notre produit s'ancre lui aussi sur le programme Barkley (PEHP). Nous aimerions ouvrir un dialogue francophone transatlantique.
+J'admire la structuration du réseau PANDA autour du soutien parental — et mon produit
+s'ancre lui aussi sur le programme Barkley (PEHP). J'aimerais ouvrir un dialogue
+francophone transatlantique.
 
 **Concrètement :**
-- Tokō est gratuit pour 1 enfant, sans carte bancaire
-- L'option Famille (4,99 €/mois) ajoute multi-enfants et un rapport PDF pour les consultations
-- Hébergement UE, RGPD strict, export intégral des données
+- Tokō est gratuit pour un enfant, sans carte bancaire ;
+- l'offre Famille (4,99 €/mois ou 39 €/an) ajoute le multi-enfants et le rapport PDF
+  pour les consultations ;
+- hébergement UE, RGPD strict, export intégral des données.
 
-**Notre demande :** pas de partenariat commercial. On aimerait juste échanger 20-30 min sur vos besoins, vos retours, et savoir si notre outil peut être utile à vos familles québécoises (adaptations de vocabulaire, références cliniques différentes, etc.).
+**Ma demande :** pas de partenariat commercial. J'aimerais échanger vingt à trente
+minutes sur vos besoins, vos retours, et savoir si l'outil peut être utile à vos
+familles québécoises (vocabulaire, références cliniques différentes, etc.).
 
 Seriez-vous disponible pour un appel dans les prochaines semaines ?
 
 Respectueusement,
-[Prénom Nom]
-Tokō — toko.app
+Damien Battistella — battistella@proton.me
+https://toko.battistella.ovh
 
 ---
 
-## Template D — Générique (pédopsy, orthophoniste, association locale)
+## Template E — Générique (pédopsy, orthophoniste, association locale)
 
 **Objet :** Tokō — carnet de bord TDAH pour vos patients/adhérents
 
 Bonjour,
 
-Je me permets de vous contacter au sujet de Tokō, un outil gratuit que nous avons construit avec des parents TDAH francophones pour faciliter le suivi entre les consultations.
+Je me permets de vous contacter au sujet de Tokō, un outil gratuit que je développe
+pour faciliter le suivi des enfants TDAH entre les consultations.
 
-Le principe : le parent note 2 minutes par soir (7 dimensions : humeur, concentration, agitation, impulsivité, sommeil, social, autonomie) et peut générer une synthèse PDF à apporter à ses rendez-vous médicaux.
+Le principe : le parent note deux minutes par soir sur 7 dimensions (agitation,
+concentration, impulsivité, régulation émotionnelle, sommeil, comportement social,
+autonomie) et peut générer une synthèse à apporter à ses rendez-vous.
 
-**Ce que Tokō n'est pas :** un outil de diagnostic, un traitement, un substitut au professionnel. C'est un carnet d'observation, rien de plus.
+**Ce que Tokō n'est pas :** un outil de diagnostic, un traitement, un substitut au
+professionnel. C'est un carnet d'observation, rien de plus.
 
-**Ce qu'il permet :** des consultations mieux préparées, des données concrètes plutôt que des souvenirs, un parent moins épuisé mentalement car il a noté au fil de l'eau.
+**Ce qu'il permet :** des consultations préparées, des données concrètes plutôt que des
+souvenirs, et un parent moins épuisé parce qu'il a noté au fil de l'eau.
 
-Si vous avez 15 minutes, je serais ravi·e de vous faire une démo rapide — et surtout d'entendre si ça répondrait à un besoin concret dans votre pratique / votre association.
-
-Un lien vers une fiche synthèse pour les professionnels : [toko.app/one-pager-pedopsy](https://toko.app/one-pager-pedopsy) (à adapter quand la page sera en ligne)
+Si vous avez quinze minutes, je serais ravi de vous faire une démo rapide — et surtout
+d'entendre si cela répondrait à un besoin concret dans votre pratique.
 
 Cordialement,
-[Prénom Nom]
-Tokō — toko.app
+Damien Battistella — battistella@proton.me
+https://toko.battistella.ovh
+
+> À ajouter quand la page sera en ligne : un lien vers la fiche synthèse pour les
+> professionnels (`one-pager-pedopsy`). Elle n'a pas encore de route publique.
 
 ---
 
 ## Tracking (internal)
 
-| Association | Contact | Sent date | Response | Follow-up date |
-|---|---|---|---|---|
-| HyperSupers TDAH France | TBD | | | |
-| TDAH Belgique | TBD | | | |
-| PANDA Québec | TBD | | | |
+| Cible | Type | Contact | Template | Envoyé | Réponse | Relance |
+|---|---|---|---|---|---|---|
+| Guidance Barkley 33 (Cestas, Gironde) | Praticienne PEHP | guidancebarkley33@gmail.com | B | | | |
+| HyperSupers TDAH France | Association (~27 k membres FB) | info@tdah-france.fr | A | | | |
+| TDAH Belgique | asbl | TBD | C | | | |
+| PANDA Québec | Regroupement | TBD | D | | | |
+
+**Ordre conseillé :** Guidance Barkley 33 en premier. Une praticienne seule qui enseigne
+déjà le PEHP répond plus vite qu'une grosse structure, et une réponse positive apporte
+trois choses d'un coup — une critique experte du produit, un canal vers des familles
+déjà encadrées, et l'intervenante qui débloque le webinaire (action #9).
 
 ## Principles (do's & don'ts)
 
@@ -122,12 +265,15 @@ Tokō — toko.app
 - Lead with value offered, not asked for
 - Acknowledge the association's work
 - Be explicit about the tool NOT being medical/diagnostic
+- Say the price plainly, including the free plan and the tarif solidaire — hiding it
+  reads as a sales trick to people whose job is to protect families
 - Keep emails under 250 words
 - Suggest a 20-min call, not a 1h demo
 
 **Don't:**
 - Use marketing speak ("révolution", "game-changer", "meilleur outil")
 - Promise metrics/outcomes
+- Claim the tool was co-designed with parents unless it verifiably was
 - Send generic mass emails without personalization
 - Follow up more than 2 times
 - Offer commissions or revenue-share (it would compromise their neutrality)


### PR DESCRIPTION
## Pourquoi

Les templates contenaient des erreurs qui se seraient propagées dans de vrais emails à de vraies associations :

- `toko.app` — ce n'est pas le domaine, c'est `toko.battistella.ovh` ;
- des placeholders `[Prénom Nom]` non remplis ;
- une voix « nous » alors que Tokō est développé par une seule personne. Une association qui vérifie tombe sur une micro-entreprise solo — le « nous » coûte plus de crédibilité qu'il n'en rapporte.

## Tableau des faits vérifiés

Ajout d'un tableau contrôlé sur l'app livrée (offre gratuite, 4,99 €/mois ou 39 €/an, tarif solidaire, hébergement UE, registre de traitements déclaratif), pour que les templates cessent d'être rédigés de mémoire.

Le besoin est concret : un brouillon écrit ainsi décrivait Tokō comme un produit uniquement payant, en omettant à la fois le plan gratuit, le tarif solidaire et le programme Barkley — c'est-à-dire les trois arguments qui comptent le plus auprès d'une association.

## Canaux fermés, documentés

Pour qu'on ne réessaie pas dans six mois en croyant à un problème d'angle :

- **Reddit** — la *Responsible Builder Policy* interdit d'inférer des caractéristiques de santé sur les utilisateurs. Cibler r/TDAH pour identifier des prospects tombe dedans, et une approbation commerciale ne lève pas cette clause. Le collecteur Reddit a été désactivé sur le produit `toko` dans Solopilot.
- **Groupes Facebook TDAH** — la charte HyperSupers interdit tout message publicitaire « sous forme de texte ou de liens », modère avant publication, et interdit la reproduction du contenu hors du forum.

Conclusion actée : on écrit **aux structures**, pas à leurs membres.

## Nouveau template + priorisation

Template B pour les praticien·nes animant les ateliers Barkley — le meilleur profil possible, puisqu'ils enseignent déjà le PEHP que Tokō implémente et que leurs familles n'ont rien pour tenir le fil entre deux séances.

La table de suivi est amorcée avec quatre cibles, et l'ordre conseillé commence par la praticienne de Gironde plutôt que par HyperSupers : une réponse positive apporte d'un coup une critique experte, un canal vers des familles encadrées, et l'intervenante qui débloque le webinaire (action #9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)