### PR TITLE
fix(web): corriger les défauts de mise en page sur mobile

### DIFF
--- a/apps/web/src/components/layout/app-header.tsx
+++ b/apps/web/src/components/layout/app-header.tsx
@@ -10,7 +10,7 @@ export function AppHeader() {
   const { t } = useTranslation();
   const hasBreadcrumbs = useBreadcrumbs().length > 0;
   return (
-    <header className="sticky top-0 z-40 flex h-14 shrink-0 items-center gap-3 border-b border-border/60 bg-background/90 px-4 backdrop-blur-lg supports-[backdrop-filter]:bg-background/70 md:px-6 lg:px-8 landscape:max-md:h-10">
+    <header className="sticky top-0 z-40 flex h-14 shrink-0 items-center gap-3 border-b border-border/60 bg-background px-4 md:px-6 lg:px-8 landscape:max-md:h-10">
       <SidebarTrigger
         aria-label={t("nav.toggleSidebar")}
         className="-ml-1 hidden md:inline-flex"

--- a/apps/web/src/components/layout/mobile-tab-bar.tsx
+++ b/apps/web/src/components/layout/mobile-tab-bar.tsx
@@ -15,7 +15,7 @@ export function MobileTabBar() {
   return (
     <nav
       aria-label={t("nav.primaryNav")}
-      className="fixed inset-x-0 bottom-0 z-40 border-t border-border/60 bg-background/95 pb-[env(safe-area-inset-bottom)] backdrop-blur-lg supports-[backdrop-filter]:bg-background/80"
+      className="fixed inset-x-0 bottom-0 z-40 border-t border-border/60 bg-background pb-[env(safe-area-inset-bottom)]"
     >
       <ul className="grid grid-cols-5">
         {tabs.map((item) => {

--- a/apps/web/src/components/shared/child-selector.tsx
+++ b/apps/web/src/components/shared/child-selector.tsx
@@ -351,7 +351,7 @@ export function ChildSelector() {
               )}
             </p>
             <div className="space-y-2">
-              <Label htmlFor="delete-child-confirm">
+              <Label htmlFor="delete-child-confirm" className="block">
                 {deleteChild && (
                   <Trans
                     i18nKey="child.typeNameToConfirm"

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -2,6 +2,11 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
+// The base layout is a flex row so the common "icon + short text" label lines
+// up on one baseline. A label that wraps a full sentence (or any inline
+// markup: links, <strong>, <Trans/>) must override it with `block`, otherwise
+// every text run and element becomes a separate flex column and the sentence
+// is rendered as unreadable side-by-side blocks.
 function Label({ className, htmlFor, ...props }: React.ComponentProps<"label">) {
   return (
     <label

--- a/apps/web/src/config/nav.ts
+++ b/apps/web/src/config/nav.ts
@@ -59,7 +59,7 @@ export const navItems: readonly NavItem[] = [
   { to: "/suivi", labelKey: "nav.tracking", shortLabelKey: "nav.trackingShort", icon: NotebookPen, primary: true, group: "main" },
   { to: "/barkley", labelKey: "nav.barkley", shortLabelKey: "nav.barkleyShort", icon: ClipboardList, primary: true, group: "main" },
   { to: "/report", labelKey: "nav.report", icon: FileText, group: "main" },
-  { to: "/account", labelKey: "nav.account", icon: UserCog, primary: true, group: "main" },
+  { to: "/account", labelKey: "nav.account", shortLabelKey: "nav.accountShort", icon: UserCog, primary: true, group: "main" },
 
   // Admin — réservé aux utilisateurs avec isAdmin === true
   { to: "/admin-users", labelKey: "nav.adminUsers", icon: Users, group: "admin", requiresAdmin: true },

--- a/apps/web/src/lib/i18n/locales/en.json
+++ b/apps/web/src/lib/i18n/locales/en.json
@@ -39,6 +39,7 @@
       "pricing": "Pricing",
       "login": "Sign in",
       "getStarted": "Try for free",
+      "getStartedShort": "Try free",
       "menu": "Menu"
     },
     "trust": {
@@ -325,6 +326,7 @@
     "routinesShort": "Routines",
     "knowledgeBase": "Knowledge base",
     "account": "My account",
+    "accountShort": "Account",
     "home": "Home",
     "crisis": "Crisis",
     "rewardsShort": "Rewards",

--- a/apps/web/src/lib/i18n/locales/fr.json
+++ b/apps/web/src/lib/i18n/locales/fr.json
@@ -39,6 +39,7 @@
       "pricing": "Tarifs",
       "login": "Connexion",
       "getStarted": "Essayer gratuitement",
+      "getStartedShort": "Essayer",
       "menu": "Menu"
     },
     "hero": {
@@ -326,6 +327,7 @@
     "routinesShort": "Routines",
     "knowledgeBase": "Base de connaissances",
     "account": "Mon compte",
+    "accountShort": "Compte",
     "home": "Accueil",
     "crisis": "Crise",
     "rewardsShort": "Récomp.",

--- a/apps/web/src/routes/AuthenticatedLayout.tsx
+++ b/apps/web/src/routes/AuthenticatedLayout.tsx
@@ -72,8 +72,13 @@ function AuthenticatedShell() {
         aria-labelledby="page-title"
         className={cn(
           "min-w-0 focus:outline-none",
+          // Scroll room for the two fixed layers stacked at the bottom of the
+          // mobile viewport: the tab bar (4.5rem) and, above it, the SOS/tip
+          // buttons (size-14 sitting 5rem from the edge). Without the taller
+          // padding the last card on every page stays permanently hidden
+          // behind the floating buttons.
           isMobile &&
-            "pb-[calc(4.5rem+env(safe-area-inset-bottom))] landscape:max-md:pb-[calc(3.5rem+env(safe-area-inset-bottom))]"
+            "pb-[calc(9.5rem+env(safe-area-inset-bottom))] landscape:max-md:pb-[calc(8.5rem+env(safe-area-inset-bottom))]"
         )}
       >
         <AppHeader />

--- a/apps/web/src/routes/_authenticated/account/index.tsx
+++ b/apps/web/src/routes/_authenticated/account/index.tsx
@@ -299,7 +299,7 @@ function AccountPage() {
                     </DialogDescription>
                   </DialogHeader>
                   <div className="space-y-2">
-                    <Label htmlFor="delete-confirmation">
+                    <Label htmlFor="delete-confirmation" className="block">
                       <Trans
                         i18nKey="account.typeDeleteToConfirm"
                         components={{ 0: <strong /> }}

--- a/apps/web/src/routes/landing-sections.tsx
+++ b/apps/web/src/routes/landing-sections.tsx
@@ -54,7 +54,7 @@ const testimonialKeys = ["t1", "t2", "t3"] as const;
 export function Nav() {
   const { t } = useTranslation();
   return (
-    <header className="sticky top-0 z-50 border-b border-border/60 bg-background/90 backdrop-blur-lg supports-[backdrop-filter]:bg-background/70 pt-[env(safe-area-inset-top)]">
+    <header className="sticky top-0 z-50 border-b border-border/60 bg-background pt-[env(safe-area-inset-top)]">
       <div className="mx-auto flex h-16 max-w-6xl items-center justify-between px-[max(1rem,env(safe-area-inset-left))]">
         <Link to="/" className="flex items-center gap-2">
           <BrandLogo className="size-8 rounded-lg" />
@@ -96,7 +96,14 @@ export function Nav() {
           </Link>
           <Link to="/login">
             <Button className="gap-2 shadow-sm">
-              {t("landing.nav.getStarted")}
+              {/* Below 360px the full label pushes the header past the
+                  viewport edge and scrolls the whole page sideways. */}
+              <span className="hidden min-[360px]:inline">
+                {t("landing.nav.getStarted")}
+              </span>
+              <span className="min-[360px]:hidden">
+                {t("landing.nav.getStartedShort")}
+              </span>
               <ArrowRight className="size-3.5" />
             </Button>
           </Link>
@@ -356,7 +363,7 @@ export function FeaturesSection() {
   return (
     <section
       id="fonctionnalites"
-      className="relative border-t border-border/60 py-24 lg:py-32"
+      className="relative border-t border-border/60 py-16 sm:py-24 lg:py-32"
     >
       <div className="pointer-events-none absolute inset-0 bg-muted/40" />
       <div className="relative mx-auto max-w-6xl px-4">
@@ -407,15 +414,19 @@ export function FormationBanner() {
     >
       <div className="mx-auto max-w-5xl px-4">
         <div className="flex flex-col items-start gap-6 rounded-2xl border border-accent-200/60 bg-accent-100/30 p-6 sm:flex-row sm:items-center sm:justify-between sm:p-8">
-          <div className="max-w-2xl">
+          {/* min-w-0 + a wrapping badge: the Badge base style is nowrap and
+              shrink-0, so on a narrow phone this long label used to set the
+              column's min-content width and push the whole card past the
+              viewport edge, making the page scroll sideways. */}
+          <div className="min-w-0 max-w-2xl">
             <Badge
               variant="outline"
-              className="mb-3 border-accent-300/60 bg-accent-100/40 text-accent-700"
+              className="mb-3 h-auto whitespace-normal py-1 text-left border-accent-300/60 bg-accent-100/40 text-accent-700"
             >
               {t("landing.formation.badge")}
             </Badge>
-            <h2 className="font-heading flex items-center gap-2 text-xl font-semibold tracking-tight sm:text-2xl">
-              <GraduationCap className="size-5 shrink-0 text-accent-700" />
+            <h2 className="font-heading flex items-start gap-2 text-xl font-semibold tracking-tight sm:text-2xl">
+              <GraduationCap className="mt-1 size-5 shrink-0 text-accent-700" />
               {t("landing.formation.title")}
             </h2>
             <p className="mt-3 leading-relaxed text-muted-foreground">
@@ -558,7 +569,7 @@ export function LandingFooter() {
             date: buildDate,
           })}
         </p>
-        <div className="flex gap-6 text-sm text-muted-foreground">
+        <div className="flex flex-wrap justify-center gap-x-6 gap-y-2 text-sm text-muted-foreground">
           <Link
             to="/mentions-legales"
             className="transition-colors hover:text-foreground"

--- a/apps/web/src/routes/register-form.tsx
+++ b/apps/web/src/routes/register-form.tsx
@@ -131,7 +131,7 @@ export function RegisterForm() {
             />
             <Label
               htmlFor="register-consent"
-              className="text-xs font-normal leading-relaxed text-muted-foreground"
+              className="block text-xs font-normal leading-relaxed text-muted-foreground"
             >
               <LegalConsentText i18nKey="login.consentLabel" />
             </Label>


### PR DESCRIPTION
Revue des pages publiques et du shell authentifié sur écran étroit, à partir des captures d'écran signalées.

## Problèmes trouvés et corrigés

### 1. Phrase de consentement illisible à l'inscription (le plus grave)
Le composant `Label` a `flex items-center gap-2` en style de base. Convenable pour `<Label>Nom</Label>`, destructeur dès que le label contient une phrase avec du balisage inline : chaque segment de texte et chaque lien devient une **colonne flex séparée**.

Mesuré dans le DOM avant correction — la mention légale s'affichait en 5 blocs côte à côte :

```
"J'ai 18 ans ou plus et j'accepte les"  x=56
"conditions d'utilisation"              x=140
"et la"                                 x=214
"politique de confidentialité"          x=234
"."                                     x=325
```

Les trois labels qui contiennent une phrase passent en `block` (consentement d'inscription, confirmation de suppression d'enfant, confirmation de suppression de compte). La contrainte est documentée dans `label.tsx` pour éviter la récidive.

### 2. Défilement horizontal de la page d'accueil
`Badge` est `whitespace-nowrap shrink-0` : le libellé « Inspirée de la méthode Barkley · recommandée par la HAS » imposait la largeur minimale de sa colonne flex et poussait la carte Formation hors de l'écran. `scrollWidth` = 425 px pour un viewport de 360 px.

Correction : `min-w-0` sur la colonne + retour à la ligne autorisé dans le badge. Le pied de page (rangée de 5 liens sans `flex-wrap`) et le CTA de la barre de navigation sous 360 px débordaient pour la même raison et sont corrigés aussi.

### 3. Contenu visible derrière les en-têtes collants
En-têtes (accueil + app) et barre d'onglets en `bg-background/70` : le contenu défilait visiblement derrière le titre, produisant une superposition de textes. Fonds désormais opaques.

### 4. Boutons flottants masquant le bas de chaque page
Les boutons SOS/astuce sont en `fixed bottom-[calc(5rem+safe)]` et font `size-14`, mais la marge basse du contenu n'était que de `4.5rem`. Une bande d'environ 64 px en bas de **chaque** page authentifiée restait donc inaccessible sous les boutons. La marge tient maintenant compte des deux couches fixes.

### 5. Divers
- Onglet « Mon compte » tronqué en « Mon… » → libellé court « Compte ».
- Section Fonctionnalités : 96 px de marge haute laissaient un écran vide après le CTA ressources sur mobile.

## Vérification

- Aucun débordement horizontal sur `/`, `/login`, `/tarifs`, `/formation`, `/ressources`, `/contact`, `/cgu`, `/confidentialite`, `/mentions-legales` à **320, 360 et 412 px** (mesuré via Playwright, `scrollWidth <= clientWidth`).
- Phrase de consentement re-mesurée : rendu en flux normal sur 2 lignes.
- `pnpm typecheck` ✅ · `pnpm test` ✅ (132 tests) · `pnpm lint` (aucune tâche configurée).

Les points 4 et 5 (marge des boutons flottants, onglet tronqué) sont vérifiés par le calcul CSS et non par un rendu authentifié — l'API/BDD n'étaient pas disponibles dans cet environnement.

---
_Generated by [Claude Code](https://claude.ai/code/session_012iLaHMzX6wyeMaP1t5uQTV)_